### PR TITLE
FE-580 Feature/annotation group

### DIFF
--- a/app/src/local/assets/mock_files/get_user_device_rewards.json
+++ b/app/src/local/assets/mock_files/get_user_device_rewards.json
@@ -108,11 +108,11 @@
             "pol": [
                 {
                     "annotation": "LOCATION_NOT_VERIFIED",
-                    "ratio": 0.8
+                    "ratio": 8
                 },
                 {
                     "annotation": "NO_LOCATION_DATA",
-                    "ratio": 0.8
+                    "ratio": 8
                 }
             ],
             "rm": [
@@ -129,7 +129,30 @@
                     "annotation": "QOD_THRESHOLD_NOT_REACHED"
                 }
             ]
-        }
+        },
+        "annotation_summary": [
+            {
+                "severity": "WARNING",
+                "group": "NO_WALLET",
+                "title": "No Wallet",
+                "message": "Station excluded from rewards because no connected wallet was found.",
+                "doc_url": "https://docs.weatherxm.com/"
+            },
+            {
+                "severity": "INFO",
+                "group": "SENSOR_PROBLEMS",
+                "title": "Sensor Problems",
+                "message": "Station is doing great! Minor sensor issues detected during our checks.",
+                "doc_url": "https://docs.weatherxm.com/"
+            },
+            {
+                "severity": "ERROR",
+                "group": "LOCATION_NOT_VERIFIED",
+                "title": "Invalid Location",
+                "message": "Station rewards were temporarily suspended, because the station’s location could not be verified. The station’s location needs to be revalidated by the owner and it will be again eligible for rewards in 2 days.",
+                "doc_url": "https://docs.weatherxm.com/"
+            }
+        ]
     },
     "weekly": {
         "total_rewards": 1252.0,
@@ -166,10 +189,10 @@
                 100,
                 50,
                 100,
-                0.26,
-                0.26,
-                0.26,
-                0.26,
+                26,
+                26,
+                26,
+                26,
                 100,
                 100,
                 10,

--- a/app/src/local/assets/mock_files/get_user_device_rewards.json
+++ b/app/src/local/assets/mock_files/get_user_device_rewards.json
@@ -132,21 +132,21 @@
         },
         "annotation_summary": [
             {
-                "severity": "WARNING",
+                "severity_level": "WARNING",
                 "group": "NO_WALLET",
                 "title": "No Wallet",
                 "message": "Station excluded from rewards because no connected wallet was found.",
                 "doc_url": "https://docs.weatherxm.com/"
             },
             {
-                "severity": "INFO",
+                "severity_level": "INFO",
                 "group": "SENSOR_PROBLEMS",
                 "title": "Sensor Problems",
                 "message": "Station is doing great! Minor sensor issues detected during our checks.",
                 "doc_url": "https://docs.weatherxm.com/"
             },
             {
-                "severity": "ERROR",
+                "severity_level": "ERROR",
                 "group": "LOCATION_NOT_VERIFIED",
                 "title": "Invalid Location",
                 "message": "Station rewards were temporarily suspended, because the station’s location could not be verified. The station’s location needs to be revalidated by the owner and it will be again eligible for rewards in 2 days.",

--- a/app/src/local/assets/mock_files/get_user_device_transactions.json
+++ b/app/src/local/assets/mock_files/get_user_device_transactions.json
@@ -111,7 +111,30 @@
                         "annotation": "NO_WALLET"
                     }
                 ]
