### PR TITLE
FE-750 Use CLAIM_APP_URL from environment secret

### DIFF
--- a/.github/workflows/build-codeanalysis.yml
+++ b/.github/workflows/build-codeanalysis.yml
@@ -6,8 +6,6 @@ name: Pull Request Code Build & Analysis
 on:
     pull_request
 env:
-    # Claim DApp URL
-    ORG_GRADLE_PROJECT_CLAIM_APP_URL: ${{ secrets.CLAIM_APP_URL }}
     # Mapbox SDK secrets
     ORG_GRADLE_PROJECT_MAPBOX_ACCESS_TOKEN: ${{ secrets.MAPBOX_ACCESS_TOKEN }}
     ORG_GRADLE_PROJECT_MAPBOX_DOWNLOADS_TOKEN: ${{ secrets.MAPBOX_DOWNLOADS_TOKEN }}
@@ -28,6 +26,8 @@ jobs:
         env:
             # API URL for Prod Flavor
             ORG_GRADLE_PROJECT_API_URL: ${{ secrets.API_URL }}
+            # Claim DApp URL
+            ORG_GRADLE_PROJECT_CLAIM_APP_URL: ${{ secrets.CLAIM_APP_URL }}
         runs-on: ubuntu-latest
         steps:
             -   name: Checkout
@@ -57,6 +57,8 @@ jobs:
         env:
             # API URL for Prod Flavor
             ORG_GRADLE_PROJECT_API_URL: ${{ secrets.API_URL }}
+            # Claim DApp URL
+            ORG_GRADLE_PROJECT_CLAIM_APP_URL: ${{ secrets.CLAIM_APP_URL }}
         runs-on: ubuntu-latest
         steps:
             -   name: Checkout

--- a/.github/workflows/on-main-firebase-distribution.yml
+++ b/.github/workflows/on-main-firebase-distribution.yml
@@ -3,8 +3,6 @@ on:
     push:
         branches: [ main ]
 env:
-    # Claim DApp URL
-    ORG_GRADLE_PROJECT_CLAIM_APP_URL: ${{ secrets.CLAIM_APP_URL }}
     # Mapbox SDK secrets
     ORG_GRADLE_PROJECT_MAPBOX_ACCESS_TOKEN: ${{ secrets.MAPBOX_ACCESS_TOKEN }}
     ORG_GRADLE_PROJECT_MAPBOX_DOWNLOADS_TOKEN: ${{ secrets.MAPBOX_DOWNLOADS_TOKEN }}
@@ -25,6 +23,8 @@ jobs:
         env:
             # API URL for Prod Flavor
             ORG_GRADLE_PROJECT_API_URL: ${{ secrets.API_URL }}
+            # Claim DApp URL
+            ORG_GRADLE_PROJECT_CLAIM_APP_URL: ${{ secrets.CLAIM_APP_URL }}
         runs-on: ubuntu-latest
         steps:
             -   name: Checkout
@@ -56,6 +56,8 @@ jobs:
         env:
             # API URL for Dev Flavor
             ORG_GRADLE_PROJECT_API_URL: ${{ secrets.API_URL }}
+            # Claim DApp URL
+            ORG_GRADLE_PROJECT_CLAIM_APP_URL: ${{ secrets.CLAIM_APP_URL }}
         runs-on: ubuntu-latest
         steps:
             -   name: Checkout

--- a/.github/workflows/on-qa-firebase-distribution.yml
+++ b/.github/workflows/on-qa-firebase-distribution.yml
@@ -16,8 +16,6 @@ on:
                     - "debug"
                 default: 'release'
 env:
-    # Claim DApp URL
-    ORG_GRADLE_PROJECT_CLAIM_APP_URL: ${{ secrets.CLAIM_APP_URL }}
     # Mapbox SDK secrets
     ORG_GRADLE_PROJECT_MAPBOX_ACCESS_TOKEN: ${{ secrets.MAPBOX_ACCESS_TOKEN }}
     ORG_GRADLE_PROJECT_MAPBOX_DOWNLOADS_TOKEN: ${{ secrets.MAPBOX_DOWNLOADS_TOKEN }}
@@ -38,6 +36,8 @@ jobs:
         env:
             # API URL for the environment selected
             ORG_GRADLE_PROJECT_API_URL: ${{ secrets.API_URL }}
+            # Claim DApp URL
+            ORG_GRADLE_PROJECT_CLAIM_APP_URL: ${{ secrets.CLAIM_APP_URL }}
         runs-on: ubuntu-latest
         steps:
             -   name: Checkout

--- a/.github/workflows/production-firebase-distribution.yml
+++ b/.github/workflows/production-firebase-distribution.yml
@@ -4,8 +4,6 @@ on:
         tags:
             - '[0-9]+.[0-9]+.[0-9]+'
 env:
-    # Claim DApp URL
-    ORG_GRADLE_PROJECT_CLAIM_APP_URL: ${{ secrets.CLAIM_APP_URL }}
     # Mapbox SDK secrets
     ORG_GRADLE_PROJECT_MAPBOX_ACCESS_TOKEN: ${{ secrets.MAPBOX_ACCESS_TOKEN }}
     ORG_GRADLE_PROJECT_MAPBOX_DOWNLOADS_TOKEN: ${{ secrets.MAPBOX_DOWNLOADS_TOKEN }}
@@ -26,6 +24,8 @@ jobs:
         env:
             # API URL for Prod Flavor
             ORG_GRADLE_PROJECT_API_URL: ${{ secrets.API_URL }}
+            # Claim DApp URL
+            ORG_GRADLE_PROJECT_CLAIM_APP_URL: ${{ secrets.CLAIM_APP_URL }}
         runs-on: ubuntu-latest
         steps:
             -   name: Checkout


### PR DESCRIPTION
## **Why?**
Add a dev URL for the claim app to dev builds.

### **How?**
Changed the GitHub workflows to use the environment secret for `CLAIM_APP_URL` and set those secrets in this repo.

### **Testing**
Not testable until merged.
