### PR TITLE
FE-528 Integration of Notifications

### DIFF
--- a/app/src/main/java/com/weatherxm/data/DataModels.kt
+++ b/app/src/main/java/com/weatherxm/data/DataModels.kt
@@ -7,6 +7,7 @@ import androidx.annotation.Keep
 import com.squareup.moshi.Json
 import com.squareup.moshi.JsonClass
 import kotlinx.parcelize.Parcelize
+import timber.log.Timber
 
 @Keep
 @JsonClass(generateAdapter = true)
@@ -82,6 +83,7 @@ enum class RemoteMessageType(val id: String, val publicName: String, val desc: S
                     it.id.equals(id, true)
                 } ?: DEFAULT
             } catch (e: IllegalArgumentException) {
+                Timber.e(e)
                 DEFAULT
             }
         }

--- a/app/src/main/java/com/weatherxm/data/DataModels.kt
+++ b/app/src/main/java/com/weatherxm/data/DataModels.kt
@@ -38,6 +38,14 @@ data class CountryInfo(
     var mapCenter: Location?,
 ) : Parcelable
 
+@Keep
+@JsonClass(generateAdapter = true)
+@Parcelize
+data class WXMRemoteMessage(
+    val type: RemoteMessageType,
+    val url: String? = null
+) : Parcelable
+
 enum class Frequency {
     EU868,
     US915,
@@ -57,4 +65,25 @@ enum class BluetoothOTAState {
     FAILED,
     ABORTED,
     COMPLETED
+}
+
+enum class RemoteMessageType(val id: String, val publicName: String, val desc: String) {
+    ANNOUNCEMENT(
+        "announcement",
+        "Announcements",
+        "These notifications are used for WeatherXM-related announcements."
+    ),
+    DEFAULT("DEFAULT", "Default", "These are general purpose notifications.");
+
+    companion object {
+        fun parse(id: String): RemoteMessageType {
+            return try {
+                RemoteMessageType.entries.firstOrNull {
+                    it.id.equals(id, true)
+                } ?: DEFAULT
+            } catch (e: IllegalArgumentException) {
+                DEFAULT
+            }
+        }
+    }
 }

--- a/app/src/main/java/com/weatherxm/service/MessagingService.kt
+++ b/app/src/main/java/com/weatherxm/service/MessagingService.kt
@@ -16,6 +16,7 @@ import com.weatherxm.R
 import com.weatherxm.ui.urlrouteractivity.UrlRouterActivity
 import com.weatherxm.util.hasPermission
 import timber.log.Timber
+import kotlin.random.Random
 
 class MessagingService : FirebaseMessagingService() {
     override fun onMessageReceived(remoteMessage: RemoteMessage) {
@@ -52,11 +53,16 @@ class MessagingService : FirebaseMessagingService() {
     }
 
     private fun handleNotification(remoteNotification: Notification, context: Context) {
-        // Create an Intent for the activity you want to start.
-        // TODO: REQUEST CODE here
+        /**
+         * In order to have multiple distinct intents we need to use unique requestCodes:
+         * https://developer.android.com/reference/android/app/PendingIntent.html
+         * So we generate a random number from 0-100 which is simple enough to sufficiently
+         * achieve it
+         */
+        val requestCode = Random.nextInt()
         val pendingIntent: PendingIntent = PendingIntent.getActivity(
             context,
-            5,
+            requestCode,
             Intent(context, UrlRouterActivity::class.java),
             PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
         )
@@ -74,7 +80,15 @@ class MessagingService : FirebaseMessagingService() {
             )
             manager.createNotificationChannel(channel)
         }
-        // TODO: ID here
-        manager.notify(12, notification)
+        /**
+         * As long as the title of the notification and the ID are different,
+         * different notifications will show up:
+         * https://developer.android.com/reference/android/app/NotificationManager#notify(java.lang.String,%20int,%20android.app.Notification)
+         *
+         * We use this functionality in order to replace any notifications that might be bugged.
+         * By sending a notification from Firebase will the same title as the previous one,
+         * that will replace the shown notification's info with the updated one.
+         */
+        manager.notify(remoteNotification.title, 0, notification)
     }
 }

--- a/app/src/main/java/com/weatherxm/service/MessagingService.kt
+++ b/app/src/main/java/com/weatherxm/service/MessagingService.kt
@@ -87,7 +87,7 @@ class MessagingService : FirebaseMessagingService() {
             setContentIntent(pendingIntent)
             setSmallIcon(R.drawable.ic_logo)
             setContentTitle(remoteMessage.notification?.title)
-            setContentInfo(remoteMessage.notification?.body)
+            setContentText(remoteMessage.notification?.body)
             setAutoCancel(true)
         }.build()
         /**

--- a/app/src/main/java/com/weatherxm/service/MessagingService.kt
+++ b/app/src/main/java/com/weatherxm/service/MessagingService.kt
@@ -1,7 +1,20 @@
 package com.weatherxm.service
 
+import android.Manifest.permission.POST_NOTIFICATIONS
+import android.app.NotificationChannel
+import android.app.NotificationManager
+import android.app.PendingIntent
+import android.content.Context
+import android.content.Intent
+import android.os.Build
+import androidx.core.app.NotificationCompat
+import androidx.core.app.NotificationManagerCompat
 import com.google.firebase.messaging.FirebaseMessagingService
 import com.google.firebase.messaging.RemoteMessage
+import com.google.firebase.messaging.RemoteMessage.Notification
+import com.weatherxm.R
+import com.weatherxm.ui.urlrouteractivity.UrlRouterActivity
+import com.weatherxm.util.hasPermission
 import timber.log.Timber
 
 class MessagingService : FirebaseMessagingService() {
@@ -16,6 +29,16 @@ class MessagingService : FirebaseMessagingService() {
         // Check if message contains a notification payload.
         remoteMessage.notification?.let {
             Timber.d("Message Notification Body: ${it.body}")
+
+            val showNotification = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+                hasPermission(POST_NOTIFICATIONS)
+            } else {
+                NotificationManagerCompat.from(this).areNotificationsEnabled()
+            }
+
+            if (showNotification) {
+                handleNotification(it, this)
+            }
         }
     }
 
@@ -26,5 +49,32 @@ class MessagingService : FirebaseMessagingService() {
      */
     override fun onNewToken(token: String) {
         Timber.d("Refreshed Firebase token: $token")
+    }
+
+    private fun handleNotification(remoteNotification: Notification, context: Context) {
+        // Create an Intent for the activity you want to start.
+        // TODO: REQUEST CODE here
+        val pendingIntent: PendingIntent = PendingIntent.getActivity(
+            context,
+            5,
+            Intent(context, UrlRouterActivity::class.java),
+            PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
+        )
+        val notification = NotificationCompat.Builder(context, "Announcements").apply {
+            setContentIntent(pendingIntent)
+            setSmallIcon(R.drawable.ic_logo)
+            setContentTitle(remoteNotification.title)
+            setContentInfo(remoteNotification.body)
+        }.build()
+
+        val manager = getSystemService(NOTIFICATION_SERVICE) as NotificationManager
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            val channel = NotificationChannel(
+                "WeatherXM", "Announcements", NotificationManager.IMPORTANCE_DEFAULT
+            )
+            manager.createNotificationChannel(channel)
+        }
+        // TODO: ID here
+        manager.notify(12, notification)
     }
 }

