### PR TITLE
Fix API url for the specific environment on QA Release workflow

### DIFF
--- a/.github/workflows/on-qa-firebase-distribution.yml
+++ b/.github/workflows/on-qa-firebase-distribution.yml
@@ -34,9 +34,9 @@ env:
     GLOBAL_GRADLE_CACHE: gradle-cache-${GITHUB_REPOSITORY}
 jobs:
     qa_dist:
-        environment: ${{ github.event.inputs.buildType }}
+        environment: ${{ github.event.inputs.environment }}
         env:
-            # API URL for Prod Flavor
+            # API URL for the environment selected
             ORG_GRADLE_PROJECT_API_URL: ${{ secrets.API_URL }}
         runs-on: ubuntu-latest
         steps:


### PR DESCRIPTION
## **Why?**
The initialization of API URL based on the environment was wrong.

### **How?**
Replace:
        `environment: ${{ github.event.inputs.buildType }}`
with:
        `environment: ${{ github.event.inputs.environment }}`