### PR TITLE
FE-721 Add custom dialog name in edit name dialog to fix the UI issue

### DIFF
--- a/app/src/main/java/com/weatherxm/ui/devicesettings/FriendlyNameDialogFragment.kt
+++ b/app/src/main/java/com/weatherxm/ui/devicesettings/FriendlyNameDialogFragment.kt
@@ -27,7 +27,6 @@ class FriendlyNameDialogFragment(
         val builder = MaterialAlertDialogBuilder(requireContext())
 
         binding = ViewEditNameBinding.inflate(layoutInflater)
-        builder.setTitle(getString(R.string.edit_name))
         builder.setView(binding.root)
 
         binding.newName.setText(currentFriendlyName)

--- a/app/src/main/res/layout/view_edit_name.xml
+++ b/app/src/main/res/layout/view_edit_name.xml
@@ -7,16 +7,26 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content">
 
+        <com.google.android.material.textview.MaterialTextView
+            android:id="@+id/title"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:textAppearance="@style/TextAppearance.WeatherXM.Title"
+            android:textStyle="bold"
+            app:layout_constraintTop_toTopOf="parent"
+            android:text="@string/edit_name" />
+
         <com.google.android.material.textfield.TextInputLayout
             android:id="@+id/new_name_container"
             style="@style/Widget.WeatherXM.TextInputEditText.OutlinedBox.Dense"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
+            android:layout_marginTop="@dimen/margin_normal"
             android:hint="@string/edit_name_hint"
             app:counterEnabled="true"
             app:counterMaxLength="64"
             app:helperText="@string/edit_name_helper_text"
-            app:layout_constraintTop_toTopOf="parent">
+            app:layout_constraintTop_toBottomOf="@id/title">
 
             <com.google.android.material.textfield.TextInputEditText
                 android:id="@+id/new_name"


### PR DESCRIPTION
## **Why?**
Fix the UI issue in the title of the edit name dialog.

### **How?**
Remove `builder.setTitle(getString(R.string.edit_name))` and add the dialog in its respective XML Layout file.

### **Testing**
Ensure that the title has the correct (white) background and it's **not** rendered as seen [here](https://linear.app/weatherxm/issue/FE-721/fix-edit-name-dialog-ui).
