### PR TITLE
FE-665 Get boost rewards data models

### DIFF
--- a/app/src/local/assets/mock_files/get_device_reward_boost.json
+++ b/app/src/local/assets/mock_files/get_device_reward_boost.json
@@ -1,0 +1,19 @@
+{
+    "code": "beta_rewards",
+    "metadata": {
+        "title": "Beta Reward",
+        "description": "Rewarded for participating in our beta reward program.",
+        "img_url": "string",
+        "doc_url": "string",
+        "about": "According to the Token Allocation table 3,000,000 $WXM are reserved to reward stations that participated to the network before the Token Launch Day (\"Beta period\")."
+    },
+    "details": {
+        "station_hours": 17500,
+        "max_daily_reward": 1.24,
+        "max_total_reward": 10.24,
+        "boost_start_date": "2024-03-05T09:29:54.450Z",
+        "boost_stop_date": "2024-03-05T09:29:54.450Z",
+        "participation_start_date": "2024-03-05T09:29:54.450Z",
+        "participation_stop_date": "2024-03-05T09:29:54.450Z"
+    }
+}

--- a/app/src/main/java/com/weatherxm/data/ApiModels.kt
+++ b/app/src/main/java/com/weatherxm/data/ApiModels.kt
@@ -572,6 +572,48 @@ data class BoostReward(
 @Keep
 @JsonClass(generateAdapter = true)
 @Parcelize
+data class BoostRewardResponse(
+    val code: String?,
+    val metadata: BoostRewardMetadata?,
+    val details: BoostRewardDetails?,
+) : Parcelable
+
+@Keep
+@JsonClass(generateAdapter = true)
+@Parcelize
+data class BoostRewardMetadata(
+    val title: String?,
+    val description: String?,
+    @Json(name = "img_url")
+    val imgUrl: String?,
+    @Json(name = "doc_url")
+    val docUrl: String?,
+    val about: String?,
+) : Parcelable
+
+@Keep
+@JsonClass(generateAdapter = true)
+@Parcelize
+data class BoostRewardDetails(
+    @Json(name = "station_hours")
+    val stationHours: Int?,
+    @Json(name = "max_daily_reward")
+    val maxDailyReward: Float?,
+    @Json(name = "max_total_reward")
+    val maxTotalReward: Float?,
+    @Json(name = "boost_start_date")
+    val boostStartDate: ZonedDateTime?,
+    @Json(name = "boost_stop_date")
+    val boostStopDate: ZonedDateTime?,
+    @Json(name = "participation_start_date")
+    val participationStartDate: ZonedDateTime?,
+    @Json(name = "participation_stop_date")
+    val participationStopDate: ZonedDateTime?,
+) : Parcelable
+
+@Keep
+@JsonClass(generateAdapter = true)
+@Parcelize
 data class QoDErrorAffects(
     val parameter: String?,
     val ratio: Int?,

--- a/app/src/main/java/com/weatherxm/data/datasource/RewardsDataSource.kt
+++ b/app/src/main/java/com/weatherxm/data/datasource/RewardsDataSource.kt
@@ -1,6 +1,7 @@
 package com.weatherxm.data.datasource
 
 import arrow.core.Either
+import com.weatherxm.data.BoostRewardResponse
 import com.weatherxm.data.Failure
 import com.weatherxm.data.RewardDetails
 import com.weatherxm.data.Rewards
@@ -22,6 +23,11 @@ interface RewardsDataSource {
 
     suspend fun getRewards(deviceId: String): Either<Failure, Rewards>
     suspend fun getRewardDetails(deviceId: String, date: String): Either<Failure, RewardDetails>
+    suspend fun getBoostReward(
+        deviceId: String,
+        boostCode: String
+    ): Either<Failure, BoostRewardResponse>
+
     suspend fun getWalletRewards(walletAddress: String): Either<Failure, WalletRewards>
 }
 
@@ -53,6 +59,13 @@ class RewardsDataSourceImpl(private val apiService: ApiService) : RewardsDataSou
         date: String
     ): Either<Failure, RewardDetails> {
         return apiService.getRewardDetails(deviceId, date).map()
+    }
+
+    override suspend fun getBoostReward(
+        deviceId: String,
+        boostCode: String
+    ): Either<Failure, BoostRewardResponse> {
+        return apiService.getRewardBoost(deviceId, boostCode).map()
     }
 
     override suspend fun getWalletRewards(walletAddress: String): Either<Failure, WalletRewards> {

--- a/app/src/main/java/com/weatherxm/data/network/ApiService.kt
+++ b/app/src/main/java/com/weatherxm/data/network/ApiService.kt
@@ -4,6 +4,7 @@ import co.infinum.retromock.meta.Mock
 import co.infinum.retromock.meta.MockBehavior
 import co.infinum.retromock.meta.MockResponse
 import com.haroldadmin.cnradapter.NetworkResponse
+import com.weatherxm.data.BoostRewardResponse
 import com.weatherxm.data.Device
 import com.weatherxm.data.DeviceInfo
 import com.weatherxm.data.NetworkSearchResults
@@ -200,6 +201,15 @@ interface ApiService {
         @Path("deviceId") deviceId: String,
         @Query("date") date: String,
     ): NetworkResponse<RewardDetails, ErrorResponse>
+
+    @Mock
+    @MockResponse(body = "mock_files/get_device_reward_boost.json")
+    @GET("/api/v1/devices/{deviceId}/rewards/boosts/{boostCode}")
+    @Headers(NO_AUTH_HEADER)
+    suspend fun getRewardBoost(
+        @Path("deviceId") deviceId: String,
+        @Path("boostCode") boostCode: String
+    ): NetworkResponse<BoostRewardResponse, ErrorResponse>
 
     @GET("/api/v1/me/devices/{deviceId}/firmware")
     @Streaming

--- a/app/src/main/java/com/weatherxm/data/repository/RewardsRepository.kt
+++ b/app/src/main/java/com/weatherxm/data/repository/RewardsRepository.kt
@@ -1,6 +1,7 @@
 package com.weatherxm.data.repository
 
 import arrow.core.Either
+import com.weatherxm.data.BoostRewardResponse
 import com.weatherxm.data.Failure
 import com.weatherxm.data.RewardDetails
 import com.weatherxm.data.Rewards
@@ -25,6 +26,11 @@ interface RewardsRepository {
         deviceId: String,
         date: ZonedDateTime
     ): Either<Failure, RewardDetails>
+
+    suspend fun getBoostReward(
+        deviceId: String,
+        boostCode: String
+    ): Either<Failure, BoostRewardResponse>
 
     suspend fun getWalletRewards(walletAddress: String): Either<Failure, WalletRewards>
 }
@@ -56,6 +62,13 @@ class RewardsRepositoryImpl(private val dataSource: RewardsDataSource) : Rewards
         date: ZonedDateTime
     ): Either<Failure, RewardDetails> {
         return dataSource.getRewardDetails(deviceId, date.toISODate())
+    }
+
+    override suspend fun getBoostReward(
+        deviceId: String,
+        boostCode: String
+    ): Either<Failure, BoostRewardResponse> {
+        return dataSource.getBoostReward(deviceId, boostCode)
     }
 
     override suspend fun getWalletRewards(walletAddress: String): Either<Failure, WalletRewards> {


### PR DESCRIPTION
## **Why?**
The new API models needed for the new reward boost response.

### **How?**
Created `BoostRewardResponse`, `BoostRewardMetadata` and `BoostRewardDetails` data classes and respective getter functions.

### **Testing**
Ensure that the models match the spec's one.
