### PR TITLE
FE-717 Update some colors

### DIFF
--- a/app/src/main/java/com/weatherxm/ui/components/DailyRewardsCardView.kt
+++ b/app/src/main/java/com/weatherxm/ui/components/DailyRewardsCardView.kt
@@ -166,7 +166,7 @@ open class DailyRewardsCardView : LinearLayout, KoinComponent {
                 backgroundColor = R.color.warningTint
             }
             SeverityLevel.INFO -> {
-                strokeColor = R.color.light_lightest_blue
+                strokeColor = R.color.infoStrokeColor
                 backgroundColor = R.color.blueTint
             }
         }

--- a/app/src/main/java/com/weatherxm/ui/rewarddetails/RewardDetailsActivity.kt
+++ b/app/src/main/java/com/weatherxm/ui/rewarddetails/RewardDetailsActivity.kt
@@ -306,7 +306,7 @@ class RewardDetailsActivity : BaseActivity(), RewardBoostListener {
         val backgroundColor: Int
         when (issue.severityLevel) {
             SeverityLevel.INFO -> {
-                strokeColor = R.color.light_lightest_blue
+                strokeColor = R.color.infoStrokeColor
                 backgroundColor = R.color.blueTint
             }
             SeverityLevel.WARNING -> {
@@ -318,7 +318,7 @@ class RewardDetailsActivity : BaseActivity(), RewardBoostListener {
                 backgroundColor = R.color.errorTint
             }
             else -> {
-                strokeColor = R.color.light_lightest_blue
+                strokeColor = R.color.infoStrokeColor
                 backgroundColor = R.color.blueTint
             }
         }

--- a/app/src/main/java/com/weatherxm/ui/rewardissues/RewardIssuesAdapter.kt
+++ b/app/src/main/java/com/weatherxm/ui/rewardissues/RewardIssuesAdapter.kt
@@ -40,7 +40,7 @@ class RewardIssuesAdapter(
                 when (item.severityLevel) {
                     SeverityLevel.INFO -> {
                         setBackground(R.color.blueTint)
-                        setStrokeColor(R.color.light_lightest_blue)
+                        setStrokeColor(R.color.infoStrokeColor)
                     }
                     SeverityLevel.WARNING -> {
                         setBackground(R.color.warningTint)
@@ -52,7 +52,7 @@ class RewardIssuesAdapter(
                     }
                     else -> {
                         setBackground(R.color.blueTint)
-                        setStrokeColor(R.color.light_lightest_blue)
+                        setStrokeColor(R.color.infoStrokeColor)
                     }
                 }
                 title(item.title)

--- a/app/src/main/res/layout/activity_preferences.xml
+++ b/app/src/main/res/layout/activity_preferences.xml
@@ -43,7 +43,7 @@
                 app:message_icon="@drawable/ic_survey"
                 app:message_icon_color="@color/colorPrimaryVariant"
                 app:message_includes_close_button="true"
-                app:message_stroke_color="@color/colorPrimaryVariant"
+                app:message_stroke_color="@color/infoStrokeColor"
                 app:message_title="@string/short_app_survey"
                 tools:visibility="visible" />
 

--- a/app/src/main/res/layout/view_ble_action_flow.xml
+++ b/app/src/main/res/layout/view_ble_action_flow.xml
@@ -190,7 +190,7 @@
         app:message_icon="@drawable/ic_info"
         app:message_icon_color="@color/colorPrimaryVariant"
         app:message_includes_close_button="false"
-        app:message_stroke_color="@color/colorPrimaryVariant"
+        app:message_stroke_color="@color/infoStrokeColor"
         tools:visibility="visible" />
 
     <!-- Buttons -->

--- a/app/src/main/res/values-night/colors.xml
+++ b/app/src/main/res/values-night/colors.xml
@@ -27,6 +27,7 @@
     <color name="fadeTop">@color/fade_dark_top</color>
     <color name="messageDialogBackground">@color/dark_top</color>
     <color name="messageDialogButton">@color/dark_layer1</color>
+    <color name="infoStrokeColor">@color/dark_primary</color>
 
     <!-- System and Launcher -->
     <color name="ic_launcher_background">#1B75BA</color>

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -27,6 +27,7 @@
     <color name="fadeTop">@color/fade_light_top</color>
     <color name="messageDialogBackground">@color/layer1</color>
     <color name="messageDialogButton">@color/light_translucent</color>
+    <color name="infoStrokeColor">@color/light_lightest_blue</color>
 
     <!-- System and Launcher -->
     <color name="ic_launcher_background">@color/colorPrimary</color>

--- a/app/src/main/res/values/palette.xml
+++ b/app/src/main/res/values/palette.xml
@@ -34,7 +34,7 @@
     <color name="dark_layer2">#23252F</color>
     <color name="dark_background">#1B1C22</color>
     <color name="dark_darkest_blue">#DCE1FF</color>
-    <color name="dark_primary">#B5C4FF</color>
+    <color name="dark_primary">#B8C6FF</color>
     <color name="dark_lightest_blue">#00297B</color>
     <color name="dark_blue_tint">#1E2438</color>
     <color name="dark_accent">#CD9EFC</color>
@@ -45,11 +45,11 @@
     <color name="light_success_tint">#D8F8EA</color>
     <color name="dark_success_tint">#17392C</color>
     <color name="error">#FF1744</color>
-    <color name="light_error_tint">#FED9E3</color>
-    <color name="dark_error_tint">#3D1A25</color>
+    <color name="light_error_tint">#FADCE3</color>
+    <color name="dark_error_tint">#4B2F36</color>
     <color name="warning">#FFAB49</color>
-    <color name="light_warning_tint">#FEEFE4</color>
-    <color name="dark_warning_tint">#3D3125</color>
+    <color name="light_warning_tint">#FBDEBC</color>
+    <color name="dark_warning_tint">#46381B</color>
 
     <!-- Fade -->
     <color name="fade_light_top">#00FEFBFF</color>


### PR DESCRIPTION
## **Why?**
Error & Warning annotation summaries have a different color from Figma

### **How?**
- Updated `darkPrimary`, `lightWarningTint`, `darkWarningTint`, `lightErrorTint` and `darkErrorTint` colors.
- Created a new color `infoStrokeColor` to use it in info-related cards as a stroke.

### **Testing**
Ensure that the colors are correct and nothing has broken up readability-wise in those cards or other info/warning/error cards in-app.