### PR TITLE
FE-754 Limit Reward Timeline data

### DIFF
--- a/app/src/main/java/com/weatherxm/data/ApiModels.kt
+++ b/app/src/main/java/com/weatherxm/data/ApiModels.kt
@@ -450,14 +450,7 @@ data class Reward(
     val baseRewardScore: Int?,
     @Json(name = "annotation_summary")
     val annotationSummary: List<RewardsAnnotationGroup>?,
-) : Parcelable {
-    companion object {
-        fun empty() = Reward(null, null, null, null, null, null)
-    }
-
-    fun isEmpty() = timestamp == null && baseReward == null && totalBoostReward == null
-        && totalReward == null && baseRewardScore == null && annotationSummary == null
-}
+) : Parcelable
 
 @Keep
 @JsonClass(generateAdapter = true)

--- a/app/src/main/java/com/weatherxm/data/ApiModels.kt
+++ b/app/src/main/java/com/weatherxm/data/ApiModels.kt
@@ -451,11 +451,12 @@ data class Reward(
     @Json(name = "annotation_summary")
     val annotationSummary: List<RewardsAnnotationGroup>?,
 ) : Parcelable {
-    fun toSortedAnnotations(): List<RewardsAnnotationGroup>? {
-        return annotationSummary?.sortedByDescending {
-            it.severityLevel
-        }
+    companion object {
+        fun empty() = Reward(null, null, null, null, null, null)
     }
+
+    fun isEmpty() = timestamp == null && baseReward == null && totalBoostReward == null
+        && totalReward == null && baseRewardScore == null && annotationSummary == null
 }
 
 @Keep

--- a/app/src/main/java/com/weatherxm/data/repository/RewardsRepository.kt
+++ b/app/src/main/java/com/weatherxm/data/repository/RewardsRepository.kt
@@ -15,10 +15,7 @@ import java.time.ZonedDateTime
 interface RewardsRepository {
     suspend fun getRewardsTimeline(
         deviceId: String,
-        page: Int?,
-        timezone: String? = null,
-        fromDate: String?,
-        toDate: String? = null
+        page: Int?
     ): Either<Failure, RewardsTimeline>
 
     suspend fun getRewards(deviceId: String): Either<Failure, Rewards>
@@ -36,20 +33,19 @@ interface RewardsRepository {
 }
 
 class RewardsRepositoryImpl(private val dataSource: RewardsDataSource) : RewardsRepository {
+    companion object {
+        const val TIMELINE_MINUS_MONTHS_TO_FETCH = 3L
+    }
 
     override suspend fun getRewardsTimeline(
         deviceId: String,
-        page: Int?,
-        timezone: String?,
-        fromDate: String?,
-        toDate: String?
+        page: Int?
     ): Either<Failure, RewardsTimeline> {
         return dataSource.getRewardsTimeline(
             deviceId,
             page,
             timezone = ZoneId.of("UTC").toString(),
-            fromDate = fromDate,
-            toDate = toDate,
+            fromDate = ZonedDateTime.now().minusMonths(TIMELINE_MINUS_MONTHS_TO_FETCH).toISODate()
         )
     }
 

--- a/app/src/main/java/com/weatherxm/ui/common/UIModels.kt
+++ b/app/src/main/java/com/weatherxm/ui/common/UIModels.kt
@@ -24,10 +24,18 @@ data class UIError(
 @Keep
 @JsonClass(generateAdapter = true)
 data class UIRewardsTimeline(
-    var rewards: List<Reward>,
+    var rewards: List<TimelineReward>,
     var hasNextPage: Boolean = false,
     var reachedTotal: Boolean = false
 )
+
+@Keep
+@JsonClass(generateAdapter = true)
+@Parcelize
+data class TimelineReward(
+    val type: RewardTimelineType,
+    val data: Reward?
+) : Parcelable
 
 @Keep
 @JsonClass(generateAdapter = true)
@@ -300,6 +308,12 @@ data class BoostDetailInfo(
     val title: String,
     val value: String
 ) : Parcelable
+
+@Suppress("EnumNaming")
+enum class RewardTimelineType {
+    DATA,
+    END_OF_LIST
+}
 
 @Parcelize
 enum class DevicesSortOrder : Parcelable {

--- a/app/src/main/java/com/weatherxm/ui/rewardslist/RewardsListActivity.kt
+++ b/app/src/main/java/com/weatherxm/ui/rewardslist/RewardsListActivity.kt
@@ -66,6 +66,10 @@ class RewardsListActivity : BaseActivity() {
             updateUINewPage(it)
         }
 
+        model.onEndOfData().observe(this) {
+            adapter.setData(it)
+        }
+
         model.fetchFirstPageRewards(deviceId)
     }
 
@@ -78,7 +82,7 @@ class RewardsListActivity : BaseActivity() {
         when (resource.status) {
             Status.SUCCESS -> {
                 if (!resource.data.isNullOrEmpty()) {
-                    adapter.submitList(resource.data)
+                    adapter.setData(resource.data)
                     binding.recycler.setVisible(true)
                     binding.status.setVisible(false)
                     binding.emptyRewardsCard.setVisible(false)
@@ -110,8 +114,7 @@ class RewardsListActivity : BaseActivity() {
         when (resource.status) {
             Status.SUCCESS -> {
                 if (!resource.data.isNullOrEmpty()) {
-                    adapter.submitList(resource.data)
-                    adapter.notifyDataSetChanged()
+                    adapter.setData(resource.data)
                 }
                 binding.loadingNewPage.setVisible(false)
             }

--- a/app/src/main/java/com/weatherxm/ui/rewardslist/RewardsListActivity.kt
+++ b/app/src/main/java/com/weatherxm/ui/rewardslist/RewardsListActivity.kt
@@ -1,7 +1,6 @@
 package com.weatherxm.ui.rewardslist
 
 import android.os.Bundle
-import android.view.View
 import com.weatherxm.R
 import com.weatherxm.data.Resource
 import com.weatherxm.data.Reward
@@ -11,6 +10,7 @@ import com.weatherxm.ui.common.Contracts.ARG_DEVICE
 import com.weatherxm.ui.common.UIDevice
 import com.weatherxm.ui.common.applyInsets
 import com.weatherxm.ui.common.parcelable
+import com.weatherxm.ui.common.setVisible
 import com.weatherxm.ui.common.toast
 import com.weatherxm.ui.components.BaseActivity
 import com.weatherxm.util.Analytics
@@ -79,32 +79,29 @@ class RewardsListActivity : BaseActivity() {
             Status.SUCCESS -> {
                 if (!resource.data.isNullOrEmpty()) {
                     adapter.submitList(resource.data)
-                    binding.recycler.visibility = View.VISIBLE
-                    binding.empty.visibility = View.GONE
+                    binding.recycler.setVisible(true)
+                    binding.status.setVisible(false)
+                    binding.emptyRewardsCard.setVisible(false)
                 } else {
-                    binding.empty.animation(R.raw.anim_empty_devices, false)
-                    binding.empty.title(getString(R.string.no_transactions_title))
-                    binding.empty.subtitle(getString(R.string.info_come_back_later))
-                    binding.empty.listener(null)
-                    binding.empty.visibility = View.VISIBLE
-                    binding.recycler.visibility = View.GONE
+                    binding.recycler.setVisible(false)
+                    binding.emptyRewardsCard.setVisible(true)
                 }
             }
             Status.ERROR -> {
                 Timber.d("Got error: $resource.message")
-                binding.recycler.visibility = View.GONE
-                binding.empty.animation(R.raw.anim_error)
-                binding.empty.title(getString(R.string.error_transactions_no_data))
-                binding.empty.subtitle(resource.message)
-                binding.empty.action(getString(R.string.action_retry))
-                binding.empty.listener { model.fetchFirstPageRewards(deviceId) }
-                binding.empty.visibility = View.VISIBLE
+                binding.recycler.setVisible(false)
+                binding.status.animation(R.raw.anim_error)
+                    .title(getString(R.string.error_rewards_no_data))
+                    .subtitle(resource.message)
+                    .action(getString(R.string.action_retry))
+                    .listener { model.fetchFirstPageRewards(deviceId) }
+                    .setVisible(true)
             }
             Status.LOADING -> {
-                binding.recycler.visibility = View.GONE
-                binding.empty.clear()
-                binding.empty.animation(R.raw.anim_loading)
-                binding.empty.visibility = View.VISIBLE
+                binding.recycler.setVisible(false)
+                binding.status.clear()
+                    .animation(R.raw.anim_loading)
+                    .setVisible(true)
             }
         }
     }
@@ -116,14 +113,14 @@ class RewardsListActivity : BaseActivity() {
                     adapter.submitList(resource.data)
                     adapter.notifyDataSetChanged()
                 }
-                binding.loadingNewPage.visibility = View.GONE
+                binding.loadingNewPage.setVisible(false)
             }
             Status.ERROR -> {
                 Timber.d("Got error: $resource.message")
-                binding.loadingNewPage.visibility = View.GONE
+                binding.loadingNewPage.setVisible(false)
             }
             Status.LOADING -> {
-                binding.loadingNewPage.visibility = View.VISIBLE
+                binding.loadingNewPage.setVisible(true)
             }
         }
     }

--- a/app/src/main/java/com/weatherxm/ui/rewardslist/RewardsListActivity.kt
+++ b/app/src/main/java/com/weatherxm/ui/rewardslist/RewardsListActivity.kt
@@ -7,6 +7,7 @@ import com.weatherxm.data.Reward
 import com.weatherxm.data.Status
 import com.weatherxm.databinding.ActivityRewardsListBinding
 import com.weatherxm.ui.common.Contracts.ARG_DEVICE
+import com.weatherxm.ui.common.TimelineReward
 import com.weatherxm.ui.common.UIDevice
 import com.weatherxm.ui.common.applyInsets
 import com.weatherxm.ui.common.parcelable
@@ -78,7 +79,7 @@ class RewardsListActivity : BaseActivity() {
         analytics.trackScreen(Analytics.Screen.DEVICE_REWARD_TRANSACTIONS, this::class.simpleName)
     }
 
-    private fun updateUIFirstPage(resource: Resource<List<Reward>>) {
+    private fun updateUIFirstPage(resource: Resource<List<TimelineReward>>) {
         when (resource.status) {
             Status.SUCCESS -> {
                 if (!resource.data.isNullOrEmpty()) {
@@ -110,7 +111,7 @@ class RewardsListActivity : BaseActivity() {
         }
     }
 
-    private fun updateUINewPage(resource: Resource<List<Reward>>) {
+    private fun updateUINewPage(resource: Resource<List<TimelineReward>>) {
         when (resource.status) {
             Status.SUCCESS -> {
                 if (!resource.data.isNullOrEmpty()) {

--- a/app/src/main/java/com/weatherxm/ui/rewardslist/RewardsListActivity.kt
+++ b/app/src/main/java/com/weatherxm/ui/rewardslist/RewardsListActivity.kt
@@ -3,7 +3,6 @@ package com.weatherxm.ui.rewardslist
 import android.os.Bundle
 import com.weatherxm.R
 import com.weatherxm.data.Resource
-import com.weatherxm.data.Reward
 import com.weatherxm.data.Status
 import com.weatherxm.databinding.ActivityRewardsListBinding
 import com.weatherxm.ui.common.Contracts.ARG_DEVICE

--- a/app/src/main/java/com/weatherxm/ui/rewardslist/RewardsListAdapter.kt
+++ b/app/src/main/java/com/weatherxm/ui/rewardslist/RewardsListAdapter.kt
@@ -1,7 +1,6 @@
 package com.weatherxm.ui.rewardslist
 
 import android.view.LayoutInflater
-import android.view.View
 import android.view.ViewGroup
 import androidx.recyclerview.widget.DiffUtil
 import androidx.recyclerview.widget.ListAdapter
@@ -9,6 +8,7 @@ import androidx.recyclerview.widget.RecyclerView
 import com.weatherxm.data.Reward
 import com.weatherxm.databinding.ListItemRewardBinding
 import com.weatherxm.ui.common.empty
+import com.weatherxm.ui.common.setVisible
 import com.weatherxm.util.DateTimeHelper.getFormattedDate
 import com.weatherxm.util.Resources
 import org.koin.core.component.KoinComponent
@@ -53,9 +53,14 @@ class RewardsListAdapter(
             if (position == currentList.size - 1) {
                 onEndOfData()
             }
-
-            updateDateAndLines(item.timestamp, position)
-            binding.mainCard.updateUI(item, true)
+            if (!item.isEmpty()) {
+                updateDateAndLines(item.timestamp, position)
+                binding.mainCard.updateUI(item, true)
+            } else {
+                binding.date.setVisible(false)
+                binding.mainCard.setVisible(false)
+                binding.endOfDataCard.setVisible(true)
+            }
         }
 
         /**
@@ -66,25 +71,23 @@ class RewardsListAdapter(
          * date as this one, then we hide the date and the respective line views.
          */
         private fun updateDateAndLines(timestamp: ZonedDateTime?, position: Int) {
-            binding.prevLine.visibility = if (position == 0) View.GONE else View.VISIBLE
-
             val formattedDate = timestamp.getFormattedDate(true)
 
             if (position == 0) {
-                binding.prevLine.visibility = View.GONE
+                binding.prevLine.setVisible(false)
                 binding.date.text = formattedDate
             } else {
                 val prevFormattedDate =
                     getItem(position - 1).timestamp?.getFormattedDate(true) ?: String.empty()
 
                 if (formattedDate == prevFormattedDate) {
-                    binding.prevLine.visibility = View.GONE
-                    binding.datePoint.visibility = View.GONE
-                    binding.date.visibility = View.GONE
+                    binding.prevLine.setVisible(false)
+                    binding.datePoint.setVisible(false)
+                    binding.date.setVisible(false)
                 } else {
-                    binding.prevLine.visibility = View.VISIBLE
-                    binding.datePoint.visibility = View.VISIBLE
-                    binding.date.visibility = View.VISIBLE
+                    binding.prevLine.setVisible(true)
+                    binding.datePoint.setVisible(true)
+                    binding.date.setVisible(true)
                     binding.date.text = formattedDate
                 }
             }

--- a/app/src/main/java/com/weatherxm/ui/rewardslist/RewardsListViewModel.kt
+++ b/app/src/main/java/com/weatherxm/ui/rewardslist/RewardsListViewModel.kt
@@ -6,7 +6,6 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.weatherxm.data.Failure
 import com.weatherxm.data.Resource
-import com.weatherxm.data.Reward
 import com.weatherxm.ui.common.RewardTimelineType
 import com.weatherxm.ui.common.TimelineReward
 import com.weatherxm.usecases.RewardsUseCase

--- a/app/src/main/java/com/weatherxm/ui/rewardslist/RewardsListViewModel.kt
+++ b/app/src/main/java/com/weatherxm/ui/rewardslist/RewardsListViewModel.kt
@@ -10,45 +10,35 @@ import com.weatherxm.data.Reward
 import com.weatherxm.usecases.RewardsUseCase
 import com.weatherxm.util.Analytics
 import com.weatherxm.util.Failure.getDefaultMessage
-import com.weatherxm.util.toISODate
 import kotlinx.coroutines.launch
 import timber.log.Timber
-import java.time.ZonedDateTime
 
 class RewardsListViewModel(
     private val usecase: RewardsUseCase,
     private val analytics: Analytics
 ) : ViewModel() {
-    companion object {
-        const val FETCH_INTERVAL_MONTHS = 3L
-    }
-
     private var currentPage = 0
     private var hasNextPage = false
     private var blockNewPageRequest = false
-    private var reachedTotal = false
-    private var currFromDate = ZonedDateTime.now().minusMonths(FETCH_INTERVAL_MONTHS)
-    private var currToDate = ZonedDateTime.now()
     private val currentShownRewards = mutableListOf<Reward>()
 
     private val onFirstPageRewards = MutableLiveData<Resource<List<Reward>>>().apply {
         value = Resource.loading()
     }
-
     private val onNewRewardsPage = MutableLiveData<Resource<List<Reward>>>()
+    private val onEndOfData = MutableLiveData<Unit>()
 
     fun onFirstPageRewards(): LiveData<Resource<List<Reward>>> = onFirstPageRewards
-
     fun onNewRewardsPage(): LiveData<Resource<List<Reward>>> = onNewRewardsPage
+    fun onEndOfData(): LiveData<Unit> = onEndOfData
 
     fun fetchFirstPageRewards(deviceId: String) {
         onFirstPageRewards.postValue(Resource.loading())
         viewModelScope.launch {
-            usecase.getRewardsTimeline(deviceId, currentPage, currFromDate.toISODate())
+            usecase.getRewardsTimeline(deviceId, currentPage)
                 .map {
                     Timber.d("Got Rewards: ${it.rewards}")
                     hasNextPage = it.hasNextPage
-                    reachedTotal = it.reachedTotal
                     currentShownRewards.addAll(it.rewards)
                     onFirstPageRewards.postValue(Resource.success(currentShownRewards))
                 }
@@ -66,66 +56,27 @@ class RewardsListViewModel(
                 currentPage++
                 blockNewPageRequest = true
 
-                usecase.getRewardsTimeline(
-                    deviceId,
-                    currentPage,
-                    currFromDate.toISODate(),
-                    currToDate.toISODate()
-                ).map {
+                usecase.getRewardsTimeline(deviceId, currentPage).map {
                     Timber.d("Got Rewards: ${it.rewards}")
                     hasNextPage = it.hasNextPage
-                    reachedTotal = it.reachedTotal
-                    /*
-                     * There is an edge case where rewards are empty, we have next page
-                     * and we need to hide the spinner (it's literally a success) in the UI,
-                     * but to not refresh the adapter. So we pass null on these occasions.
-                     */
-                    if (it.rewards.isNotEmpty()) {
-                        currentShownRewards.addAll(it.rewards)
-                        onNewRewardsPage.postValue(Resource.success(currentShownRewards))
-                    } else {
-                        onNewRewardsPage.postValue(Resource.success(null))
-                    }
-                }.onLeft {
-                    analytics.trackEventFailure(it.code)
-                }
-
-                blockNewPageRequest = false
-            }
-        } else if (!hasNextPage && !blockNewPageRequest && !reachedTotal) {
-            onNewRewardsPage.postValue(Resource.loading())
-            viewModelScope.launch {
-                currentPage = 0
-                blockNewPageRequest = true
-                currToDate = currFromDate
-                currFromDate = currFromDate.minusMonths(FETCH_INTERVAL_MONTHS)
-
-                usecase.getRewardsTimeline(
-                    deviceId,
-                    currentPage,
-                    currFromDate.toISODate(),
-                    currToDate.toISODate()
-                ).map {
-                    Timber.d("Got Rewards: ${it.rewards}")
-                    hasNextPage = it.hasNextPage
-                    reachedTotal = it.reachedTotal
                     currentShownRewards.addAll(it.rewards)
-                    /*
-                     * There is an edge case where rewards are empty, we have next page
-                     * and we need to hide the spinner (it's literally a success) in the UI,
-                     * but to not refresh the adapter. So we pass null on these occasions.
+                    /**
+                     * Add an empty reward at the end in order to let the adapter know that we
+                     * reached the end of the data and show the respective card
                      */
-                    if (it.rewards.isNotEmpty()) {
-                        currentShownRewards.addAll(it.rewards)
-                        onNewRewardsPage.postValue(Resource.success(currentShownRewards))
-                    } else {
-                        onNewRewardsPage.postValue(Resource.success(null))
+                    if (!hasNextPage) {
+                        currentShownRewards.add(Reward.empty())
                     }
+                    onNewRewardsPage.postValue(Resource.success(currentShownRewards))
                 }.onLeft {
                     analytics.trackEventFailure(it.code)
                 }
+
                 blockNewPageRequest = false
             }
+        } else if (!hasNextPage) {
+            // TODO: Empty reward on last page
+            onEndOfData.postValue(Unit)
         }
     }
 

--- a/app/src/main/java/com/weatherxm/ui/rewardslist/RewardsListViewModel.kt
+++ b/app/src/main/java/com/weatherxm/ui/rewardslist/RewardsListViewModel.kt
@@ -26,11 +26,11 @@ class RewardsListViewModel(
         value = Resource.loading()
     }
     private val onNewRewardsPage = MutableLiveData<Resource<List<Reward>>>()
-    private val onEndOfData = MutableLiveData<Unit>()
+    private val onEndOfData = MutableLiveData<List<Reward>>()
 
     fun onFirstPageRewards(): LiveData<Resource<List<Reward>>> = onFirstPageRewards
     fun onNewRewardsPage(): LiveData<Resource<List<Reward>>> = onNewRewardsPage
-    fun onEndOfData(): LiveData<Unit> = onEndOfData
+    fun onEndOfData(): LiveData<List<Reward>> = onEndOfData
 
     fun fetchFirstPageRewards(deviceId: String) {
         onFirstPageRewards.postValue(Resource.loading())
@@ -60,13 +60,6 @@ class RewardsListViewModel(
                     Timber.d("Got Rewards: ${it.rewards}")
                     hasNextPage = it.hasNextPage
                     currentShownRewards.addAll(it.rewards)
-                    /**
-                     * Add an empty reward at the end in order to let the adapter know that we
-                     * reached the end of the data and show the respective card
-                     */
-                    if (!hasNextPage) {
-                        currentShownRewards.add(Reward.empty())
-                    }
                     onNewRewardsPage.postValue(Resource.success(currentShownRewards))
                 }.onLeft {
                     analytics.trackEventFailure(it.code)
@@ -75,8 +68,9 @@ class RewardsListViewModel(
                 blockNewPageRequest = false
             }
         } else if (!hasNextPage) {
-            // TODO: Empty reward on last page
-            onEndOfData.postValue(Unit)
+            // Add an empty reward to indicate the end of data and send all rewards to the activity
+            currentShownRewards.add(Reward.empty())
+            onEndOfData.postValue(currentShownRewards)
         }
     }
 

--- a/app/src/main/java/com/weatherxm/ui/rewardslist/RewardsListViewModel.kt
+++ b/app/src/main/java/com/weatherxm/ui/rewardslist/RewardsListViewModel.kt
@@ -7,6 +7,8 @@ import androidx.lifecycle.viewModelScope
 import com.weatherxm.data.Failure
 import com.weatherxm.data.Resource
 import com.weatherxm.data.Reward
+import com.weatherxm.ui.common.RewardTimelineType
+import com.weatherxm.ui.common.TimelineReward
 import com.weatherxm.usecases.RewardsUseCase
 import com.weatherxm.util.Analytics
 import com.weatherxm.util.Failure.getDefaultMessage
@@ -20,17 +22,17 @@ class RewardsListViewModel(
     private var currentPage = 0
     private var hasNextPage = false
     private var blockNewPageRequest = false
-    private val currentShownRewards = mutableListOf<Reward>()
+    private val currentShownRewards = mutableListOf<TimelineReward>()
 
-    private val onFirstPageRewards = MutableLiveData<Resource<List<Reward>>>().apply {
+    private val onFirstPageRewards = MutableLiveData<Resource<List<TimelineReward>>>().apply {
         value = Resource.loading()
     }
-    private val onNewRewardsPage = MutableLiveData<Resource<List<Reward>>>()
-    private val onEndOfData = MutableLiveData<List<Reward>>()
+    private val onNewRewardsPage = MutableLiveData<Resource<List<TimelineReward>>>()
+    private val onEndOfData = MutableLiveData<List<TimelineReward>>()
 
-    fun onFirstPageRewards(): LiveData<Resource<List<Reward>>> = onFirstPageRewards
-    fun onNewRewardsPage(): LiveData<Resource<List<Reward>>> = onNewRewardsPage
-    fun onEndOfData(): LiveData<List<Reward>> = onEndOfData
+    fun onFirstPageRewards(): LiveData<Resource<List<TimelineReward>>> = onFirstPageRewards
+    fun onNewRewardsPage(): LiveData<Resource<List<TimelineReward>>> = onNewRewardsPage
+    fun onEndOfData(): LiveData<List<TimelineReward>> = onEndOfData
 
     fun fetchFirstPageRewards(deviceId: String) {
         onFirstPageRewards.postValue(Resource.loading())
@@ -68,8 +70,7 @@ class RewardsListViewModel(
                 blockNewPageRequest = false
             }
         } else if (!hasNextPage) {
-            // Add an empty reward to indicate the end of data and send all rewards to the activity
-            currentShownRewards.add(Reward.empty())
+            currentShownRewards.add(TimelineReward(RewardTimelineType.END_OF_LIST, null))
             onEndOfData.postValue(currentShownRewards)
         }
     }

--- a/app/src/main/java/com/weatherxm/usecases/RewardsUseCase.kt
+++ b/app/src/main/java/com/weatherxm/usecases/RewardsUseCase.kt
@@ -10,6 +10,8 @@ import com.weatherxm.data.Failure
 import com.weatherxm.data.RewardDetails
 import com.weatherxm.data.repository.RewardsRepository
 import com.weatherxm.ui.common.BoostDetailInfo
+import com.weatherxm.ui.common.RewardTimelineType
+import com.weatherxm.ui.common.TimelineReward
 import com.weatherxm.ui.common.UIBoost
 import com.weatherxm.ui.common.UIRewardsTimeline
 import com.weatherxm.ui.common.empty
@@ -55,6 +57,8 @@ class RewardsUseCaseImpl(
                     it.data.filter { tx ->
                         // Keep only transactions that have a reward for this device
                         tx.baseReward != null
+                    }.map {
+                        TimelineReward(RewardTimelineType.DATA, it)
                     },
                     it.hasNextPage
                 )

--- a/app/src/main/java/com/weatherxm/usecases/RewardsUseCase.kt
+++ b/app/src/main/java/com/weatherxm/usecases/RewardsUseCase.kt
@@ -22,9 +22,7 @@ import java.time.ZonedDateTime
 interface RewardsUseCase {
     suspend fun getRewardsTimeline(
         deviceId: String,
-        page: Int?,
-        fromDate: String?,
-        toDate: String? = null
+        page: Int?
     ): Either<Failure, UIRewardsTimeline>
 
     suspend fun getRewardDetails(
@@ -44,15 +42,11 @@ class RewardsUseCaseImpl(
 ) : RewardsUseCase {
     override suspend fun getRewardsTimeline(
         deviceId: String,
-        page: Int?,
-        fromDate: String?,
-        toDate: String?
+        page: Int?
     ): Either<Failure, UIRewardsTimeline> {
         return repository.getRewardsTimeline(
             deviceId = deviceId,
-            page = page,
-            fromDate = fromDate,
-            toDate = toDate
+            page = page
         ).map {
             if (it.data.isEmpty()) {
                 UIRewardsTimeline(listOf(), reachedTotal = true)

--- a/app/src/main/res/layout/activity_rewards_list.xml
+++ b/app/src/main/res/layout/activity_rewards_list.xml
@@ -5,6 +5,7 @@
     android:id="@+id/root"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
+    android:clipChildren="false"
     android:animateLayoutChanges="true"
     android:fitsSystemWindows="false">
 
@@ -27,6 +28,7 @@
     <androidx.constraintlayout.widget.ConstraintLayout
         android:layout_width="match_parent"
         android:layout_height="match_parent"
+        android:clipChildren="false"
         app:layout_behavior="com.google.android.material.appbar.AppBarLayout$ScrollingViewBehavior">
 
         <androidx.recyclerview.widget.RecyclerView
@@ -58,13 +60,23 @@
     <!-- Empty -->
 
     <com.weatherxm.ui.components.EmptyView
-        android:id="@+id/empty"
+        android:id="@+id/status"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
         android:layout_gravity="center"
         android:padding="@dimen/padding_extra_large"
         android:visibility="gone"
         app:empty_animation="@raw/anim_loading"
+        tools:visibility="visible" />
+
+    <com.weatherxm.ui.components.EmptyRewardsCardView
+        android:id="@+id/emptyRewardsCard"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginHorizontal="@dimen/margin_large"
+        android:layout_marginTop="@dimen/margin_large"
+        android:visibility="gone"
+        app:layout_behavior="com.google.android.material.appbar.AppBarLayout$ScrollingViewBehavior"
         tools:visibility="visible" />
 
 </androidx.coordinatorlayout.widget.CoordinatorLayout>

--- a/app/src/main/res/layout/list_item_reward.xml
+++ b/app/src/main/res/layout/list_item_reward.xml
@@ -5,9 +5,7 @@
     android:id="@+id/root"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
-    android:clipChildren="false"
-    android:clipToPadding="false"
-    android:paddingHorizontal="@dimen/padding_normal">
+    android:clipChildren="false">
 
     <View
         android:id="@+id/prev_line"
@@ -53,8 +51,48 @@
         android:id="@+id/mainCard"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
+        android:layout_marginHorizontal="@dimen/margin_normal"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintHeight_percent="0.6"
         app:layout_constraintTop_toBottomOf="@id/current_line" />
+
+    <com.google.android.material.card.MaterialCardView
+        android:id="@+id/endOfDataCard"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginHorizontal="@dimen/margin_normal"
+        android:visibility="gone"
+        app:cardElevation="@dimen/elevation_small"
+        app:contentPadding="@dimen/padding_large"
+        app:layout_constraintTop_toBottomOf="@id/current_line">
+
+        <androidx.constraintlayout.widget.ConstraintLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content">
+
+            <ImageView
+                android:id="@+id/timelineEndIcon"
+                android:layout_width="20dp"
+                android:layout_height="20dp"
+                android:src="@drawable/ic_checkmark_hex_filled"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toTopOf="parent"
+                app:tint="@color/darkGrey"
+                tools:ignore="contentDescription" />
+
+            <com.google.android.material.textview.MaterialTextView
+                android:id="@+id/endOfDataText"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="@dimen/margin_small"
+                android:text="@string/timeline_end_message"
+                android:textAppearance="@style/TextAppearance.WeatherXM.Default.BodyMedium"
+                android:textColor="@color/darkGrey"
+                app:layout_constraintBottom_toBottomOf="@id/timelineEndIcon"
+                app:layout_constraintStart_toEndOf="@id/timelineEndIcon"
+                app:layout_constraintTop_toTopOf="@id/timelineEndIcon" />
+
+        </androidx.constraintlayout.widget.ConstraintLayout>
+    </com.google.android.material.card.MaterialCardView>
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/list_item_reward.xml
+++ b/app/src/main/res/layout/list_item_reward.xml
@@ -56,43 +56,4 @@
         app:layout_constraintHeight_percent="0.6"
         app:layout_constraintTop_toBottomOf="@id/current_line" />
 
-    <com.google.android.material.card.MaterialCardView
-        android:id="@+id/endOfDataCard"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:layout_marginHorizontal="@dimen/margin_normal"
-        android:visibility="gone"
-        app:cardElevation="@dimen/elevation_small"
-        app:contentPadding="@dimen/padding_large"
-        app:layout_constraintTop_toBottomOf="@id/current_line">
-
-        <androidx.constraintlayout.widget.ConstraintLayout
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content">
-
-            <ImageView
-                android:id="@+id/timelineEndIcon"
-                android:layout_width="20dp"
-                android:layout_height="20dp"
-                android:src="@drawable/ic_checkmark_hex_filled"
-                app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toTopOf="parent"
-                app:tint="@color/darkGrey"
-                tools:ignore="contentDescription" />
-
-            <com.google.android.material.textview.MaterialTextView
-                android:id="@+id/endOfDataText"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_marginStart="@dimen/margin_small"
-                android:text="@string/timeline_end_message"
-                android:textAppearance="@style/TextAppearance.WeatherXM.Default.BodyMedium"
-                android:textColor="@color/darkGrey"
-                app:layout_constraintBottom_toBottomOf="@id/timelineEndIcon"
-                app:layout_constraintStart_toEndOf="@id/timelineEndIcon"
-                app:layout_constraintTop_toTopOf="@id/timelineEndIcon" />
-
-        </androidx.constraintlayout.widget.ConstraintLayout>
-    </com.google.android.material.card.MaterialCardView>
-
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/list_item_reward_end_of_data.xml
+++ b/app/src/main/res/layout/list_item_reward_end_of_data.xml
@@ -1,0 +1,75 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/root"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:clipChildren="false">
+
+    <View
+        android:id="@+id/prev_line"
+        android:layout_width="4dp"
+        android:layout_height="24dp"
+        android:layout_marginStart="48dp"
+        android:background="@color/midGrey"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
+
+    <View
+        android:id="@+id/date_point"
+        android:layout_width="12dp"
+        android:layout_height="12dp"
+        android:layout_marginStart="44dp"
+        android:background="@drawable/token_transaction_date_icon"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/prev_line" />
+
+    <View
+        android:id="@+id/current_line"
+        android:layout_width="4dp"
+        android:layout_height="24dp"
+        android:layout_marginStart="48dp"
+        android:background="@color/midGrey"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/date_point" />
+
+    <com.google.android.material.card.MaterialCardView
+        android:id="@+id/endOfDataCard"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginHorizontal="@dimen/margin_normal"
+        app:cardElevation="@dimen/elevation_small"
+        app:contentPadding="@dimen/padding_large"
+        app:layout_constraintTop_toBottomOf="@id/current_line">
+
+        <androidx.constraintlayout.widget.ConstraintLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content">
+
+            <ImageView
+                android:id="@+id/timelineEndIcon"
+                android:layout_width="20dp"
+                android:layout_height="20dp"
+                android:src="@drawable/ic_checkmark_hex_filled"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toTopOf="parent"
+                app:tint="@color/darkGrey"
+                tools:ignore="contentDescription" />
+
+            <com.google.android.material.textview.MaterialTextView
+                android:id="@+id/endOfDataText"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="@dimen/margin_small"
+                android:text="@string/timeline_end_message"
+                android:textAppearance="@style/TextAppearance.WeatherXM.Default.BodyMedium"
+                android:textColor="@color/darkGrey"
+                app:layout_constraintBottom_toBottomOf="@id/timelineEndIcon"
+                app:layout_constraintStart_toEndOf="@id/timelineEndIcon"
+                app:layout_constraintTop_toTopOf="@id/timelineEndIcon" />
+
+        </androidx.constraintlayout.widget.ConstraintLayout>
+    </com.google.android.material.card.MaterialCardView>
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/values/messages.xml
+++ b/app/src/main/res/values/messages.xml
@@ -35,7 +35,7 @@
     <string name="error_claim_device_claiming_error"><![CDATA[Station claiming failed.<br><b>This device is not in claiming mode or the secret provided is invalid.</b><br>If the problem persists, please contact our support team at <a>support.weatherxm.com</a>]]></string>
     <string name="error_claim_gps_failed">Could not get current location.</string>
     <string name="error_cell_devices_no_data">Failed to get the cell devices.</string>
-    <string name="error_transactions_no_data">Oops! $WXM transactions could not be fetched.</string>
+    <string name="error_rewards_no_data">Oops! $WXM rewards could not be fetched.</string>
     <string name="error_open_website_support_cannot_open_url">Oops! Could not open %s</string>
     <string name="error_cannot_open_play_store">Oops! Could not open Play Store.</string>
     <string name="error_cannot_open_app_settings">Oops! Could not open App Settings.</string>
@@ -61,6 +61,5 @@
     <string name="warn_validation_invalid_friendly_name">Invalid Friendly Name</string>
 
     <!-- Info Messages -->
-    <string name="info_come_back_later">Please come back later!</string>
     <string name="session_expired">Your session has expired. Please login again.</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -229,7 +229,7 @@
     <!-- Rewards -->
     <string name="title_reward_timeline">Reward Timeline</string>
     <string name="view_timeline">View Timeline</string>
-    <string name="no_transactions_title">Oh, no! No transactions yet?</string>
+    <string name="timeline_end_message">You can’t view more than 90 days.</string>
     <string name="rewards">Rewards</string>
     <string name="wxm_amount">%s $WXM</string>
     <string name="reward">+ %s $WXM</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -229,7 +229,7 @@
     <!-- Rewards -->
     <string name="title_reward_timeline">Reward Timeline</string>
     <string name="view_timeline">View Timeline</string>
-    <string name="timeline_end_message">You can’t view more than 90 days.</string>
+    <string name="timeline_end_message">You’ve reached the end of the Timeline.</string>
     <string name="rewards">Rewards</string>
     <string name="wxm_amount">%s $WXM</string>
     <string name="reward">+ %s $WXM</string>


### PR DESCRIPTION
## **Why?**
Limit timeline data to 3 months in the past. Some UI fixes and added an end of data card.

### **How?**
- Create a new object TimelineReward for a better approach based on Pantelis comment below. 
- When we get to the end of the data, we add a new `TimelineReward` with `type = END_OF_DATA` at the end of the list which the adapter handles to show the respective "end of data card" at the end of the list.
- Removed the functionality of `timezone`, `fromDate`, `toDate` in the API call in the ViewModel and UseCase as these are not needed anymore and it's part of the `Repository` to create the proper `fromDate` for the DataSource etc.

### **Testing**
Check any station's reward timeline and ensure everything is OK and you can see the "End of data" card at the 3-months mark.