### PR TITLE
Update Gradle to 8.3.1

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -57,7 +57,7 @@ timber = "5.0.1"
 zxing-android-embedded = "4.3.0"
 
 # Plugins
-android-gradle-plugin = "8.3.0"
+android-gradle-plugin = "8.3.1"
 kotlin-android-plugin = "1.9.22"
 kotlin-parcelize-plugin = "1.9.22"
 ksp-plugin = "1.9.22-1.0.18"


### PR DESCRIPTION
## **Why?**
Update Gradle to 8.3.1. Contains a fix to [this](https://github.com/WeatherXM/wxm-android/pull/76).

### **Testing**
Just ensure the project builds successfully. An Android Studio update might be needed first.