### PR TITLE
FE-577 When current weather data is null, show the respective component

### DIFF
--- a/app/src/main/java/com/weatherxm/ui/components/WeatherCardView.kt
+++ b/app/src/main/java/com/weatherxm/ui/components/WeatherCardView.kt
@@ -12,6 +12,7 @@ import com.weatherxm.data.services.CacheService.Companion.KEY_TEMPERATURE
 import com.weatherxm.data.services.CacheService.Companion.KEY_WIND
 import com.weatherxm.databinding.ViewWeatherCardBinding
 import com.weatherxm.ui.common.empty
+import com.weatherxm.ui.common.setVisible
 import com.weatherxm.util.DateTimeHelper.getFormattedDate
 import com.weatherxm.util.DateTimeHelper.getFormattedTime
 import com.weatherxm.util.Weather
@@ -113,11 +114,18 @@ class WeatherCardView : LinearLayout {
     }
 
     fun setData(data: HourlyWeather?) {
-        weatherData = data
-        updateCurrentWeatherUI()
-        val lastUpdatedDate = data?.timestamp?.getFormattedDate(includeYear = true)
-        val lastUpdatedTime = data?.timestamp?.getFormattedTime(context)
-        binding.lastUpdatedOn.text =
-            context.getString(R.string.last_updated, "$lastUpdatedDate, $lastUpdatedTime")
+        if (data == null || data.isEmpty()) {
+            binding.weatherDataLayout.setVisible(false)
+            binding.secondaryCard.setVisible(false)
+            binding.noDataLayout.setVisible(true)
+        } else {
+            weatherData = data
+            updateCurrentWeatherUI()
+            val lastUpdatedDate = data?.timestamp?.getFormattedDate(includeYear = true)
+            val lastUpdatedTime = data?.timestamp?.getFormattedTime(context)
+            binding.lastUpdatedOn.text =
+                context.getString(R.string.last_updated, "$lastUpdatedDate, $lastUpdatedTime")
+        }
+
     }
 }

--- a/app/src/main/java/com/weatherxm/ui/devicedetails/current/CurrentFragment.kt
+++ b/app/src/main/java/com/weatherxm/ui/devicedetails/current/CurrentFragment.kt
@@ -117,6 +117,9 @@ class CurrentFragment : BaseFragment() {
     private fun onDeviceUpdated(device: UIDevice) {
         binding.progress.visibility = View.INVISIBLE
         setAlerts(device)
+        if (device.currentWeather == null || device.currentWeather.isEmpty()) {
+            binding.historicalCharts.setVisible(false)
+        }
         binding.currentWeatherCard.setData(device.currentWeather)
         binding.followCard.setVisible(device.isUnfollowed())
         binding.historicalCharts.isEnabled = !device.isUnfollowed()

--- a/app/src/main/res/layout/fragment_device_details_current.xml
+++ b/app/src/main/res/layout/fragment_device_details_current.xml
@@ -61,8 +61,7 @@
 
                         <androidx.constraintlayout.widget.ConstraintLayout
                             android:layout_width="match_parent"
-                            android:layout_height="wrap_content"
-                            android:paddingBottom="@dimen/padding_normal">
+                            android:layout_height="wrap_content">
 
                             <com.weatherxm.ui.components.WeatherCardView
                                 android:id="@+id/currentWeatherCard"
@@ -76,8 +75,10 @@
                                 android:layout_width="match_parent"
                                 android:layout_height="wrap_content"
                                 android:layout_marginHorizontal="@dimen/margin_normal"
+                                android:layout_marginBottom="@dimen/margin_normal"
                                 android:backgroundTint="@color/subtle_button_background_color"
                                 android:text="@string/view_historical_data"
+                                app:layout_constraintBottom_toBottomOf="parent"
                                 android:textColor="@color/subtle_button_text_stroke_color"
                                 app:layout_constraintTop_toBottomOf="@id/currentWeatherCard"
                                 app:strokeColor="@color/subtle_button_text_stroke_color" />

--- a/app/src/main/res/layout/list_item_device.xml
+++ b/app/src/main/res/layout/list_item_device.xml
@@ -128,7 +128,7 @@
                         android:id="@+id/noDataMessage"
                         android:layout_width="0dp"
                         android:layout_height="wrap_content"
-                        android:layout_marginTop="@dimen/margin_normal"
+                        android:layout_marginTop="@dimen/margin_small"
                         android:text="@string/no_data_message"
                         android:textAppearance="@style/TextAppearance.WeatherXM.Default.BodyMedium"
                         app:layout_constraintEnd_toEndOf="parent"

--- a/app/src/main/res/layout/view_weather_card.xml
+++ b/app/src/main/res/layout/view_weather_card.xml
@@ -25,6 +25,46 @@
                 app:cardElevation="1px"
                 app:layout_constraintTop_toTopOf="parent">
 
+                <androidx.constraintlayout.widget.ConstraintLayout
+                    android:id="@+id/noDataLayout"
+                    android:layout_width="match_parent"
+                    android:layout_height="match_parent"
+                    android:visibility="gone">
+
+                    <ImageView
+                        android:id="@+id/noDataIcon"
+                        android:layout_width="38dp"
+                        android:layout_height="38dp"
+                        android:src="@drawable/ic_no_data"
+                        app:layout_constraintBottom_toBottomOf="parent"
+                        app:layout_constraintStart_toStartOf="parent"
+                        app:layout_constraintTop_toTopOf="parent"
+                        app:tint="@color/colorOnSurface"
+                        tools:ignore="ContentDescription" />
+
+                    <com.google.android.material.textview.MaterialTextView
+                        android:id="@+id/noDataTitle"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:layout_marginStart="@dimen/margin_large"
+                        android:text="@string/no_data"
+                        android:textAppearance="@style/TextAppearance.WeatherXM.EmptyView.Title"
+                        app:layout_constraintStart_toEndOf="@id/noDataIcon"
+                        app:layout_constraintTop_toTopOf="parent" />
+
+                    <com.google.android.material.textview.MaterialTextView
+                        android:id="@+id/noDataMessage"
+                        android:layout_width="0dp"
+                        android:layout_height="wrap_content"
+                        android:layout_marginTop="@dimen/margin_small"
+                        android:text="@string/no_data_message"
+                        android:textAppearance="@style/TextAppearance.WeatherXM.Default.BodyMedium"
+                        app:layout_constraintEnd_toEndOf="parent"
+                        app:layout_constraintStart_toStartOf="@id/noDataTitle"
+                        app:layout_constraintTop_toBottomOf="@id/noDataTitle" />
+
+                </androidx.constraintlayout.widget.ConstraintLayout>
+
                 <LinearLayout
                     android:id="@+id/weatherDataLayout"
                     android:layout_width="match_parent"


### PR DESCRIPTION
## **Why?**
"No Data" view in device details when weather data is empty or null.

### **How?**
1. Added the respective component in .XML
2. Make the respective checks in `CurrentFragment` and `WeatherCardView` in order to handle visibility changes in each case.

### **Testing**
Try local mock flavor and delete the current weather object in `get_user_device.json` or find such an empty station in our network and test against it.
