### PR TITLE
FE-518 Use Firebase.crashlytics per the docs

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -86,7 +86,7 @@
             android:value="false" /> <!-- Enable/Disable crashlytics reporting -->
         <meta-data
             android:name="firebase_crashlytics_collection_enabled"
-            android:value="${crashlyticsEnabled}" /> <!-- Icon to show in notification tray for messages sent from Firebase -->
+            android:value="${crashlyticsEnabled}" />
         <meta-data
             android:name="com.google.firebase.messaging.default_notification_icon"
             android:resource="@drawable/ic_notification_default" /> <!-- Default color for incoming Firebase notification messages -->

--- a/app/src/main/java/com/weatherxm/data/Modules.kt
+++ b/app/src/main/java/com/weatherxm/data/Modules.kt
@@ -28,6 +28,7 @@ import com.google.firebase.Firebase
 import com.google.firebase.analytics.FirebaseAnalytics
 import com.google.firebase.analytics.analytics
 import com.google.firebase.crashlytics.FirebaseCrashlytics
+import com.google.firebase.crashlytics.crashlytics
 import com.google.firebase.installations.FirebaseInstallations
 import com.google.firebase.messaging.FirebaseMessaging
 import com.google.firebase.remoteconfig.FirebaseRemoteConfig
@@ -707,7 +708,7 @@ val firebase = module {
     }
 
     single<FirebaseCrashlytics>(createdAtStart = true) {
-        FirebaseCrashlytics.getInstance()
+        Firebase.crashlytics
     }
 
     single<FirebaseMessaging>(createdAtStart = true) {


### PR DESCRIPTION
## **Why?**

Use `Firebase.crashlytics` per the official Firebase tutorial.

### **How?**

On `modules` instead of `FirebaseCrashlytics.getInstance()` use `Firebase.crashlytics`