-            }
+            },
+            "annotation_summary": [
+                {
+                    "severity": "WARNING",
+                    "group": "NO_WALLET",
+                    "title": "No Wallet",
+                    "message": "Station excluded from rewards because no connected wallet was found.",
+                    "doc_url": "https://docs.weatherxm.com/"
+                },
+                {
+                    "severity": "INFO",
+                    "group": "SENSOR_PROBLEMS",
+                    "title": "Sensor Problems",
+                    "message": "Station is doing great! Minor sensor issues detected during our checks.",
+                    "doc_url": "https://docs.weatherxm.com/"
+                },
+                {
+                    "severity": "ERROR",
+                    "group": "LOCATION_NOT_VERIFIED",
+                    "title": "Invalid Location",
+                    "message": "Station rewards were temporarily suspended, because the station’s location could not be verified. The station’s location needs to be revalidated by the owner and it will be again eligible for rewards in 2 days.",
+                    "doc_url": "https://docs.weatherxm.com/"
+                }
+            ]
         },
         {
             "timestamp": "2022-06-02T12:00:02+00:00",

--- a/app/src/local/assets/mock_files/get_user_device_transactions.json
+++ b/app/src/local/assets/mock_files/get_user_device_transactions.json
@@ -114,21 +114,21 @@
             },
             "annotation_summary": [
                 {
-                    "severity": "WARNING",
+                    "severity_level": "WARNING",
                     "group": "NO_WALLET",
                     "title": "No Wallet",
                     "message": "Station excluded from rewards because no connected wallet was found.",
                     "doc_url": "https://docs.weatherxm.com/"
                 },
                 {
-                    "severity": "INFO",
+                    "severity_level": "INFO",
                     "group": "SENSOR_PROBLEMS",
                     "title": "Sensor Problems",
                     "message": "Station is doing great! Minor sensor issues detected during our checks.",
                     "doc_url": "https://docs.weatherxm.com/"
                 },
                 {
-                    "severity": "ERROR",
+                    "severity_level": "ERROR",
                     "group": "LOCATION_NOT_VERIFIED",
                     "title": "Invalid Location",
                     "message": "Station rewards were temporarily suspended, because the station’s location could not be verified. The station’s location needs to be revalidated by the owner and it will be again eligible for rewards in 2 days.",

--- a/app/src/main/java/com/weatherxm/data/ApiModels.kt
+++ b/app/src/main/java/com/weatherxm/data/ApiModels.kt
@@ -519,7 +519,8 @@ data class RewardsAnnotation(
 @JsonClass(generateAdapter = true)
 @Parcelize
 data class RewardsAnnotationGroup(
-    val severity: Severity?,
+    @Json(name = "severity_level")
+    val severityLevel: SeverityLevel?,
     val group: String?,
     val title: String?,
     val message: String?,
@@ -581,7 +582,7 @@ enum class Relation {
     followed
 }
 
-enum class Severity {
+enum class SeverityLevel {
     INFO,
     WARNING,
     ERROR

--- a/app/src/main/java/com/weatherxm/data/ApiModels.kt
+++ b/app/src/main/java/com/weatherxm/data/ApiModels.kt
@@ -5,6 +5,7 @@ import androidx.annotation.Keep
 import com.squareup.moshi.Json
 import com.squareup.moshi.JsonClass
 import com.weatherxm.ui.common.AnnotationCode
+import com.weatherxm.ui.common.AnnotationGroupCode
 import com.weatherxm.ui.common.DeviceRelation
 import com.weatherxm.ui.common.UIDevice
 import com.weatherxm.ui.common.empty
@@ -196,7 +197,9 @@ data class Transaction(
     @Json(name = "lost_rewards")
     val lostRewards: Float?,
     val timeline: RewardsTimeline?,
-    val annotations: RewardsAnnotations?
+    val annotations: RewardsAnnotations?,
+    @Json(name = "annotation_summary")
+    val annotationSummary: List<RewardsAnnotationGroup>?,
 ) : Parcelable
 
 @Keep
@@ -470,7 +473,9 @@ data class RewardsObject(
     @Json(name = "lost_rewards")
     val lostRewards: Float?,
     val timeline: RewardsTimeline?,
-    val annotations: RewardsAnnotations?
+    val annotations: RewardsAnnotations?,
+    @Json(name = "annotation_summary")
+    val annotationSummary: List<RewardsAnnotationGroup>?,
 ) : Parcelable
 
 @Keep
@@ -506,6 +511,27 @@ data class RewardsAnnotation(
         } catch (e: IllegalArgumentException) {
             Timber.w(e)
             AnnotationCode.UNKNOWN
+        }
+    }
+}
+
+@Keep
+@JsonClass(generateAdapter = true)
+@Parcelize
+data class RewardsAnnotationGroup(
+    val severity: Severity?,
+    val group: String?,
+    val title: String?,
+    val message: String?,
+    @Json(name = "doc_url")
+    val docUrl: String?,
+) : Parcelable {
+    fun toAnnotationGroupCode(): AnnotationGroupCode {
+        return try {
+            AnnotationGroupCode.valueOf(group ?: String.empty())
+        } catch (e: IllegalArgumentException) {
+            Timber.w(e)
+            AnnotationGroupCode.UNKNOWN
         }
     }
 }
@@ -553,5 +579,11 @@ enum class BatteryState {
 enum class Relation {
     owned,
     followed
+}
+
+enum class Severity {
+    INFO,
+    WARNING,
+    ERROR
 }
 

--- a/app/src/main/java/com/weatherxm/ui/cellinfo/CellInfoActivity.kt
+++ b/app/src/main/java/com/weatherxm/ui/cellinfo/CellInfoActivity.kt
@@ -8,7 +8,6 @@ import com.weatherxm.data.Resource
 import com.weatherxm.data.Status
 import com.weatherxm.databinding.ActivityCellInfoBinding
 import com.weatherxm.ui.common.Contracts
-import com.weatherxm.ui.common.DeviceRelation
 import com.weatherxm.ui.common.UIDevice
 import com.weatherxm.ui.common.applyInsets
 import com.weatherxm.ui.common.parcelable
@@ -127,15 +126,15 @@ class CellInfoActivity : BaseActivity(), CellDeviceListener {
             return
         }
 
-        if (device.relation == DeviceRelation.FOLLOWED) {
+        if (device.isFollowed()) {
             navigator.showHandleFollowDialog(this, false, device.name) {
                 model.unFollowStation(device.id)
             }
-        } else if (device.relation == DeviceRelation.UNFOLLOWED && !device.isOnline()) {
+        } else if (device.isUnfollowed() && !device.isOnline()) {
             navigator.showHandleFollowDialog(this, true, device.name) {
                 model.followStation(device.id)
             }
-        } else if (device.relation == DeviceRelation.UNFOLLOWED) {
+        } else if (device.isUnfollowed()) {
             model.followStation(device.id)
         }
     }

--- a/app/src/main/java/com/weatherxm/ui/common/UIModels.kt
+++ b/app/src/main/java/com/weatherxm/ui/common/UIModels.kt
@@ -92,7 +92,7 @@ data class UIRewardObject(
         setTimelineTitle(context, rewards.timeline?.referenceDate, fromDate, toDate)
         timelineScores = rewards.timeline?.rewardScores ?: mutableListOf()
         annotationSummary = rewards.annotationSummary?.sortedByDescending {
-            it.severity?.ordinal
+            it.severityLevel?.ordinal
         } ?: mutableListOf()
         setAnnotations(hideAnnotationsThreshold, rewards.annotations)
     }
@@ -110,7 +110,7 @@ data class UIRewardObject(
         setTimelineTitle(context, tx.timeline?.referenceDate)
         timelineScores = tx.timeline?.rewardScores ?: mutableListOf()
         annotationSummary = tx.annotationSummary?.sortedByDescending {
-            it.severity?.ordinal
+            it.severityLevel?.ordinal
         } ?: mutableListOf()
         setAnnotations(hideAnnotationsThreshold, tx.annotations)
     }

--- a/app/src/main/java/com/weatherxm/ui/components/MessageCardView.kt
+++ b/app/src/main/java/com/weatherxm/ui/components/MessageCardView.kt
@@ -8,7 +8,9 @@ import android.view.LayoutInflater
 import android.view.View
 import android.widget.LinearLayout
 import androidx.annotation.ColorRes
+import androidx.annotation.DrawableRes
 import androidx.annotation.StringRes
+import androidx.core.content.res.ResourcesCompat
 import com.google.android.material.button.MaterialButton.ICON_GRAVITY_END
 import com.google.android.material.button.MaterialButton.ICON_GRAVITY_START
 import com.weatherxm.R
@@ -111,10 +113,10 @@ class MessageCardView : LinearLayout {
         return this
     }
 
-    fun title(subtitle: String?): MessageCardView {
+    fun title(title: String?): MessageCardView {
         binding.title.apply {
-            text = subtitle
-            visibility = if (subtitle != null) View.VISIBLE else View.GONE
+            text = title
+            visibility = if (title != null) View.VISIBLE else View.GONE
         }
         return this
     }
@@ -137,12 +139,21 @@ class MessageCardView : LinearLayout {
         return this
     }
 
+    fun setIcon(@DrawableRes drawableResId: Int): MessageCardView {
+        binding.icon.setImageDrawable(
+            ResourcesCompat.getDrawable(resources, drawableResId, context.theme)
+        )
+        binding.icon.setVisible(true)
+        return this
+    }
+
     fun setIconColor(@ColorRes colorResId: Int): MessageCardView {
         binding.icon.setColor(colorResId)
         return this
     }
 
     fun setStrokeColor(@ColorRes colorResId: Int): MessageCardView {
+        binding.card.strokeWidth = 2
         binding.card.strokeColor = context.getColor(colorResId)
         return this
     }

--- a/app/src/main/java/com/weatherxm/ui/devicealerts/DeviceAlertsAdapter.kt
+++ b/app/src/main/java/com/weatherxm/ui/devicealerts/DeviceAlertsAdapter.kt
@@ -8,7 +8,6 @@ import androidx.recyclerview.widget.RecyclerView
 import com.weatherxm.R
 import com.weatherxm.databinding.ListItemAlertBinding
 import com.weatherxm.ui.common.DeviceAlert
-import com.weatherxm.ui.common.DeviceRelation
 import com.weatherxm.ui.common.UIDevice
 import com.weatherxm.ui.common.setVisible
 
@@ -46,7 +45,7 @@ class DeviceAlertsAdapter(
                     }
                 showWarningCard()
             } else if (item == DeviceAlert.OFFLINE) {
-                val messageResId = if (device?.relation == DeviceRelation.OWNED) {
+                val messageResId = if (device?.isOwned() == true) {
                     R.string.station_offline_alert_message
                 } else {
                     R.string.no_data_message_public_device

--- a/app/src/main/java/com/weatherxm/ui/devicedetails/DeviceDetailsActivity.kt
+++ b/app/src/main/java/com/weatherxm/ui/devicedetails/DeviceDetailsActivity.kt
@@ -234,11 +234,11 @@ class DeviceDetailsActivity : BaseActivity() {
         }
 
         with(binding.toolbar) {
-            if (device.relation == DeviceRelation.FOLLOWED) {
+            if (device.isFollowed()) {
                 if (menu.findItem(R.id.settings) == null) {
                     menu.add(Menu.NONE, R.id.settings, 1, R.string.station_settings)
                 }
-            } else if (device.relation == DeviceRelation.UNFOLLOWED) {
+            } else if (device.isUnfollowed()) {
                 menu.removeItem(R.id.settings)
             }
         }
@@ -268,15 +268,15 @@ class DeviceDetailsActivity : BaseActivity() {
             return
         }
 
-        if (model.device.relation == DeviceRelation.FOLLOWED) {
+        if (model.device.isFollowed()) {
             navigator.showHandleFollowDialog(this, false, model.device.name) {
                 model.unFollowStation()
             }
-        } else if (model.device.relation == DeviceRelation.UNFOLLOWED && !model.device.isOnline()) {
+        } else if (model.device.isUnfollowed() && !model.device.isOnline()) {
             navigator.showHandleFollowDialog(this, true, model.device.name) {
                 model.followStation()
             }
-        } else if (model.device.relation == DeviceRelation.UNFOLLOWED) {
+        } else if (model.device.isUnfollowed()) {
             model.followStation()
         }
     }

--- a/app/src/main/java/com/weatherxm/ui/devicedetails/current/CurrentFragment.kt
+++ b/app/src/main/java/com/weatherxm/ui/devicedetails/current/CurrentFragment.kt
@@ -80,12 +80,8 @@ class CurrentFragment : BaseFragment() {
             navigator.showHistoryActivity(requireContext(), model.device)
         }
 
-        binding.followCard.setVisible(
-            model.device.relation == DeviceRelation.UNFOLLOWED
-        )
-        binding.historicalCharts.isEnabled =
-            model.device.relation != DeviceRelation.UNFOLLOWED
-
+        binding.followCard.setVisible(model.device.isUnfollowed())
+        binding.historicalCharts.isEnabled = !model.device.isUnfollowed()
         binding.followPromptBtn.setOnClickListener {
             handleFollowClick()
         }
@@ -109,11 +105,11 @@ class CurrentFragment : BaseFragment() {
             return
         }
 
-        if (model.device.relation == DeviceRelation.UNFOLLOWED && !model.device.isOnline()) {
+        if (model.device.isUnfollowed() && !model.device.isOnline()) {
             navigator.showHandleFollowDialog(activity, true, model.device.name) {
                 parentModel.followStation()
             }
-        } else if (model.device.relation == DeviceRelation.UNFOLLOWED) {
+        } else if (model.device.isUnfollowed()) {
             parentModel.followStation()
         }
     }
@@ -122,12 +118,8 @@ class CurrentFragment : BaseFragment() {
         binding.progress.visibility = View.INVISIBLE
         setAlerts(device)
         binding.currentWeatherCard.setData(device.currentWeather)
-
-        binding.followCard.setVisible(
-            device.relation == DeviceRelation.UNFOLLOWED
-        )
-        binding.historicalCharts.isEnabled =
-            device.relation != DeviceRelation.UNFOLLOWED
+        binding.followCard.setVisible(device.isUnfollowed())
+        binding.historicalCharts.isEnabled = !device.isUnfollowed()
     }
 
     private fun setAlerts(device: UIDevice) {

--- a/app/src/main/java/com/weatherxm/ui/devicedetails/forecast/ForecastViewModel.kt
+++ b/app/src/main/java/com/weatherxm/ui/devicedetails/forecast/ForecastViewModel.kt
@@ -9,7 +9,6 @@ import com.weatherxm.data.ApiError
 import com.weatherxm.data.Failure
 import com.weatherxm.data.NetworkError.ConnectionTimeoutError
 import com.weatherxm.data.NetworkError.NoConnectionError
-import com.weatherxm.ui.common.DeviceRelation
 import com.weatherxm.ui.common.UIDevice
 import com.weatherxm.ui.common.UIError
 import com.weatherxm.ui.common.UIForecast
@@ -45,7 +44,7 @@ class ForecastViewModel(
          *
          * Or do not fetch forecast if we this device is UNFOLLOWED
          */
-        if (device.isDeviceFromSearchResult || device.relation == DeviceRelation.UNFOLLOWED) {
+        if (device.isDeviceFromSearchResult || device.isUnfollowed()) {
             return
         }
         onLoading.postValue(true)

--- a/app/src/main/java/com/weatherxm/ui/devicesettings/DeviceSettingsActivity.kt
+++ b/app/src/main/java/com/weatherxm/ui/devicesettings/DeviceSettingsActivity.kt
@@ -132,7 +132,7 @@ class DeviceSettingsActivity : BaseActivity() {
         binding.editLocationBtn.setOnClickListener {
             navigator.showEditLocation(editLocationLauncher, this, model.device)
         }
-        binding.editLocationBtn.setVisible(model.device.relation == DeviceRelation.OWNED)
+        binding.editLocationBtn.setVisible(model.device.isOwned())
 
         if (model.device.relation == DeviceRelation.FOLLOWED) {
             binding.locationDesc.setHtml(
@@ -155,7 +155,7 @@ class DeviceSettingsActivity : BaseActivity() {
     }
 
     private fun updateMinimap() {
-        val deviceMapLocation = if (model.device.relation == DeviceRelation.OWNED) {
+        val deviceMapLocation = if (model.device.isOwned()) {
             model.device.location
         } else {
             null

--- a/app/src/main/java/com/weatherxm/ui/devicesettings/DeviceSettingsViewModel.kt
+++ b/app/src/main/java/com/weatherxm/ui/devicesettings/DeviceSettingsViewModel.kt
@@ -8,7 +8,6 @@ import com.weatherxm.R
 import com.weatherxm.data.ApiError
 import com.weatherxm.data.BatteryState
 import com.weatherxm.data.DeviceProfile
-import com.weatherxm.ui.common.DeviceRelation
 import com.weatherxm.ui.common.UIDevice
 import com.weatherxm.ui.common.UIError
 import com.weatherxm.ui.common.capitalizeWords
@@ -220,7 +219,7 @@ class DeviceSettingsViewModel(
                 }
             }
             device.currentFirmware?.let { current ->
-                if (device.needsUpdate() && device.relation == DeviceRelation.OWNED
+                if (device.needsUpdate() && device.isOwned()
                     && usecase.shouldShowOTAPrompt(device)
                 ) {
                     add(

--- a/app/src/main/java/com/weatherxm/ui/home/HomeViewModel.kt
+++ b/app/src/main/java/com/weatherxm/ui/home/HomeViewModel.kt
@@ -5,7 +5,6 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.weatherxm.data.DataError
 import com.weatherxm.data.SingleLiveEvent
-import com.weatherxm.ui.common.DeviceRelation
 import com.weatherxm.ui.common.UIDevice
 import com.weatherxm.usecases.UserUseCase
 import com.weatherxm.util.Analytics
@@ -34,7 +33,7 @@ class HomeViewModel(
     fun hasDevices() = hasDevices
 
     fun getWalletMissing(devices: List<UIDevice>?) {
-        if (devices?.firstOrNull { it.relation == DeviceRelation.OWNED } == null) {
+        if (devices?.firstOrNull { it.isOwned() } == null) {
             hasDevices = false
             return
         }

--- a/app/src/main/java/com/weatherxm/ui/rewarddetails/RewardDetailsActivity.kt
+++ b/app/src/main/java/com/weatherxm/ui/rewarddetails/RewardDetailsActivity.kt
@@ -5,10 +5,8 @@ import android.view.MenuItem
 import com.google.firebase.analytics.FirebaseAnalytics
 import com.weatherxm.R
 import com.weatherxm.databinding.ActivityRewardDetailsBinding
-import com.weatherxm.ui.common.AnnotationCode
 import com.weatherxm.ui.common.Contracts.ARG_DEVICE
 import com.weatherxm.ui.common.Contracts.ARG_REWARDS_OBJECT
-import com.weatherxm.ui.common.DeviceRelation
 import com.weatherxm.ui.common.UIDevice
 import com.weatherxm.ui.common.UIRewardObject
 import com.weatherxm.ui.common.applyInsets
@@ -52,7 +50,7 @@ class RewardDetailsActivity : BaseActivity(), RewardProblemsListener {
         binding.contactSupportBtn.setOnClickListener {
             navigator.openSupportCenter(this, Analytics.ParamValue.REWARD_ANNOTATIONS.paramValue)
         }
-        binding.contactSupportBtn.setVisible(device.relation == DeviceRelation.OWNED)
+        binding.contactSupportBtn.setVisible(device.isOwned())
 
         binding.rewardsContentCard.updateUI(
             rewardsObject,
@@ -85,14 +83,14 @@ class RewardDetailsActivity : BaseActivity(), RewardProblemsListener {
             binding.problemsFoundDesc.setHtml(getString(R.string.problems_found_desc, lostRewards))
         }
 
-        val adapter = RewardProblemsAdapter(device, data.rewardScore, this)
+        val adapter = RewardProblemsAdapter(device, this)
         binding.problemsList.adapter = adapter
 
-        adapter.submitList(data.annotations)
+        adapter.submitList(data.annotationSummary)
     }
 
     private fun onMenuItem(menuItem: MenuItem): Boolean {
-        return if(menuItem.itemId == R.id.read_more) {
+        return if (menuItem.itemId == R.id.read_more) {
             analytics.trackEventSelectContent(
                 contentType = Analytics.ParamValue.REWARD_DETAILS_READ_MORE.paramValue
             )
@@ -103,36 +101,26 @@ class RewardDetailsActivity : BaseActivity(), RewardProblemsListener {
         }
     }
 
-    override fun onAddWallet(annotation: AnnotationCode?) {
-        trackUserActionOnErrors(annotation)
+    override fun onAddWallet(group: String?) {
+        trackUserActionOnErrors(group)
         navigator.showConnectWallet(this)
     }
 
-    override fun onUpdateFirmware(device: UIDevice, annotation: AnnotationCode?) {
-        trackUserActionOnErrors(annotation)
-        navigator.showDeviceHeliumOTA(this, device, false)
-    }
-
-    override fun onContactSupport(device: UIDevice, annotation: AnnotationCode?) {
-        trackUserActionOnErrors(annotation)
-        navigator.openSupportCenter(this, Analytics.ParamValue.REWARD_ANNOTATIONS.paramValue)
-    }
-
-    override fun onDocumentation(url: String, annotation: AnnotationCode?) {
-        trackUserActionOnErrors(annotation)
+    override fun onDocumentation(url: String, group: String?) {
+        trackUserActionOnErrors(group)
         navigator.openWebsite(this, url)
     }
 
-    override fun onEditLocation(device: UIDevice, annotation: AnnotationCode?) {
-        trackUserActionOnErrors(annotation)
+    override fun onEditLocation(device: UIDevice, group: String?) {
+        trackUserActionOnErrors(group)
         navigator.showEditLocation(null, this, device)
     }
 
-    private fun trackUserActionOnErrors(annotation: AnnotationCode?) {
+    private fun trackUserActionOnErrors(group: String?) {
         analytics.trackEventUserAction(
             actionName = Analytics.ParamValue.REWARD_DETAILS_ERROR.paramValue,
             contentType = null,
-            Pair(FirebaseAnalytics.Param.ITEM_ID, annotation?.name ?: String.empty())
+            Pair(FirebaseAnalytics.Param.ITEM_ID, group ?: String.empty())
         )
     }
 }

--- a/app/src/main/java/com/weatherxm/ui/rewarddetails/RewardProblemsAdapter.kt
+++ b/app/src/main/java/com/weatherxm/ui/rewarddetails/RewardProblemsAdapter.kt
@@ -7,7 +7,7 @@ import androidx.recyclerview.widget.ListAdapter
 import androidx.recyclerview.widget.RecyclerView
 import com.weatherxm.R
 import com.weatherxm.data.RewardsAnnotationGroup
-import com.weatherxm.data.Severity
+import com.weatherxm.data.SeverityLevel
 import com.weatherxm.databinding.ListItemRewardProblemBinding
 import com.weatherxm.ui.common.AnnotationGroupCode
 import com.weatherxm.ui.common.UIDevice
@@ -37,20 +37,20 @@ class RewardProblemsAdapter(
 
         fun bind(item: RewardsAnnotationGroup) {
             with(binding.annotationContainer) {
-                when (item.severity) {
-                    Severity.INFO -> {
+                when (item.severityLevel) {
+                    SeverityLevel.INFO -> {
                         setBackground(R.color.blueTint)
                         setStrokeColor(R.color.colorPrimaryVariant)
                         setIcon(R.drawable.ic_info)
                         setIconColor(R.color.colorPrimaryVariant)
                     }
-                    Severity.WARNING -> {
+                    SeverityLevel.WARNING -> {
                         setBackground(R.color.warningTint)
                         setStrokeColor(R.color.warning)
                         setIcon(R.drawable.ic_warn)
                         setIconColor(R.color.warning)
                     }
-                    Severity.ERROR -> {
+                    SeverityLevel.ERROR -> {
                         setBackground(R.color.errorTint)
                         setStrokeColor(R.color.error)
                         setIcon(R.drawable.ic_warn)
@@ -105,7 +105,7 @@ class RewardProblemsDiffCallback : DiffUtil.ItemCallback<RewardsAnnotationGroup>
         newItem: RewardsAnnotationGroup
     ): Boolean {
         return oldItem.title == newItem.title && oldItem.message == newItem.message &&
-            oldItem.severity == newItem.severity && oldItem.group == newItem.group &&
+            oldItem.severityLevel == newItem.severityLevel && oldItem.group == newItem.group &&
             oldItem.docUrl == newItem.docUrl
     }
 }

--- a/app/src/main/java/com/weatherxm/ui/rewarddetails/RewardProblemsAdapter.kt
+++ b/app/src/main/java/com/weatherxm/ui/rewarddetails/RewardProblemsAdapter.kt
@@ -6,24 +6,16 @@ import androidx.recyclerview.widget.DiffUtil
 import androidx.recyclerview.widget.ListAdapter
 import androidx.recyclerview.widget.RecyclerView
 import com.weatherxm.R
+import com.weatherxm.data.RewardsAnnotationGroup
+import com.weatherxm.data.Severity
 import com.weatherxm.databinding.ListItemRewardProblemBinding
-import com.weatherxm.ui.common.AnnotationCode
-import com.weatherxm.ui.common.DeviceRelation
+import com.weatherxm.ui.common.AnnotationGroupCode
 import com.weatherxm.ui.common.UIDevice
-import com.weatherxm.ui.common.UIRewardsAnnotation
-import com.weatherxm.util.Rewards.getMessage
-import com.weatherxm.util.Rewards.getRewardAnnotationBackgroundColor
-import com.weatherxm.util.Rewards.getRewardAnnotationColor
-import com.weatherxm.util.Rewards.getTitleResId
-import com.weatherxm.util.Rewards.pointToDocsHome
-import com.weatherxm.util.Rewards.pointToDocsTroubleshooting
-import com.weatherxm.util.Rewards.pointToPoLPreLaunch
 
 class RewardProblemsAdapter(
     private val device: UIDevice,
-    private val rewardScore: Int?,
     private val listener: RewardProblemsListener
-) : ListAdapter<UIRewardsAnnotation, RewardProblemsAdapter.RewardProblemsViewHolder>(
+) : ListAdapter<RewardsAnnotationGroup, RewardProblemsAdapter.RewardProblemsViewHolder>(
     RewardProblemsDiffCallback()
 ) {
 
@@ -43,110 +35,83 @@ class RewardProblemsAdapter(
     inner class RewardProblemsViewHolder(private val binding: ListItemRewardProblemBinding) :
         RecyclerView.ViewHolder(binding.root) {
 
-        fun bind(item: UIRewardsAnnotation) {
-            with(binding.error) {
-                setBackground(getRewardAnnotationBackgroundColor(rewardScore))
-                val annotationColor = getRewardAnnotationColor(rewardScore)
-                setIconColor(annotationColor)
-                setStrokeColor(annotationColor)
-                item.annotation?.getTitleResId()?.let {
-                    title(it)
-                }
-                htmlMessage(item.getMessage(context, device)) {
-                    if (item.annotation.pointToPoLPreLaunch()) {
-                        listener.onDocumentation(
-                            itemView.context.getString(R.string.docs_url_pol_algorithm),
-                            item.annotation
-                        )
+        fun bind(item: RewardsAnnotationGroup) {
+            with(binding.annotationContainer) {
+                when (item.severity) {
+                    Severity.INFO -> {
+                        setBackground(R.color.blueTint)
+                        setStrokeColor(R.color.colorPrimaryVariant)
+                        setIcon(R.drawable.ic_info)
+                        setIconColor(R.color.colorPrimaryVariant)
+                    }
+                    Severity.WARNING -> {
+                        setBackground(R.color.warningTint)
+                        setStrokeColor(R.color.warning)
+                        setIcon(R.drawable.ic_warn)
+                        setIconColor(R.color.warning)
+                    }
+                    Severity.ERROR -> {
+                        setBackground(R.color.errorTint)
+                        setStrokeColor(R.color.error)
+                        setIcon(R.drawable.ic_warn)
+                        setIconColor(R.color.error)
+                    }
+                    else -> {
+                        setBackground(R.color.blueTint)
+                        setStrokeColor(R.color.colorPrimaryVariant)
+                        setIcon(R.drawable.ic_info)
+                        setIconColor(R.color.colorPrimaryVariant)
                     }
                 }
-                if (device.relation == DeviceRelation.OWNED) {
-                    getAction(item.annotation)
-                }
+                title(item.title)
+                message(item.message)
+                setAction(item.toAnnotationGroupCode(), item.docUrl)
             }
         }
 
-        private fun getAction(annotation: AnnotationCode?) {
+        private fun setAction(code: AnnotationGroupCode?, docUrl: String?) {
             with(itemView.context) {
-                if (annotation == AnnotationCode.OBC && device.needsUpdate()) {
-                    binding.error.action(getString(R.string.action_update_firmware)) {
-                        listener.onUpdateFirmware(device, annotation)
+                if (code == AnnotationGroupCode.NO_WALLET && device.isOwned()) {
+                    binding.annotationContainer.action(getString(R.string.add_wallet_now)) {
+                        listener.onAddWallet(code.toString())
                     }
-                } else if (annotation.pointToDocsHome()) {
-                    binding.error.action(getString(R.string.read_more)) {
-                        listener.onDocumentation(getString(R.string.docs_url), annotation)
+                } else if (code == AnnotationGroupCode.LOCATION_NOT_VERIFIED && device.isOwned()) {
+                    binding.annotationContainer.action(getString(R.string.edit_location)) {
+                        listener.onEditLocation(device, code.toString())
                     }
-                } else if (annotation.pointToDocsTroubleshooting()) {
-                    binding.error.action(getString(R.string.read_more)) {
-                        listener.onDocumentation(
-                            getString(R.string.docs_url_troubleshooting),
-                            annotation
-                        )
-                    }
-                } else if (annotation == AnnotationCode.NO_WALLET) {
-                    binding.error.action(getString(R.string.add_wallet_now)) {
-                        listener.onAddWallet(annotation)
-                    }
-                } else if (annotation == AnnotationCode.CELL_CAPACITY_REACHED) {
-                    binding.error.action(getString(R.string.read_more)) {
-                        listener.onDocumentation(
-                            getString(R.string.docs_url_cell_capacity),
-                            annotation
-                        )
-                    }
-                } else if (annotation == AnnotationCode.POL_THRESHOLD_NOT_REACHED) {
-                    binding.error.action(getString(R.string.read_more)) {
-                        listener.onDocumentation(
-                            getString(R.string.docs_url_pol_algorithm),
-                            annotation
-                        )
-                    }
-                } else if (annotation == AnnotationCode.QOD_THRESHOLD_NOT_REACHED) {
-                    binding.error.action(getString(R.string.read_more)) {
-                        listener.onDocumentation(
-                            getString(R.string.docs_url_qod_algorithm),
-                            annotation
-                        )
-                    }
-                } else if (annotation == AnnotationCode.LOCATION_NOT_VERIFIED) {
-                    binding.error.action(getString(R.string.edit_location)) {
-                        listener.onEditLocation(device, annotation)
-                    }
-                } else if (annotation == AnnotationCode.UNKNOWN) {
-                    binding.error.action(getString(R.string.contact_support_title)) {
-                        listener.onContactSupport(device, annotation)
+                } else if (!docUrl.isNullOrEmpty()) {
+                    binding.annotationContainer.action(getString(R.string.read_more)) {
+                        listener.onDocumentation(docUrl, code.toString())
                     }
                 } else {
-                    // Do nothing, no action should be set.
+                    // Do nothing
                 }
             }
         }
     }
 }
 
-class RewardProblemsDiffCallback : DiffUtil.ItemCallback<UIRewardsAnnotation>() {
+class RewardProblemsDiffCallback : DiffUtil.ItemCallback<RewardsAnnotationGroup>() {
 
     override fun areItemsTheSame(
-        oldItem: UIRewardsAnnotation,
-        newItem: UIRewardsAnnotation
+        oldItem: RewardsAnnotationGroup,
+        newItem: RewardsAnnotationGroup
     ): Boolean {
         return oldItem == newItem
     }
 
     override fun areContentsTheSame(
-        oldItem: UIRewardsAnnotation,
-        newItem: UIRewardsAnnotation
+        oldItem: RewardsAnnotationGroup,
+        newItem: RewardsAnnotationGroup
     ): Boolean {
-        return oldItem.annotation == newItem.annotation &&
-            oldItem.ratioOfAnnotation == newItem.ratioOfAnnotation &&
-            oldItem.qodParametersAffected.size == newItem.qodParametersAffected.size
+        return oldItem.title == newItem.title && oldItem.message == newItem.message &&
+            oldItem.severity == newItem.severity && oldItem.group == newItem.group &&
+            oldItem.docUrl == newItem.docUrl
     }
 }
 
 interface RewardProblemsListener {
-    fun onAddWallet(annotation: AnnotationCode?)
-    fun onUpdateFirmware(device: UIDevice, annotation: AnnotationCode?)
-    fun onContactSupport(device: UIDevice, annotation: AnnotationCode?)
-    fun onDocumentation(url: String, annotation: AnnotationCode?)
-    fun onEditLocation(device: UIDevice, annotation: AnnotationCode?)
+    fun onAddWallet(group: String?)
+    fun onDocumentation(url: String, group: String?)
+    fun onEditLocation(device: UIDevice, group: String?)
 }

--- a/app/src/main/java/com/weatherxm/usecases/DeviceDetailsUseCaseImpl.kt
+++ b/app/src/main/java/com/weatherxm/usecases/DeviceDetailsUseCaseImpl.kt
@@ -37,7 +37,7 @@ class DeviceDetailsUseCaseImpl(
 ) : DeviceDetailsUseCase {
 
     override suspend fun getUserDevice(device: UIDevice): Either<Failure, UIDevice> {
-        return if (device.relation == DeviceRelation.UNFOLLOWED) {
+        return if (device.isUnfollowed()) {
             explorerRepository.getCellDevice(device.cellIndex, device.id).map {
                 it.toUIDevice().apply {
                     this.relation = DeviceRelation.UNFOLLOWED
@@ -50,9 +50,8 @@ class DeviceDetailsUseCaseImpl(
             deviceRepository.getUserDevice(device.id).map {
                 it.toUIDevice().apply {
                     val shouldShowOTAPrompt = deviceOTARepository.shouldShowOTAPrompt(
-                        id,
-                        assignedFirmware
-                    ) && relation == DeviceRelation.OWNED
+                        id, assignedFirmware
+                    ) && isOwned()
                     val alerts = mutableListOf<DeviceAlert>()
                     if (shouldShowOTAPrompt && profile == Helium && needsUpdate()) {
                         alerts.add(DeviceAlert.NEEDS_UPDATE)

--- a/app/src/main/java/com/weatherxm/usecases/DeviceListUseCaseImpl.kt
+++ b/app/src/main/java/com/weatherxm/usecases/DeviceListUseCaseImpl.kt
@@ -7,7 +7,6 @@ import com.weatherxm.data.repository.DeviceOTARepository
 import com.weatherxm.data.repository.DeviceRepository
 import com.weatherxm.data.repository.UserPreferencesRepository
 import com.weatherxm.ui.common.DeviceAlert
-import com.weatherxm.ui.common.DeviceRelation
 import com.weatherxm.ui.common.DevicesFilterType
 import com.weatherxm.ui.common.DevicesGroupBy
 import com.weatherxm.ui.common.DevicesSortFilterOptions
@@ -24,9 +23,8 @@ class DeviceListUseCaseImpl(
             val devices = response.map {
                 val device = it.toUIDevice()
                 val shouldShowOTAPrompt = deviceOTARepository.shouldShowOTAPrompt(
-                    device.id,
-                    device.assignedFirmware
-                ) && device.relation == DeviceRelation.OWNED
+                    device.id, device.assignedFirmware
+                ) && device.isOwned()
                 val alerts = mutableListOf<DeviceAlert>()
                 if (device.isActive == false) {
                     alerts.add(DeviceAlert.OFFLINE)

--- a/app/src/main/java/com/weatherxm/util/Rewards.kt
+++ b/app/src/main/java/com/weatherxm/util/Rewards.kt
@@ -104,7 +104,7 @@ object Rewards {
                 context.getString(R.string.annotation_obc_desc, getAffectedParameters())
             }
             AnnotationCode.SPIKE_INST -> {
-                if (device.relation == DeviceRelation.OWNED) {
+                if (device.isOwned()) {
                     context.getString(R.string.annotation_spikes_desc, getAffectedParameters())
                 } else {
                     context.getString(
@@ -113,21 +113,21 @@ object Rewards {
                 }
             }
             AnnotationCode.NO_DATA -> {
-                if (device.relation == DeviceRelation.OWNED) {
+                if (device.isOwned()) {
                     context.getString(R.string.annotation_no_data_desc)
                 } else {
                     context.getString(R.string.annotation_no_data_public_desc)
                 }
             }
             AnnotationCode.NO_MEDIAN -> {
-                if (device.relation == DeviceRelation.OWNED) {
+                if (device.isOwned()) {
                     context.getString(R.string.annotation_no_median_desc)
                 } else {
                     context.getString(R.string.annotation_no_median_public_desc)
                 }
             }
             AnnotationCode.SHORT_CONST -> {
-                if (device.relation == DeviceRelation.OWNED) {
+                if (device.isOwned()) {
                     context.getString(R.string.annotation_short_const_desc, getAffectedParameters())
                 } else {
                     context.getString(
@@ -136,7 +136,7 @@ object Rewards {
                 }
             }
             AnnotationCode.LONG_CONST -> {
-                if (device.relation == DeviceRelation.OWNED) {
+                if (device.isOwned()) {
                     context.getString(R.string.annotation_long_const_desc, getAffectedParameters())
                 } else {
                     context.getString(
@@ -148,7 +148,7 @@ object Rewards {
                 context.getString(R.string.annotation_frozen_sensor_desc)
             }
             AnnotationCode.ANOMALOUS_INCREASE -> {
-                if (device.relation == DeviceRelation.OWNED) {
+                if (device.isOwned()) {
                     context.getString(
                         R.string.annotation_anom_increase_desc, getAffectedParameters()
                     )
@@ -171,14 +171,14 @@ object Rewards {
                 }
             }
             AnnotationCode.NO_WALLET -> {
-                if (device.relation == DeviceRelation.OWNED) {
+                if (device.isOwned()) {
                     context.getString(R.string.annotation_no_wallet_desc)
                 } else {
                     context.getString(R.string.annotation_no_wallet_public_desc)
                 }
             }
             AnnotationCode.CELL_CAPACITY_REACHED -> {
-                if (device.relation == DeviceRelation.OWNED) {
+                if (device.isOwned()) {
                     context.getString(R.string.annotation_cell_capacity_reached_desc)
                 } else {
                     context.getString(R.string.annotation_cell_capacity_reached_public_desc)
@@ -186,21 +186,21 @@ object Rewards {
             }
             AnnotationCode.RELOCATED -> context.getString(R.string.annotation_relocated_desc)
             AnnotationCode.POL_THRESHOLD_NOT_REACHED -> {
-                if (device.relation == DeviceRelation.OWNED) {
+                if (device.isOwned()) {
                     context.getString(R.string.annotation_pol_threshold_desc)
                 } else {
                     context.getString(R.string.annotation_pol_threshold_public_desc)
                 }
             }
             AnnotationCode.QOD_THRESHOLD_NOT_REACHED -> {
-                if (device.relation == DeviceRelation.OWNED) {
+                if (device.isOwned()) {
                     context.getString(R.string.annotation_qod_threshold_desc)
                 } else {
                     context.getString(R.string.annotation_qod_threshold_public_desc)
                 }
             }
             AnnotationCode.UNIDENTIFIED_ANOMALOUS_CHANGE -> {
-                if (device.relation == DeviceRelation.OWNED) {
+                if (device.isOwned()) {
                     context.getString(
                         R.string.annotation_unidentified_change_desc, getAffectedParameters()
                     )
@@ -211,7 +211,7 @@ object Rewards {
                 }
             }
             AnnotationCode.UNIDENTIFIED_SPIKE -> {
-                if (device.relation == DeviceRelation.OWNED) {
+                if (device.isOwned()) {
                     context.getString(
                         R.string.annotation_unidentified_spike_desc, getAffectedParameters()
                     )
@@ -222,7 +222,7 @@ object Rewards {
                 }
             }
             AnnotationCode.UNKNOWN -> {
-                if (device.relation == DeviceRelation.OWNED) {
+                if (device.isOwned()) {
                     context.getString(R.string.annotation_unknown_desc)
                 } else {
                     context.getString(R.string.annotation_unknown_public_desc)

--- a/app/src/main/res/layout/list_item_reward_problem.xml
+++ b/app/src/main/res/layout/list_item_reward_problem.xml
@@ -8,15 +8,15 @@
     android:orientation="vertical">
 
     <com.weatherxm.ui.components.MessageCardView
-        android:id="@+id/error"
+        android:id="@+id/annotationContainer"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        app:message_background_tint="@color/errorTint"
         app:message_card_radius="@dimen/radius_medium"
-        app:message_icon="@drawable/ic_warn"
-        app:message_icon_color="@color/error"
         app:message_includes_close_button="false"
-        app:message_stroke_color="@color/error"
+        tools:message_background_tint="@color/errorTint"
+        tools:message_icon="@drawable/ic_warn"
+        tools:message_icon_color="@color/error"
         tools:message_message="Your station didn’t send any data for the 50% of the previous day. Please check that it is properly connected to the internet and the batteries are OK."
+        tools:message_stroke_color="@color/error"
         tools:message_title="Connectivity" />
 </LinearLayout>


### PR DESCRIPTION
## **Why?**
Integrate new `annotation_summary` property.

### **How?**
- Added `annotationSummary` in the API Models and `RewardsAnnotationGroup` which is the new structure we will use.
- Sort the new summary annotations based on severity (error -> warning -> info) before populating the UI
- Minor enhancements in `MessageCardView` in order to implement the new annotations
- Changes in `RewardProblemsAdapter` to use the new `RewardsAnnotatonGroup` as input data

### **Testing**
Either run `localMockDebug` flavor or the dev flavor (which communicates with the dev API) and ensure everything is OK rewards-related.

### Others:
Replace the following:
1. `device.relation == DeviceRelation.OWNED`
2. `device.relation == DeviceRelation.FOLLOWED`
3. `device.relation == DeviceRelation.UNFOLLOWED`

With the respective extension functions:
1. `device.isOwned()`
2. `device.isFollowed()`
3. `device.isUnfollowed()`