### PR TITLE
FE-706 Feature/cells deep link

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -136,6 +136,11 @@
                     android:host="${explorer_host}"
                     android:pathPattern="/stations/.*"
                     android:scheme="https" />
+
+                <data
+                    android:host="${explorer_host}"
+                    android:pathPattern="/cells/.*"
+                    android:scheme="https" />
             </intent-filter>
         </activity>
         <activity

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -132,15 +132,10 @@
                 <category android:name="android.intent.category.DEFAULT" />
                 <category android:name="android.intent.category.BROWSABLE" />
 
-                <data
-                    android:host="${explorer_host}"
-                    android:pathPattern="/stations/.*"
-                    android:scheme="https" />
-
-                <data
-                    android:host="${explorer_host}"
-                    android:pathPattern="/cells/.*"
-                    android:scheme="https" />
+                <data android:scheme="https"/>
+                <data android:host="${explorer_host}"/>
+                <data android:pathPattern="/stations/.*"/>
+                <data android:pathPattern="/cells/.*"/>
             </intent-filter>
         </activity>
         <activity

--- a/app/src/main/java/com/weatherxm/data/Failure.kt
+++ b/app/src/main/java/com/weatherxm/data/Failure.kt
@@ -195,6 +195,7 @@ sealed class DataError : Failure() {
     object CacheMissError : DataError()
     object CacheExpiredError : DataError()
     object NoWalletAddressError : DataError()
+    object CellNotFound : DataError()
 }
 
 @Keep

--- a/app/src/main/java/com/weatherxm/ui/Navigator.kt
+++ b/app/src/main/java/com/weatherxm/ui/Navigator.kt
@@ -150,12 +150,13 @@ class Navigator(private val analytics: Analytics) {
         }
     }
 
-    fun showCellInfo(context: Context?, cell: UICell) {
+    fun showCellInfo(context: Context?, cell: UICell, openExplorerOnBack: Boolean = false) {
         context?.let {
             it.startActivity(
                 Intent(it, CellInfoActivity::class.java)
                     .addFlags(Intent.FLAG_ACTIVITY_SINGLE_TOP or Intent.FLAG_ACTIVITY_CLEAR_TOP)
                     .putExtra(ARG_EXPLORER_CELL, cell)
+                    .putExtra(ARG_OPEN_EXPLORER_ON_BACK, openExplorerOnBack)
             )
         }
     }

--- a/app/src/main/java/com/weatherxm/ui/cellinfo/CellInfoActivity.kt
+++ b/app/src/main/java/com/weatherxm/ui/cellinfo/CellInfoActivity.kt
@@ -1,6 +1,7 @@
 package com.weatherxm.ui.cellinfo
 
 import android.os.Bundle
+import androidx.activity.addCallback
 import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import com.google.firebase.analytics.FirebaseAnalytics
 import com.weatherxm.R
@@ -8,6 +9,7 @@ import com.weatherxm.data.Resource
 import com.weatherxm.data.Status
 import com.weatherxm.databinding.ActivityCellInfoBinding
 import com.weatherxm.ui.common.Contracts
+import com.weatherxm.ui.common.Contracts.ARG_OPEN_EXPLORER_ON_BACK
 import com.weatherxm.ui.common.UIDevice
 import com.weatherxm.ui.common.applyInsets
 import com.weatherxm.ui.common.parcelable
@@ -50,6 +52,20 @@ class CellInfoActivity : BaseActivity(), CellDeviceListener {
                 }
             }
         }
