### PR TITLE
FE-451 Create dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+
+version: 2
+updates:
+  - package-ecosystem: "gradle"
+    directory: "/" # Location of package manifests
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
## **Why?**
Create `dependabot.yml` in order to have it open automatically PRs for version updates.

### **How?**

Followed the guide [here](https://medium.com/@vladyslav.hontar/dependabot-in-action-d9b56b2be86c).

### **Testing**

I think we cannot test it, we need it merged to main and see how it goes.