### PR TITLE
FE-734 Fix background color of boost card when loading/unknown

### DIFF
--- a/app/src/main/java/com/weatherxm/ui/common/Views.kt
+++ b/app/src/main/java/com/weatherxm/ui/common/Views.kt
@@ -355,7 +355,7 @@ fun MaterialCardView.setCardStroke(@ColorRes colorResId: Int, width: Int) {
  * Fallback in case img url or drawable is missing so the texts can be visible
  */
 fun MaterialCardView.setBoostFallbackBackground() {
-    setCardBackgroundColor(context.getColor(R.color.dark_background))
+    setCardBackgroundColor(context.getColor(R.color.blue))
 }
 
 private fun Context.hideKeyboard(view: View) {

--- a/app/src/main/java/com/weatherxm/ui/rewardboosts/RewardBoostActivity.kt
+++ b/app/src/main/java/com/weatherxm/ui/rewardboosts/RewardBoostActivity.kt
@@ -84,9 +84,8 @@ class RewardBoostActivity : BaseActivity() {
     @Suppress("MagicNumber")
     @SuppressLint("SetTextI18n")
     private fun updateUI(boostCode: String?, data: UIBoost) {
-        if (data.imgUrl.isEmpty()) {
-            binding.boostCard.setBoostFallbackBackground()
-        } else {
+        binding.boostCard.setBoostFallbackBackground()
+        if (data.imgUrl.isNotEmpty()) {
             imageLoader.enqueue(
                 ImageRequest.Builder(this)
                     .data(data.imgUrl)

--- a/app/src/main/java/com/weatherxm/ui/rewarddetails/RewardBoostAdapter.kt
+++ b/app/src/main/java/com/weatherxm/ui/rewarddetails/RewardBoostAdapter.kt
@@ -45,10 +45,9 @@ class RewardBoostAdapter(
             binding.desc.text = item.description
             binding.amount.text =
                 itemView.context.getString(R.string.reward, formatTokens(item.actualReward))
+            binding.root.setBoostFallbackBackground()
 
-            if (item.imgUrl.isNullOrEmpty()) {
-                binding.root.setBoostFallbackBackground()
-            } else {
+            if (!item.imgUrl.isNullOrEmpty()) {
                 imageLoader.enqueue(
                     ImageRequest.Builder(itemView.context)
                         .data(item.imgUrl)

--- a/app/src/main/java/com/weatherxm/util/Charts.kt
+++ b/app/src/main/java/com/weatherxm/util/Charts.kt
@@ -557,8 +557,8 @@ fun LineChart.initializeNetworkStatsChart(entries: List<Entry>) {
 
     // Line and highlight Settings
     lineData.setDrawValues(false)
-    dataSet.color = context.getColor(R.color.network_stats_chart_primary)
-    dataSet.setCircleColor(context.getColor(R.color.network_stats_chart_primary))
+    dataSet.color = context.getColor(R.color.blue)
+    dataSet.setCircleColor(context.getColor(R.color.blue))
     dataSet.setDrawCircleHole(false)
     dataSet.circleRadius = 1F
     dataSet.lineWidth = LINE_WIDTH

--- a/app/src/main/res/layout/view_daily_rewards_card.xml
+++ b/app/src/main/res/layout/view_daily_rewards_card.xml
@@ -110,7 +110,7 @@
                         android:src="@drawable/ic_reward_scale"
                         app:layout_constraintStart_toEndOf="@id/baseRewardScore"
                         app:layout_constraintTop_toTopOf="@id/baseRewardIcon"
-                        app:tint="@color/network_stats_chart_primary"
+                        app:tint="@color/blue"
                         tools:ignore="ContentDescription" />
 
                     <FrameLayout

--- a/app/src/main/res/values/palette.xml
+++ b/app/src/main/res/values/palette.xml
@@ -6,6 +6,7 @@
     <color name="white">#FFFFFF</color>
     <color name="purple">#9D1F63</color>
     <color name="green">#46D163</color>
+    <color name="blue">#2780FF</color>
 
     <!-- Color Palette/Library Design Team -->
 
@@ -60,7 +61,6 @@
     <color name="follow_heart_color">#FF9AAE</color>
 
     <!-- Network Stats -->
-    <color name="network_stats_chart_primary">#2780FF</color>
     <color name="network_stats_slider_light">#BED6FF</color>
     <color name="network_stats_slider_dark">#2E4C80</color>
 


### PR DESCRIPTION
## **Why?**
In the loading state of the boost details screen or when the boost type is not supported then we would use the #2780FF as the default color.

### **How?**
Renamed the #2780FF color to `blue` and used it accordingly.

### **Testing**
Test a station that has beta rewards boost or any other unknown type and ensure that blue color is shown correctly.