### PR TITLE
FE-724 Fix UI bug of overflowing lines in boost card

### DIFF
--- a/app/src/main/java/com/weatherxm/ui/rewardboosts/RewardBoostActivity.kt
+++ b/app/src/main/java/com/weatherxm/ui/rewardboosts/RewardBoostActivity.kt
@@ -99,14 +99,14 @@ class RewardBoostActivity : BaseActivity() {
         binding.title.text = data.title
         binding.amount.text = getString(R.string.reward, data.actualReward)
         if (BoostCode.beta_rewards.name == boostCode && data.boostScore != null) {
-            binding.dailyBoostScore.text = if (data.boostScore == 100) {
+            binding.dailyBoostScore.text = "${data.boostScore}%"
+            binding.rewardsDesc.text = if (data.boostScore == 100) {
                 getString(R.string.got_all_beta_rewards)
             } else {
-                "${data.boostScore}%"
+                getString(R.string.boost_tokens_lost, data.lostRewards)
             }
-            binding.lostRewards.text = getString(R.string.boost_tokens_lost, data.lostRewards)
         } else {
-            binding.lostRewards.setVisible(false)
+            binding.rewardsDesc.setVisible(false)
             binding.divider.setVisible(false)
             binding.dailyBoostScoreTitle.setVisible(false)
             binding.dailyBoostScore.setVisible(false)

--- a/app/src/main/res/layout/activity_reward_boost.xml
+++ b/app/src/main/res/layout/activity_reward_boost.xml
@@ -135,7 +135,7 @@
                             app:layout_constraintTop_toBottomOf="@id/dailyBoostScore" />
 
                         <com.google.android.material.textview.MaterialTextView
-                            android:id="@+id/lostRewards"
+                            android:id="@+id/rewardsDesc"
                             android:layout_width="match_parent"
                             android:layout_height="wrap_content"
                             android:layout_marginTop="@dimen/margin_small"


### PR DESCRIPTION
## **Why?**
Fix UI bug of overflowing lines in boost card.

### **How?**
When reward score == 100 edit the `rewardsDesc` properly and not the `boostScore` as we did before by mistake.

### **Testing**
Test against any internal station that has some boost rewards in the dev server and ensure everything is OK.