### PR TITLE
Fix some DFU-related crashes on Android 13 & 14

### DIFF
--- a/app/src/main/java/com/weatherxm/data/bluetooth/BluetoothUpdater.kt
+++ b/app/src/main/java/com/weatherxm/data/bluetooth/BluetoothUpdater.kt
@@ -2,7 +2,6 @@ package com.weatherxm.data.bluetooth
 
 import android.content.Context
 import android.net.Uri
-import android.os.Build
 import com.weatherxm.R
 import com.weatherxm.data.BluetoothOTAState
 import com.weatherxm.data.OTAState
@@ -118,7 +117,7 @@ class BluetoothUpdater(
 
     @Suppress("MagicNumber")
     private fun createErrorMessage(errorCode: Int, defaultMessage: String?): String? {
-        return if(errorCode == 133) {
+        return if (errorCode == 133) {
             "$defaultMessage - ${context.getString(R.string.error_helium_ota_133_suffix)}"
         } else {
             defaultMessage
@@ -130,17 +129,15 @@ class BluetoothUpdater(
         onOTAState.resetReplayCache()
         setUpdater()
 
-        /*
-        * This is needed because of crashing. More:
-        * https://github.com/NordicSemiconductor/Android-DFU-Library/issues/266
-        * https://github.com/NordicSemiconductor/Android-DFU-Library/issues/106
+        /**
+         * This is needed because of some crashes. We do not need notifications here.
+         * More:
+         * https://github.com/NordicSemiconductor/Android-DFU-Library/issues/438
+         * https://github.com/NordicSemiconductor/Android-DFU-Library/issues/266
+         * https://github.com/NordicSemiconductor/Android-DFU-Library/issues/106
          */
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-            DfuServiceInitiator.createDfuNotificationChannel(context)
-        } else {
-            dfuServiceInitiator.setForeground(false)
-            dfuServiceInitiator.setDisableNotification(true)
-        }
+        dfuServiceInitiator.setForeground(false)
+        dfuServiceInitiator.setDisableNotification(true)
 
         dfuServiceInitiator.setZip(updatePackage)
         dfuServiceInitiator.start(context, DfuService::class.java)

--- a/app/src/main/java/com/weatherxm/usecases/DeviceListUseCaseImpl.kt
+++ b/app/src/main/java/com/weatherxm/usecases/DeviceListUseCaseImpl.kt
@@ -30,7 +30,8 @@ class DeviceListUseCaseImpl(
                     alerts.add(DeviceAlert.OFFLINE)
                 }
 
-                if (shouldShowOTAPrompt && device.profile == Helium && device.needsUpdate()) {
+                // FIXME: Revert this before merging. For testing purposes. 
+                if (true) {
                     alerts.add(DeviceAlert.NEEDS_UPDATE)
                 }
                 device.apply {


### PR DESCRIPTION
## **Why?**
Fix some reported DFU-related crashes (reported on Firebase and as a library issue [here](https://github.com/NordicSemiconductor/Android-DFU-Library/issues/438)).

### **How?**
- Removed the "notifications" part of the DFU (as we do not needed it after all) along with `setForeground(false)` & `setDisableNotification(true)` at all cases.

### **Testing**
Try running an update on a Helium device. By default the flag `needsUpdate` is set to `true` on this PR so the warning will always be there on the devices list. That's for testing purposes in order to have an entry point to update the device.