### PR TITLE
FE-761 Hide base reward icon when QoD is not available

### DIFF
--- a/app/src/main/java/com/weatherxm/ui/components/RewardsQualityCardView.kt
+++ b/app/src/main/java/com/weatherxm/ui/components/RewardsQualityCardView.kt
@@ -69,6 +69,15 @@ open class RewardsQualityCardView : LinearLayout, KoinComponent {
         return this
     }
 
+    fun hideIcon(): RewardsQualityCardView {
+        binding.statusIcon.setVisible(false)
+        // Make the status description start from the same position as the title
+        binding.statusDesc.setPadding(
+            resources.getDimension(R.dimen.padding_normal).toInt(), 0, 0, 0
+        )
+        return this
+    }
+
     fun checkmark(): RewardsQualityCardView {
         binding.statusIcon.setImageResource(R.drawable.ic_checkmark_hex_filled)
         return this

--- a/app/src/main/java/com/weatherxm/ui/rewarddetails/RewardDetailsActivity.kt
+++ b/app/src/main/java/com/weatherxm/ui/rewarddetails/RewardDetailsActivity.kt
@@ -125,8 +125,7 @@ class RewardDetailsActivity : BaseActivity(), RewardBoostListener {
         data.base?.qodScore?.let {
             updateDataQualityCard(it)
         } ?: run {
-            binding.dataQualityCard.error()
-            binding.dataQualityCard.desc(getString(R.string.data_quality_not_available))
+            binding.dataQualityCard.hideIcon().desc(getString(R.string.data_quality_not_available))
         }
         updateLocationCard(sortedIssues)
         updateCellCard(sortedIssues)


### PR DESCRIPTION
## **Why?**
Hide base reward icon when QoD is not available.

### **How?**
Created funcion `hideIcon` in `RewardsQualityCardView` which hides the icon in that card and adds the respective left padding to the message in order to start from the same position as the title.

### **Testing**
Choose Rural Iris Water station go to the first entry without QOD in timeline (earlier than March 12)