### PR TITLE
FE-566 Use as inputs the "release" & "debug" on the manual QA release

### DIFF
--- a/.github/workflows/on-qa-firebase-distribution.yml
+++ b/.github/workflows/on-qa-firebase-distribution.yml
@@ -2,11 +2,19 @@ name: Build QA Release and Distribute on Firebase
 on:
     workflow_dispatch:
         inputs:
-            buildType:
+            environment:
                 type: environment
-                description: 'Select between "production" and "development" as build types.'
+                description: 'Select between "production" and "development" as the environment.'
                 required: true
                 default: 'production'
+            buildType:
+                type: choice
+                description: 'Select between "release" and "debug" as build types.'
+                required: true
+                options:
+                    - "release"
+                    - "debug"
+                default: 'release'
 env:
     # Claim DApp URL
     ORG_GRADLE_PROJECT_CLAIM_APP_URL: ${{ secrets.CLAIM_APP_URL }}
@@ -53,12 +61,22 @@ jobs:
                     distribution: 'temurin'
                     java-version: '17'
             -   name: Build production release for the QA Team and distribute on Firebase
-                if: ${{ github.event.inputs.buildType == 'production' }}
+                if: ${{ github.event.inputs.environment == 'production' && github.event.inputs.buildType == 'release' }}
+                run: |
+                    ./gradlew :app:assembleRemoteProdRelease :app:appDistributionUploadRemoteProdRelease -PSKIP_PRODUCTION_ENV
+                    rm ./ci-service-account.json
+            -   name: Build production debug for the QA Team and distribute on Firebase
+                if: ${{ github.event.inputs.environment == 'production' && github.event.inputs.buildType == 'debug' }}
                 run: |
                     ./gradlew :app:assembleRemoteProdRelease :app:appDistributionUploadRemoteProdRelease -PSKIP_PRODUCTION_ENV
                     rm ./ci-service-account.json
             -   name: Build development release for the QA Team and distribute on Firebase
-                if: ${{ github.event.inputs.buildType == 'development' }}
+                if: ${{ github.event.inputs.environment == 'development' && github.event.inputs.buildType == 'release' }}
+                run: |
+                    ./gradlew :app:assembleRemoteDevRelease :app:appDistributionUploadRemoteDevRelease -PSKIP_PRODUCTION_ENV
+                    rm ./ci-service-account.json
+            -   name: Build development debug for the QA Team and distribute on Firebase
+                if: ${{ github.event.inputs.environment == 'development' && github.event.inputs.buildType == 'debug' }}
                 run: |
                     ./gradlew :app:assembleRemoteDevDebug :app:appDistributionUploadRemoteDevDebug -PSKIP_PRODUCTION_ENV
                     rm ./ci-service-account.json

--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ We have 4 different [GitHub Actions](https://github.com/features/actions):
    Firebase Channels. Currently used for internal testing.
 4. **Build QA Release and Distribute on Firebase:** An action that gets 
    [manually triggered](https://github.blog/changelog/2020-07-06-github-actions-manual-triggers-with-workflow_dispatch/)
-   and takes as input the environment, creates a release and distributes it through 
+   and takes as input the `environment`, the `build type` and creates a release and distributes it through 
    [Firebase App Distribution](https://firebase.google.com/docs/app-distribution) in the QA 
    Firebase Channels. Currently used for internal testing.
 


### PR DESCRIPTION
## **Why?**

We need to let the QA team who triggers the release to choose between `release` or `debug` build types.

### **How?**

Added:
```
            buildType:
                type: choice
                description: 'Select between "release" and "debug" as build types.'
                required: true
                options:
                    - "release"
                    - "debug"
                default: 'release'
```
And some `if` below to run the respective assemble and distribute commands.

### **Testing**

Not possible until merged 😞 