+        val openExplorerOnBack = intent.getBooleanExtra(ARG_OPEN_EXPLORER_ON_BACK, false)
+        onBackPressedDispatcher.addCallback {
+            if (!openExplorerOnBack || model.isLoggedIn() == null) {
+                finish()
+                return@addCallback
+            }
+            if (model.isLoggedIn() == true) {
+                navigator.showHome(this@CellInfoActivity, model.cell.center)
+            } else {
+                navigator.showExplorer(this@CellInfoActivity, model.cell.center)
+            }
+            finish()
+        }
+
         binding.capacityChip.setOnCloseIconClickListener {
             analytics.trackEventSelectContent(
                 Analytics.ParamValue.LEARN_MORE.paramValue,

--- a/app/src/main/java/com/weatherxm/ui/components/BaseMapFragment.kt
+++ b/app/src/main/java/com/weatherxm/ui/components/BaseMapFragment.kt
@@ -29,7 +29,8 @@ open class BaseMapFragment : BaseFragment() {
         const val CURRENT_LON = "current_lon"
         const val CURRENT_ZOOM = "current_zoom"
         const val DEFAULT_ZOOM_LEVEL: Double = 1.0
-        const val USER_LOCATION_ZOOM_LEVEL: Double = 15.0
+        const val USER_LOCATION_ZOOM_LEVEL: Double = 11.0
+        const val USER_SET_LOCATION_ZOOM_LEVEL: Double = 15.0
         val REVERSE_GEOCODING_DELAY = TimeUnit.SECONDS.toMillis(1)
     }
 

--- a/app/src/main/java/com/weatherxm/ui/components/EditLocationMapFragment.kt
+++ b/app/src/main/java/com/weatherxm/ui/components/EditLocationMapFragment.kt
@@ -97,7 +97,7 @@ class EditLocationMapFragment : BaseMapFragment() {
     private fun recenter(map: MapboxMap?, location: Location) {
         map?.setCamera(
             CameraOptions.Builder()
-                .zoom(USER_LOCATION_ZOOM_LEVEL)
+                .zoom(USER_SET_LOCATION_ZOOM_LEVEL)
                 .center(Point.fromLngLat(location.lon, location.lat))
                 .build()
         )

--- a/app/src/main/java/com/weatherxm/ui/explorer/ExplorerMapFragment.kt
+++ b/app/src/main/java/com/weatherxm/ui/explorer/ExplorerMapFragment.kt
@@ -33,7 +33,6 @@ import com.weatherxm.ui.common.setVisible
 import com.weatherxm.ui.common.toast
 import com.weatherxm.ui.components.BaseMapFragment
 import com.weatherxm.ui.explorer.ExplorerViewModel.Companion.HEATMAP_SOURCE_ID
-import com.weatherxm.ui.explorer.ExplorerViewModel.Companion.USER_LOCATION_DEFAULT_ZOOM_LEVEL
 import com.weatherxm.ui.explorer.search.NetworkSearchResultsListAdapter
 import com.weatherxm.ui.explorer.search.NetworkSearchViewModel
 import com.weatherxm.ui.networkstats.NetworkStatsActivity
@@ -146,14 +145,7 @@ class ExplorerMapFragment : BaseMapFragment() {
         // Fly the camera to the center of the hex selected
         model.onNavigateToLocation().observe(this) { location ->
             location?.let {
-                cameraFly(Point.fromLngLat(it.lon, it.lat))
-            }
-        }
-
-        // Fly the camera to the starting location on a low zoom level
-        model.onStartingLocation().observe(this) { location ->
-            location?.let {
-                cameraFly(Point.fromLngLat(it.lon, it.lat), DEFAULT_ZOOM_LEVEL)
+                cameraFly(Point.fromLngLat(it.location.lon, it.location.lat), it.zoomLevel)
             }
         }
 
@@ -175,7 +167,7 @@ class ExplorerMapFragment : BaseMapFragment() {
         }
     }
 
-    private fun cameraFly(center: Point, zoomLevel: Double = USER_LOCATION_DEFAULT_ZOOM_LEVEL) {
+    private fun cameraFly(center: Point, zoomLevel: Double = USER_LOCATION_ZOOM_LEVEL) {
         binding.mapView.getMapboxMap().flyTo(
             CameraOptions.Builder().zoom(zoomLevel).center(center).build(),
             MapAnimationOptions.Builder().duration(CAMERA_ANIMATION_DURATION).build()

--- a/app/src/main/java/com/weatherxm/ui/explorer/ExplorerUIModels.kt
+++ b/app/src/main/java/com/weatherxm/ui/explorer/ExplorerUIModels.kt
@@ -30,6 +30,14 @@ data class UICell(
 
 @Keep
 @JsonClass(generateAdapter = true)
+@Parcelize
+data class NavigationLocation(
+    var zoomLevel: Double,
+    var location: Location
+) : Parcelable
+
+@Keep
+@JsonClass(generateAdapter = true)
 data class ExplorerCamera(
     var zoom: Double,
     var center: Point

--- a/app/src/main/java/com/weatherxm/ui/urlrouteractivity/UrlRouterActivity.kt
+++ b/app/src/main/java/com/weatherxm/ui/urlrouteractivity/UrlRouterActivity.kt
@@ -38,6 +38,12 @@ class UrlRouterActivity : BaseActivity() {
             finish()
         }
 
+        model.onCell().observe(this) {
+            binding.logo.setVisible(false)
+            navigator.showCellInfo(this, it, openExplorerOnBack = true)
+            finish()
+        }
+
         model.onRemoteMessage().observe(this) {
             binding.logo.setVisible(false)
             it.url?.let { url ->

--- a/app/src/main/java/com/weatherxm/ui/urlrouteractivity/UrlRouterViewModel.kt
+++ b/app/src/main/java/com/weatherxm/ui/urlrouteractivity/UrlRouterViewModel.kt
@@ -8,19 +8,22 @@ import androidx.lifecycle.viewModelScope
 import arrow.core.getOrElse
 import com.weatherxm.R
 import com.weatherxm.data.ApiError
+import com.weatherxm.data.DataError
 import com.weatherxm.data.Failure
 import com.weatherxm.data.WXMRemoteMessage
 import com.weatherxm.data.repository.ExplorerRepositoryImpl.Companion.EXCLUDE_PLACES
 import com.weatherxm.ui.common.Contracts.ARG_REMOTE_MESSAGE
 import com.weatherxm.ui.common.UIDevice
-import com.weatherxm.ui.common.parcelable
 import com.weatherxm.ui.common.empty
+import com.weatherxm.ui.common.parcelable
 import com.weatherxm.ui.explorer.SearchResult
+import com.weatherxm.ui.explorer.UICell
 import com.weatherxm.usecases.DeviceListUseCase
 import com.weatherxm.usecases.ExplorerUseCase
 import com.weatherxm.util.Failure.getDefaultMessage
 import com.weatherxm.util.Resources
 import kotlinx.coroutines.launch
+import timber.log.Timber
 
 class UrlRouterViewModel(
     private val usecase: ExplorerUseCase,
@@ -29,14 +32,17 @@ class UrlRouterViewModel(
 ) : ViewModel() {
     companion object {
         const val STATIONS_PATH_SEGMENT = "stations"
+        const val CELLS_PATH_SEGMENT = "cells"
     }
 
     private val onError = MutableLiveData<String>()
     private val onDevice = MutableLiveData<UIDevice>()
+    private val onCell = MutableLiveData<UICell>()
     private val onRemoteMessage = MutableLiveData<WXMRemoteMessage>()
 
     fun onError(): LiveData<String> = onError
     fun onDevice(): LiveData<UIDevice> = onDevice
+    fun onCell(): LiveData<UICell> = onCell
     fun onRemoteMessage(): LiveData<WXMRemoteMessage> = onRemoteMessage
 
     fun parseUrl(intent: Intent) {
@@ -52,9 +58,25 @@ class UrlRouterViewModel(
             // e.g. https://exporer.weatherxm.com/stations/my-weather-station
             if (pathSegments.size == 2 && pathSegments[0].equals(STATIONS_PATH_SEGMENT)) {
                 searchForDevice(pathSegments[1])
+            } else if (pathSegments.size == 2 && pathSegments[0].equals(CELLS_PATH_SEGMENT)) {
+                searchForCell(pathSegments[1])
             } else {
+                Timber.w("Error parsing the URL: ${intent.data?.path}")
                 onError.postValue(resources.getString(R.string.could_not_parse_url))
             }
+        }
+    }
+
+    private fun searchForCell(cellIndex: String) {
+        viewModelScope.launch {
+            usecase.getCellInfo(cellIndex)
+                .onRight {
+                    onCell.postValue(it)
+                }
+                .onLeft {
+                    Timber.w("Error fetching cell info: $it")
+                    handleError(it)
+                }
         }
     }
 
@@ -72,7 +94,7 @@ class UrlRouterViewModel(
                     }
                 }
                 .onLeft {
-                    onError.postValue(it.getDefaultMessage(R.string.error_reach_out))
+                    handleError(it)
                 }
         }
     }
@@ -86,23 +108,21 @@ class UrlRouterViewModel(
             usecase.getCellDevice(
                 searchResult.stationCellIndex ?: String.empty(),
                 searchResult.stationId ?: String.empty()
-            )
-                .onRight {
-                    it.cellCenter = searchResult.center
-                    onDevice.postValue(it)
-                }
-                .onLeft {
-                    handleError(it)
-                }
+            ).onRight {
+                it.cellCenter = searchResult.center
+                onDevice.postValue(it)
+            }.onLeft {
+                handleError(it)
+            }
         }
     }
 
     private fun handleError(failure: Failure) {
         onError.postValue(
-            if (failure is ApiError.DeviceNotFound) {
-                resources.getString(R.string.error_device_not_found)
-            } else {
-                failure.getDefaultMessage(R.string.error_reach_out)
+            when (failure) {
+                is ApiError.DeviceNotFound -> resources.getString(R.string.error_device_not_found)
+                is DataError.CellNotFound -> resources.getString(R.string.error_cell_not_found)
+                else -> failure.getDefaultMessage(R.string.error_reach_out)
             }
         )
     }

--- a/app/src/main/java/com/weatherxm/usecases/ExplorerUseCase.kt
+++ b/app/src/main/java/com/weatherxm/usecases/ExplorerUseCase.kt
@@ -27,4 +27,5 @@ interface ExplorerUseCase {
     suspend fun getRecentSearches(): List<SearchResult>
     suspend fun setRecentSearch(search: SearchResult)
     suspend fun getUserCountryLocation(): Location?
+    suspend fun getCellInfo(index: String): Either<Failure, UICell>
 }

--- a/app/src/main/java/com/weatherxm/usecases/ExplorerUseCaseImpl.kt
+++ b/app/src/main/java/com/weatherxm/usecases/ExplorerUseCaseImpl.kt
@@ -1,6 +1,7 @@
 package com.weatherxm.usecases
 
 import arrow.core.Either
+import arrow.core.flatMap
 import arrow.core.getOrElse
 import com.google.gson.Gson
 import com.mapbox.geojson.Feature
@@ -10,6 +11,7 @@ import com.mapbox.maps.extension.style.sources.generated.GeoJsonSource
 import com.mapbox.maps.extension.style.sources.generated.geoJsonSource
 import com.mapbox.maps.plugin.annotation.generated.PolygonAnnotationOptions
 import com.weatherxm.R
+import com.weatherxm.data.DataError
 import com.weatherxm.data.Failure
 import com.weatherxm.data.Location
 import com.weatherxm.data.repository.AddressRepository
@@ -49,6 +51,16 @@ class ExplorerUseCaseImpl(
             coordinates.add(coordinates[0])
         }
         return latLongs
+    }
+
+    override suspend fun getCellInfo(index: String): Either<Failure, UICell> {
+        return explorerRepository.getCells().flatMap {
+            it.firstOrNull { cell ->
+                cell.index == index
+            }?.let { cell ->
+                Either.Right(UICell(cell.index, cell.center))
+            } ?: Either.Left(DataError.CellNotFound)
+        }
     }
 
     override suspend fun getCells(): Either<Failure, ExplorerData> {

--- a/app/src/main/res/values/messages.xml
+++ b/app/src/main/res/values/messages.xml
@@ -20,6 +20,7 @@
     <string name="error_user_device_data_failed">Getting data for this device failed.</string>
     <string name="error_user_device_offline"><![CDATA[Your weather station hasn\'t connected for a while.<br/>Please, visit our <a href="%1$s">troubleshooting guide</a>.]]></string>
     <string name="error_device_not_found">Could not find the requested device</string>
+    <string name="error_cell_not_found">Could not find the requested explorer cell</string>
     <string name="error_invalid_location">Invalid Location</string>
     <string name="error_connect_wallet_invalid_address">Invalid wallet address</string>
     <string name="error_forecast_generic_message">Fetching forecast failed</string>


### PR DESCRIPTION
## **Why?**
Handle deep linking of `https://explorer.weatherxm.com/cells/*` URLs.

### **How?**
1. Added the respective `data` block in the `UrlRouterActivity` in the `AndroidManifest`.
2. Created `getCellInfo` function in UseCase which gets all cells and returns the one that matches the predefined `index` or a `CellNotFound` failure.
3. Implemented the "search and return a cell" functionality in `UrlRouterViewModel` in order to properly either fetch the cell and pass it to `CellInfoActivity` and open that activity, either return a failure and handle it accordingly.
4. Added a listener on back pressed on `CellInfoActivity` to open the explorer when this activity gets opened through a deep link
5. The "navigate to location" functionality on Explorer wasn't working, so I made the respective fixes on `ExplorerViewModel` and optimized the code there.

### **Testing**
**Use Prod flavor:**
1. Either use the "Share Cell" feature in the app or open cell details through the explorer on any cell in your mobile browser
7. Copy the link and open it in a browser or send it via any Instant Messaging to yourself and try opening it directly (e.g. through Messenger/Telegram/Slack etc.)
8. A pop-up should show up as a prompt to open the page in-app. If not, check if there is an "Open in app" option by clicking on the 3 dots at the top right corner of the browser/page
9. If still nothing is there, ensure that the app has permissions to open `explorer.weatherxm.com` URLs (you can find the option through app settings in your device). Enable the permissions and go back to step 2.

Ensure that the above flow is working properly.