### PR TITLE
FE-722 Toolbar fix of changing color when scrolling

### DIFF
--- a/app/src/main/res/layout/activity_change_frequency_station.xml
+++ b/app/src/main/res/layout/activity_change_frequency_station.xml
@@ -11,7 +11,8 @@
     <com.google.android.material.appbar.AppBarLayout
         android:id="@+id/app_bar"
         android:layout_width="match_parent"
-        android:layout_height="wrap_content">
+        android:layout_height="wrap_content"
+        app:liftOnScroll="false">
 
         <com.google.android.material.appbar.MaterialToolbar
             android:id="@+id/toolbar"

--- a/app/src/main/res/layout/activity_connect_wallet.xml
+++ b/app/src/main/res/layout/activity_connect_wallet.xml
@@ -9,7 +9,8 @@
     <com.google.android.material.appbar.AppBarLayout
         android:id="@+id/app_bar"
         android:layout_width="match_parent"
-        android:layout_height="wrap_content">
+        android:layout_height="wrap_content"
+        app:liftOnScroll="false">
 
         <com.google.android.material.appbar.MaterialToolbar
             android:id="@+id/toolbar"

--- a/app/src/main/res/layout/activity_delete_account.xml
+++ b/app/src/main/res/layout/activity_delete_account.xml
@@ -8,7 +8,8 @@
     <com.google.android.material.appbar.AppBarLayout
         android:id="@+id/app_bar"
         android:layout_width="match_parent"
-        android:layout_height="wrap_content">
+        android:layout_height="wrap_content"
+        app:liftOnScroll="false">
 
         <com.google.android.material.appbar.MaterialToolbar
             android:id="@+id/toolbar"

--- a/app/src/main/res/layout/activity_device_alerts.xml
+++ b/app/src/main/res/layout/activity_device_alerts.xml
@@ -12,7 +12,8 @@
     <com.google.android.material.appbar.AppBarLayout
         android:id="@+id/app_bar"
         android:layout_width="match_parent"
-        android:layout_height="wrap_content">
+        android:layout_height="wrap_content"
+        app:liftOnScroll="false">
 
         <com.google.android.material.appbar.MaterialToolbar
             android:id="@+id/toolbar"

--- a/app/src/main/res/layout/activity_device_settings.xml
+++ b/app/src/main/res/layout/activity_device_settings.xml
@@ -11,7 +11,8 @@
     <com.google.android.material.appbar.AppBarLayout
         android:id="@+id/app_bar"
         android:layout_width="match_parent"
-        android:layout_height="wrap_content">
+        android:layout_height="wrap_content"
+        app:liftOnScroll="false">
 
         <com.google.android.material.appbar.MaterialToolbar
             android:id="@+id/toolbar"

--- a/app/src/main/res/layout/activity_history.xml
+++ b/app/src/main/res/layout/activity_history.xml
@@ -12,7 +12,8 @@
         android:id="@+id/app_bar"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:background="@color/colorSurface">
+        android:background="@color/colorSurface"
+        app:liftOnScroll="false">
 
         <com.google.android.material.appbar.MaterialToolbar
             android:id="@+id/toolbar"

--- a/app/src/main/res/layout/activity_network_stats.xml
+++ b/app/src/main/res/layout/activity_network_stats.xml
@@ -11,7 +11,8 @@
     <com.google.android.material.appbar.AppBarLayout
         android:id="@+id/app_bar"
         android:layout_width="match_parent"
-        android:layout_height="wrap_content">
+        android:layout_height="wrap_content"
+        app:liftOnScroll="false">
 
         <com.google.android.material.appbar.MaterialToolbar
             android:id="@+id/toolbar"

--- a/app/src/main/res/layout/activity_preferences.xml
+++ b/app/src/main/res/layout/activity_preferences.xml
@@ -11,7 +11,8 @@
     <com.google.android.material.appbar.AppBarLayout
         android:id="@+id/app_bar"
         android:layout_width="match_parent"
-        android:layout_height="wrap_content">
+        android:layout_height="wrap_content"
+        app:liftOnScroll="false">
 
         <com.google.android.material.appbar.MaterialToolbar
             android:id="@+id/toolbar"

