### PR TITLE
FE-555 Create a workflow_dispatch aka manual workflow to trigger a QA release

### DIFF
--- a/.github/workflows/on-qa-firebase-distribution.yml
+++ b/.github/workflows/on-qa-firebase-distribution.yml
@@ -1,7 +1,12 @@
-name: Build Production & Development and Distribute on Firebase
+name: Build QA Release and Distribute on Firebase
 on:
-    push:
-        branches: [ main ]
+    workflow_dispatch:
+        inputs:
+            buildType:
+                type: environment
+                description: 'Select between "production" and "development" as build types.'
+                required: true
+                default: 'production'
 env:
     # Claim DApp URL
     ORG_GRADLE_PROJECT_CLAIM_APP_URL: ${{ secrets.CLAIM_APP_URL }}
@@ -13,15 +18,15 @@ env:
     ORG_GRADLE_PROJECT_RELEASE_KEYSTORE_PASSWORD: ${{ secrets.RELEASE_KEYSTORE_PASSWORD }}
     ORG_GRADLE_PROJECT_RELEASE_KEY_ALIAS: ${{ secrets.RELEASE_KEY_ALIAS }}
     ORG_GRADLE_PROJECT_RELEASE_KEY_PASSWORD: ${{ secrets.RELEASE_KEY_PASSWORD }}
-    # Firebase distribution test groups
-    ORG_GRADLE_PROJECT_FIREBASE_PUBLIC_TEST_GROUP: ${{ secrets.FIREBASE_PUBLIC_TEST_GROUP }}
-    ORG_GRADLE_PROJECT_FIREBASE_INTERNAL_TEST_GROUP: ${{ secrets.FIREBASE_INTERNAL_TEST_GROUP }}
+    # Firebase distribution only on QA Groups
+    ORG_GRADLE_PROJECT_FIREBASE_PUBLIC_TEST_GROUP: ${{ secrets.FIREBASE_QA_TEST_GROUP }}
+    ORG_GRADLE_PROJECT_FIREBASE_INTERNAL_TEST_GROUP: ${{ secrets.FIREBASE_QA_TEST_GROUP }}
     # Gradle config
     GRADLE_USER_HOME: ${GITHUB_WORKSPACE}/.gradle
     GLOBAL_GRADLE_CACHE: gradle-cache-${GITHUB_REPOSITORY}
 jobs:
-    production_dist:
-        environment: production
+    qa_dist:
+        environment: ${{ github.event.inputs.buildType }}
         env:
             # API URL for Prod Flavor
             ORG_GRADLE_PROJECT_API_URL: ${{ secrets.API_URL }}
@@ -47,38 +52,13 @@ jobs:
                 with:
                     distribution: 'temurin'
                     java-version: '17'
-            -   name: Build production release and distribute on Firebase
+            -   name: Build production release for the QA Team and distribute on Firebase
+                if: ${{ github.event.inputs.buildType == 'production' }}
                 run: |
                     ./gradlew :app:assembleRemoteProdRelease :app:appDistributionUploadRemoteProdRelease -PSKIP_PRODUCTION_ENV
                     rm ./ci-service-account.json
-    development_dist:
-        environment: development
-        env:
-            # API URL for Dev Flavor
-            ORG_GRADLE_PROJECT_API_URL: ${{ secrets.API_URL }}
-        runs-on: ubuntu-latest
-        steps:
-            -   name: Checkout
-                uses: actions/checkout@v2
-                with:
-                    fetch-depth: 0
-            -   name: Gradle package cache
-                uses: actions/cache@v2
-                with:
-                    key: ${{ env.GLOBAL_GRADLE_CACHE }}
-                    path: ${{ env.GRADLE_USER_HOME }}
-            -   name: Decode secrets
-                run: |
-                    echo "${{ secrets.ENCODED_GOOGLE_SERVICES }}" | base64 -d > ./app/google-services.json
-                    echo "${{ secrets.ENCODED_SERVICE_ACCOUNT }}" | base64 -d > ./ci-service-account.json
-                    echo "${{ secrets.ENCODED_RELEASE_KEYSTORE }}" > release-keystore.asc
-                    gpg -d --passphrase "${{ secrets.ENCODED_RELEASE_KEYSTORE_PASSPHRASE }}" --batch release-keystore.asc > ./${{ secrets.RELEASE_KEYSTORE }}
-            -   name: Setup JDK 17
-                uses: actions/setup-java@v3
-                with:
-                    distribution: 'temurin'
-                    java-version: '17'
-            -   name: Build development release and distribute on Firebase
+            -   name: Build development release for the QA Team and distribute on Firebase
+                if: ${{ github.event.inputs.buildType == 'development' }}
                 run: |
                     ./gradlew :app:assembleRemoteDevDebug :app:appDistributionUploadRemoteDevDebug -PSKIP_PRODUCTION_ENV
                     rm ./ci-service-account.json

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ optimizations. Our config file for Detekt can be found in `detekt.yml`.
 
 # GitHub Actions
 
-We have 3 different [GitHub Actions](https://github.com/features/actions):
+We have 4 different [GitHub Actions](https://github.com/features/actions):
 
 1. **Code Analysis:** An action that runs on **every Pull Request**, building the app and
    running `./gradlew :app:detekt` in order to find potential code optimizations.
@@ -81,6 +81,11 @@ We have 3 different [GitHub Actions](https://github.com/features/actions):
    running `./gradlew :app:assembleRemoteProdRelease :app:appDistributionUploadRemoteProdRelease` in
    order to distribute a **Remote Prod** version of the app
    through [Firebase App Distribution](https://firebase.google.com/docs/app-distribution) in the
+   Firebase Channels. Currently used for internal testing.
+4. **Build QA Release and Distribute on Firebase:** An action that gets 
+   [manually triggered](https://github.blog/changelog/2020-07-06-github-actions-manual-triggers-with-workflow_dispatch/)
+   and takes as input the environment, creates a release and distributes it through 
+   [Firebase App Distribution](https://firebase.google.com/docs/app-distribution) in the QA 
    Firebase Channels. Currently used for internal testing.
 
 # How to merge `feature/` in Git?


### PR DESCRIPTION
## **Why?**

We need a way for the QA team to manually trigger releases whenever they want.

### **How?**

- Followed the guide [here](https://github.blog/changelog/2020-07-06-github-actions-manual-triggers-with-workflow_dispatch/) and added a `workflow_dispatch` GitHub Workflow, which takes as input the environment parameters (`production` or `development`), sets the respective environment and creates the respective release.

### **Testing**

Not possible, based on [this](https://stackoverflow.com/a/74722590/5403137), the action needs to be on the `main` branch,