--- a/app/src/main/java/com/weatherxm/service/MessagingService.kt
+++ b/app/src/main/java/com/weatherxm/service/MessagingService.kt
@@ -88,6 +88,7 @@ class MessagingService : FirebaseMessagingService() {
             setSmallIcon(R.drawable.ic_logo)
             setContentTitle(remoteMessage.notification?.title)
             setContentInfo(remoteMessage.notification?.body)
+            setAutoCancel(true)
         }.build()
         /**
          * As long as the title of the notification and the ID are different,

--- a/app/src/main/java/com/weatherxm/ui/Navigator.kt
+++ b/app/src/main/java/com/weatherxm/ui/Navigator.kt
@@ -16,6 +16,7 @@ import com.google.firebase.analytics.FirebaseAnalytics
 import com.journeyapps.barcodescanner.ScanOptions
 import com.weatherxm.R
 import com.weatherxm.data.Location
+import com.weatherxm.data.WXMRemoteMessage
 import com.weatherxm.ui.analytics.AnalyticsOptInActivity
 import com.weatherxm.ui.cellinfo.CellInfoActivity
 import com.weatherxm.ui.claimdevice.helium.ClaimHeliumActivity
@@ -26,6 +27,7 @@ import com.weatherxm.ui.common.Contracts.ARG_DEVICE
 import com.weatherxm.ui.common.Contracts.ARG_EXPLORER_CELL
 import com.weatherxm.ui.common.Contracts.ARG_IS_DELETE_ACCOUNT_FORM
 import com.weatherxm.ui.common.Contracts.ARG_OPEN_EXPLORER_ON_BACK
+import com.weatherxm.ui.common.Contracts.ARG_REMOTE_MESSAGE
 import com.weatherxm.ui.common.Contracts.ARG_REWARDS_OBJECT
 import com.weatherxm.ui.common.Contracts.ARG_USER_MESSAGE
 import com.weatherxm.ui.common.Contracts.ARG_WALLET_REWARDS
@@ -62,6 +64,7 @@ import com.weatherxm.ui.sendfeedback.SendFeedbackActivity
 import com.weatherxm.ui.signup.SignupActivity
 import com.weatherxm.ui.startup.StartupActivity
 import com.weatherxm.ui.updateprompt.UpdatePromptActivity
+import com.weatherxm.ui.urlrouteractivity.UrlRouterActivity
 import com.weatherxm.util.Analytics
 import timber.log.Timber
 import java.time.LocalDate
@@ -347,6 +350,14 @@ class Navigator(private val analytics: Analytics) {
             Intent(context, ChangeFrequencyActivity::class.java)
                 .addFlags(Intent.FLAG_ACTIVITY_SINGLE_TOP or Intent.FLAG_ACTIVITY_CLEAR_TOP)
                 .putExtra(ARG_DEVICE, device)
+        )
+    }
+
+    fun showUrlRouter(context: Context, wxmRemoteMessage: WXMRemoteMessage? = null) {
+        context.startActivity(
+            Intent(context, UrlRouterActivity::class.java)
+                .addFlags(Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK)
+                .putExtra(ARG_REMOTE_MESSAGE, wxmRemoteMessage)
         )
     }
 

--- a/app/src/main/java/com/weatherxm/ui/common/Contracts.kt
+++ b/app/src/main/java/com/weatherxm/ui/common/Contracts.kt
@@ -18,4 +18,7 @@ object Contracts {
     const val ARG_REWARDS_OBJECT = "rewards_object"
     const val ARG_WALLET_REWARDS = "wallet_rewards"
     const val ARG_TOKEN_CLAIMED_AMOUNT = "claimed_amount"
+    const val ARG_REMOTE_MESSAGE= "remote_message"
+    const val ARG_URL = "url"
+    const val ARG_TYPE = "type"
 }

--- a/app/src/main/java/com/weatherxm/ui/components/EmptyView.kt
+++ b/app/src/main/java/com/weatherxm/ui/components/EmptyView.kt
@@ -45,7 +45,11 @@ class EmptyView : LinearLayout {
                 title(getString(R.styleable.EmptyView_empty_title))
                 subtitle(getString(R.styleable.EmptyView_empty_subtitle))
                 action(getString(EmptyView_empty_action))
-                animation(getResourceId(R.styleable.EmptyView_empty_animation, 0))
+
+                val prefilledAnimation = getResourceId(R.styleable.EmptyView_empty_animation, 0)
+                if (prefilledAnimation != 0) {
+                    animation(prefilledAnimation)
+                }
             } finally {
                 recycle()
             }

--- a/app/src/main/java/com/weatherxm/ui/startup/StartupActivity.kt
+++ b/app/src/main/java/com/weatherxm/ui/startup/StartupActivity.kt
@@ -20,10 +20,13 @@ class StartupActivity : BaseActivity() {
                 StartupState.ShowHome -> navigator.showHome(this)
                 StartupState.ShowAnalyticsOptIn -> navigator.showAnalyticsOptIn(this)
                 StartupState.ShowUpdate -> navigator.showUpdatePrompt(this)
+                is StartupState.ShowUrlRouter -> navigator.showUrlRouter(this, state.remoteMessage)
             }
             finish()
             overridePendingTransition(android.R.anim.fade_in, android.R.anim.fade_out)
         }
+
+        model.handleStartup(intent)
     }
 
     override fun onResume() {

--- a/app/src/main/java/com/weatherxm/ui/startup/StartupState.kt
+++ b/app/src/main/java/com/weatherxm/ui/startup/StartupState.kt
@@ -1,11 +1,13 @@
 package com.weatherxm.ui.startup
 
 import androidx.annotation.Keep
+import com.weatherxm.data.WXMRemoteMessage
 
 @Keep
 sealed class StartupState {
-    object ShowExplorer : StartupState()
-    object ShowHome : StartupState()
-    object ShowAnalyticsOptIn : StartupState()
-    object ShowUpdate : StartupState()
+    data object ShowExplorer : StartupState()
+    data object ShowHome : StartupState()
+    data object ShowAnalyticsOptIn : StartupState()
+    data object ShowUpdate : StartupState()
+    data class ShowUrlRouter(val remoteMessage: WXMRemoteMessage) : StartupState()
 }

--- a/app/src/main/java/com/weatherxm/ui/startup/StartupViewModel.kt
+++ b/app/src/main/java/com/weatherxm/ui/startup/StartupViewModel.kt
@@ -1,10 +1,40 @@
 package com.weatherxm.ui.startup
 
+import android.content.Intent
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
-import androidx.lifecycle.asLiveData
+import androidx.lifecycle.viewModelScope
+import com.weatherxm.data.RemoteMessageType
+import com.weatherxm.data.WXMRemoteMessage
+import com.weatherxm.ui.common.Contracts
+import com.weatherxm.ui.common.Contracts.ARG_URL
 import com.weatherxm.usecases.StartupUseCase
+import kotlinx.coroutines.launch
 
 class StartupViewModel(private val startupUseCase: StartupUseCase) : ViewModel() {
 
-    fun startup() = startupUseCase.getStartupState().asLiveData()
+    private val onStartupState = MutableLiveData<StartupState>()
+
+    fun startup(): LiveData<StartupState> = onStartupState
+
+    fun handleStartup(intent: Intent) {
+        val type = if (intent.hasExtra(Contracts.ARG_TYPE)) {
+            RemoteMessageType.parse(intent.getStringExtra(Contracts.ARG_TYPE) ?: "")
+        } else {
+            null
+        }
+
+        if (type != null) {
+            onStartupState.postValue(
+                StartupState.ShowUrlRouter(WXMRemoteMessage(type, intent.getStringExtra(ARG_URL)))
+            )
+        } else {
+            viewModelScope.launch {
+                startupUseCase.getStartupState().collect {
+                    onStartupState.postValue(it)
+                }
+            }
+        }
+    }
 }

--- a/app/src/main/java/com/weatherxm/ui/urlrouteractivity/UrlRouterActivity.kt
+++ b/app/src/main/java/com/weatherxm/ui/urlrouteractivity/UrlRouterActivity.kt
@@ -2,11 +2,8 @@ package com.weatherxm.ui.urlrouteractivity
 
 import android.os.Bundle
 import com.weatherxm.R
-import com.weatherxm.data.WXMRemoteMessage
 import com.weatherxm.databinding.ActivityUrlRouterBinding
-import com.weatherxm.ui.common.Contracts.ARG_REMOTE_MESSAGE
 import com.weatherxm.ui.common.applyInsets
-import com.weatherxm.ui.common.parcelable
 import com.weatherxm.ui.common.setVisible
 import com.weatherxm.ui.components.BaseActivity
 import org.koin.androidx.viewmodel.ext.android.viewModel
@@ -21,9 +18,6 @@ class UrlRouterActivity : BaseActivity() {
         setContentView(binding.root)
 
         binding.root.applyInsets()
-
-        // TODO: Handle remote message
-        val remoteMessage = intent.parcelable<WXMRemoteMessage>(ARG_REMOTE_MESSAGE)
 
         model.onError().observe(this) {
             binding.logo.setVisible(false)
@@ -44,7 +38,18 @@ class UrlRouterActivity : BaseActivity() {
             finish()
         }
 
-        model.parseUrl(intent.data)
+        model.onRemoteMessage().observe(this) {
+            binding.logo.setVisible(false)
+            it.url?.let { url ->
+                if (isTaskRoot) {
+                    navigator.showStartup(this)
+                }
+                navigator.openWebsite(this, url)
+            }
+            finish()
+        }
+
+        model.parseUrl(intent)
     }
 }
 

--- a/app/src/main/java/com/weatherxm/ui/urlrouteractivity/UrlRouterActivity.kt
+++ b/app/src/main/java/com/weatherxm/ui/urlrouteractivity/UrlRouterActivity.kt
@@ -2,8 +2,11 @@ package com.weatherxm.ui.urlrouteractivity
 
 import android.os.Bundle
 import com.weatherxm.R
+import com.weatherxm.data.WXMRemoteMessage
 import com.weatherxm.databinding.ActivityUrlRouterBinding
+import com.weatherxm.ui.common.Contracts.ARG_REMOTE_MESSAGE
 import com.weatherxm.ui.common.applyInsets
+import com.weatherxm.ui.common.parcelable
 import com.weatherxm.ui.common.setVisible
 import com.weatherxm.ui.components.BaseActivity
 import org.koin.androidx.viewmodel.ext.android.viewModel
@@ -18,6 +21,9 @@ class UrlRouterActivity : BaseActivity() {
         setContentView(binding.root)
 
         binding.root.applyInsets()
+
+        // TODO: Handle remote message
+        val remoteMessage = intent.parcelable<WXMRemoteMessage>(ARG_REMOTE_MESSAGE)
 
         model.onError().observe(this) {
             binding.logo.setVisible(false)

--- a/app/src/main/java/com/weatherxm/ui/urlrouteractivity/UrlRouterViewModel.kt
+++ b/app/src/main/java/com/weatherxm/ui/urlrouteractivity/UrlRouterViewModel.kt
@@ -1,6 +1,6 @@
 package com.weatherxm.ui.urlrouteractivity
 
-import android.net.Uri
+import android.content.Intent
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
@@ -9,8 +9,11 @@ import arrow.core.getOrElse
 import com.weatherxm.R
 import com.weatherxm.data.ApiError
 import com.weatherxm.data.Failure
+import com.weatherxm.data.WXMRemoteMessage
 import com.weatherxm.data.repository.ExplorerRepositoryImpl.Companion.EXCLUDE_PLACES
+import com.weatherxm.ui.common.Contracts.ARG_REMOTE_MESSAGE
 import com.weatherxm.ui.common.UIDevice
+import com.weatherxm.ui.common.parcelable
 import com.weatherxm.ui.explorer.SearchResult
 import com.weatherxm.usecases.DeviceListUseCase
 import com.weatherxm.usecases.ExplorerUseCase
@@ -29,18 +32,28 @@ class UrlRouterViewModel(
 
     private val onError = MutableLiveData<String>()
     private val onDevice = MutableLiveData<UIDevice>()
+    private val onRemoteMessage = MutableLiveData<WXMRemoteMessage>()
 
     fun onError(): LiveData<String> = onError
     fun onDevice(): LiveData<UIDevice> = onDevice
+    fun onRemoteMessage(): LiveData<WXMRemoteMessage> = onRemoteMessage
 
-    fun parseUrl(uri: Uri?) {
-        val pathSegments = uri?.pathSegments ?: mutableListOf()
+    fun parseUrl(intent: Intent) {
+        intent.parcelable<WXMRemoteMessage>(ARG_REMOTE_MESSAGE)?.let {
+            if (it.url.isNullOrEmpty()) {
+                onError.postValue(resources.getString(R.string.could_not_parse_url))
+            } else {
+                onRemoteMessage.postValue(it)
+            }
+        } ?: run {
+            val pathSegments = intent.data?.pathSegments ?: mutableListOf()
 
-        // e.g. https://exporer.weatherxm.com/stations/my-weather-station
-        if (pathSegments.size == 2 && pathSegments[0].equals(STATIONS_PATH_SEGMENT)) {
-            searchForDevice(pathSegments[1])
-        } else {
-            onError.postValue(resources.getString(R.string.could_not_parse_url))
+            // e.g. https://exporer.weatherxm.com/stations/my-weather-station
+            if (pathSegments.size == 2 && pathSegments[0].equals(STATIONS_PATH_SEGMENT)) {
+                searchForDevice(pathSegments[1])
+            } else {
+                onError.postValue(resources.getString(R.string.could_not_parse_url))
+            }
         }
     }
 

--- a/app/src/main/java/com/weatherxm/ui/widgets/RemoteViews.kt
+++ b/app/src/main/java/com/weatherxm/ui/widgets/RemoteViews.kt
@@ -69,7 +69,7 @@ fun RemoteViews.onShouldLogin(
 
     val pendingIntent: PendingIntent = PendingIntent.getActivity(
         context,
-        0,
+        appWidgetId,
         Intent(context, LoginActivity::class.java),
         PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
     )

--- a/app/src/main/java/com/weatherxm/util/Permissions.kt
+++ b/app/src/main/java/com/weatherxm/util/Permissions.kt
@@ -1,9 +1,12 @@
 package com.weatherxm.util
 
 import android.Manifest
+import android.content.Context
 import android.content.Intent
+import android.content.pm.PackageManager
 import android.net.Uri
 import android.provider.Settings
+import androidx.core.content.ContextCompat
 import androidx.fragment.app.FragmentActivity
 import com.fondesa.kpermissions.allDenied
 import com.fondesa.kpermissions.allPermanentlyDenied
@@ -92,6 +95,10 @@ fun FragmentActivity.checkPermissionsAndThen(
             result.allPermanentlyDenied() -> onPermanentlyDenied()
         }
     }
+}
+
+fun Context.hasPermission(permission: String): Boolean {
+    return ContextCompat.checkSelfPermission(this, permission) == PackageManager.PERMISSION_GRANTED
 }
 
 private fun FragmentActivity.permissionsBuilder(

--- a/app/src/main/res/layout/activity_url_router.xml
+++ b/app/src/main/res/layout/activity_url_router.xml
@@ -24,7 +24,7 @@
         android:layout_gravity="center"
         android:padding="@dimen/padding_extra_large"
         android:visibility="gone"
-        app:empty_animation="@raw/anim_empty_devices"
+        tools:empty_animation="@raw/anim_empty_devices"
         tools:empty_subtitle="How are you?"
         tools:empty_title="Nothing here"
         tools:visibility="visible" />


### PR DESCRIPTION
## **Why?**

Integrate notifications in order to be able to show them to users.

### **How?**

1. Created `WXMRemoteMessage` which will be our `data class` for these messages
2. Created `enum class RemoteMessageType(val id: String, val publicName: String, val desc: String)` where `id` is the respective `type` custom value as agreed, `publicName` & `desc` are texts that will be visible in app-settings for informing the user what this channel is about.
3. Proper implementation of `onMessageReceived` in order to handle notifications when the app is on foreground
4. When the app is in the background, and the notification gets clicked, `StartupActivity` starts with notification-data in its `intent` so we handle it there and if the app opened due to a notification we open the `UrlRouterActivity`.
5. `UrlRouterActivity` makes all the necessary checks as to what to do next and if a valid `url` is present it opens a Chrome Tab with `navigator.openWebsite(...)`. Also, we make a check `isTaskRoot` in order to first reopen the `StartupActivity` in case a user hits the "back button" to keep the app open after the ChromeTab gets closed (the `StartupActivity` handles properly as to "where" the user should go next).

### **Testing**

1. Get your FCM token by searching in Logcat "token"
7. Try sending a test message through Firebase Console
8. Test the app in different scenarios how it handles it, visible, on the background, stopped.