--- a/app/src/main/res/layout/activity_reward_boost.xml
+++ b/app/src/main/res/layout/activity_reward_boost.xml
@@ -12,7 +12,8 @@
     <com.google.android.material.appbar.AppBarLayout
         android:id="@+id/app_bar"
         android:layout_width="match_parent"
-        android:layout_height="wrap_content">
+        android:layout_height="wrap_content"
+        app:liftOnScroll="false">
 
         <com.google.android.material.appbar.MaterialToolbar
             android:id="@+id/toolbar"

--- a/app/src/main/res/layout/activity_reward_details.xml
+++ b/app/src/main/res/layout/activity_reward_details.xml
@@ -12,7 +12,8 @@
     <com.google.android.material.appbar.AppBarLayout
         android:id="@+id/app_bar"
         android:layout_width="match_parent"
-        android:layout_height="wrap_content">
+        android:layout_height="wrap_content"
+        app:liftOnScroll="false">
 
         <com.google.android.material.appbar.MaterialToolbar
             android:id="@+id/toolbar"

--- a/app/src/main/res/layout/activity_reward_issues.xml
+++ b/app/src/main/res/layout/activity_reward_issues.xml
@@ -7,14 +7,13 @@
     android:layout_height="match_parent"
     android:animateLayoutChanges="true"
     android:background="@color/colorSurface"
-    android:clipChildren="false"
-    android:clipToPadding="false"
     android:fitsSystemWindows="false">
 
     <com.google.android.material.appbar.AppBarLayout
         android:id="@+id/app_bar"
         android:layout_width="match_parent"
-        android:layout_height="wrap_content">
+        android:layout_height="wrap_content"
+        app:liftOnScroll="false">
 
         <com.google.android.material.appbar.MaterialToolbar
             android:id="@+id/toolbar"
@@ -26,9 +25,10 @@
     <androidx.core.widget.NestedScrollView
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:layout_marginHorizontal="@dimen/margin_normal"
         android:layout_marginTop="@dimen/margin_small"
         android:clipChildren="false"
+        android:clipToPadding="false"
+        android:paddingHorizontal="@dimen/padding_normal"
         app:layout_behavior="com.google.android.material.appbar.AppBarLayout$ScrollingViewBehavior">
 
         <androidx.constraintlayout.widget.ConstraintLayout

--- a/app/src/main/res/layout/activity_rewards_list.xml
+++ b/app/src/main/res/layout/activity_rewards_list.xml
@@ -11,7 +11,8 @@
     <com.google.android.material.appbar.AppBarLayout
         android:id="@+id/app_bar"
         android:layout_width="match_parent"
-        android:layout_height="wrap_content">
+        android:layout_height="wrap_content"
+        app:liftOnScroll="false">
 
         <com.google.android.material.appbar.MaterialToolbar
             android:id="@+id/toolbar"

--- a/app/src/main/res/layout/fragment_profile.xml
+++ b/app/src/main/res/layout/fragment_profile.xml
@@ -144,16 +144,15 @@
         android:id="@+id/swiperefresh"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
-        android:clipChildren="false"
-        android:clipToPadding="false"
-        android:paddingHorizontal="@dimen/padding_normal_to_large"
-        android:paddingVertical="@dimen/padding_normal_to_large"
         app:layout_behavior="com.google.android.material.appbar.AppBarLayout$ScrollingViewBehavior">
 
         <androidx.core.widget.NestedScrollView
             android:layout_width="match_parent"
             android:layout_height="match_parent"
-            android:clipChildren="false">
+            android:clipChildren="false"
+            android:clipToPadding="false"
+            android:paddingHorizontal="@dimen/padding_normal_to_large"
+            android:paddingVertical="@dimen/padding_normal_to_large">
 
             <androidx.constraintlayout.widget.ConstraintLayout
                 android:layout_width="match_parent"


### PR DESCRIPTION
## **Why?**
If/when the content scrolls under the Toolbar, the Toolbar changes color, instead of staying as is in certain screens.

### **How?**
Added `app:liftOnScroll="false"` on each AppBar and fixed in some screens the paddings (clipping when scrolling).

### **Testing**
Ensure that the toolbar doesn't change color if/when scrolling in the following screens:
- Settings
- Wallet
- Network Stats
- Historical Charts
- Reward Timeline
- Reward Detail
- Reward Issues
- Boost Detail
- Delete Account
- Station Settings
- Change Frequency
- Device Alerts