### PR TITLE
FE-753 Feature/low battery station details

### DIFF
--- a/app/src/main/java/com/weatherxm/ui/Navigator.kt
+++ b/app/src/main/java/com/weatherxm/ui/Navigator.kt
@@ -385,8 +385,8 @@ class Navigator(private val analytics: Analytics) {
         }
     }
 
-    fun showDeviceAlerts(fragment: Fragment, device: UIDevice?) {
-        fragment.context?.let {
+    fun showDeviceAlerts(context: Context?, device: UIDevice?) {
+        context?.let {
             it.startActivity(
                 Intent(it, DeviceAlertsActivity::class.java)
                     .addFlags(Intent.FLAG_ACTIVITY_SINGLE_TOP or Intent.FLAG_ACTIVITY_CLEAR_TOP)

--- a/app/src/main/java/com/weatherxm/ui/devicealerts/DeviceAlertsActivity.kt
+++ b/app/src/main/java/com/weatherxm/ui/devicealerts/DeviceAlertsActivity.kt
@@ -1,6 +1,7 @@
 package com.weatherxm.ui.devicealerts
 
 import android.os.Bundle
+import com.google.firebase.analytics.FirebaseAnalytics
 import com.weatherxm.R
 import com.weatherxm.data.DeviceProfile
 import com.weatherxm.databinding.ActivityDeviceAlertsBinding
@@ -70,15 +71,20 @@ class DeviceAlertsActivity : BaseActivity(), DeviceAlertListener {
     }
 
     override fun onContactSupportClicked() {
-        navigator.openSupportCenter(this, Analytics.ParamValue.DEVICE_ALERTS.paramValue)
+        navigator.openSupportCenter(this, Analytics.ParamValue.STATION_OFFLINE.paramValue)
         finish()
     }
 
     override fun onLowBatteryReadMoreClicked() {
-        if (device?.profile == DeviceProfile.M5) {
-            navigator.openWebsite(this, getString(R.string.docs_url_low_battery_m5))
-        } else if (device?.profile == DeviceProfile.Helium) {
-            navigator.openWebsite(this, getString(R.string.docs_url_low_battery_helium))
+        val url = if (device?.profile == DeviceProfile.M5) {
+            getString(R.string.docs_url_low_battery_m5)
+        } else {
+            getString(R.string.docs_url_low_battery_helium)
         }
+        navigator.openWebsite(this, url)
+        analytics.trackEventSelectContent(
+            Analytics.ParamValue.WEB_DOCUMENTATION.paramValue,
+            Pair(FirebaseAnalytics.Param.ITEM_ID, url)
+        )
     }
 }

--- a/app/src/main/java/com/weatherxm/ui/devicedetails/DeviceDetailsActivity.kt
+++ b/app/src/main/java/com/weatherxm/ui/devicedetails/DeviceDetailsActivity.kt
@@ -287,7 +287,6 @@ class DeviceDetailsActivity : BaseActivity() {
         }
         if (alertsWithoutOffline.size > 1) {
             binding.alertChip.text = getString(R.string.issues, alertsWithoutOffline.size)
-            binding.alertChip.setVisible(true)
             setupAlertChipClickListener(null)
         } else if (alertsWithoutOffline.size == 1) {
             if (alertsWithoutOffline[0].alert == DeviceAlertType.NEEDS_UPDATE) {
@@ -302,10 +301,8 @@ class DeviceDetailsActivity : BaseActivity() {
                 binding.alertChip.text = getString(R.string.low_battery)
                 setupAlertChipClickListener(Analytics.ParamValue.LOW_BATTERY_ID.paramValue)
             }
-            binding.alertChip.setVisible(true)
-        } else {
-            binding.alertChip.setVisible(false)
         }
+        binding.alertChip.setVisible(alertsWithoutOffline.isNotEmpty())
     }
 
     private fun setupAlertChipClickListener(analyticsItemId: String?) {

--- a/app/src/main/java/com/weatherxm/ui/devicedetails/current/CurrentFragment.kt
+++ b/app/src/main/java/com/weatherxm/ui/devicedetails/current/CurrentFragment.kt
@@ -126,69 +126,32 @@ class CurrentFragment : BaseFragment() {
     }
 
     private fun setAlerts(device: UIDevice) {
-        binding.multipleAlertsView.setVisible(false)
-        binding.warningView.setVisible(false)
-        binding.errorView.setVisible(false)
-        binding.currentWeatherCardWithErrorContainer.setCardStroke(R.color.transparent, 0)
-        if (device.alerts.size > 1) {
-            binding.multipleAlertsView.action {
-                navigator.showDeviceAlerts(this, device)
-            }
-            if (device.hasErrors()) {
-                binding.multipleAlertsView
-                    .title(getString(R.string.issues_detected, device.alerts.size))
-                    .setBackground(R.color.errorTint)
-                    .setIcon(R.drawable.ic_error_hex_filled)
-                binding.currentWeatherCardWithErrorContainer.setCardStroke(R.color.error, 2)
-            } else {
-                binding.multipleAlertsView
-                    .title(getString(R.string.alerts_detected, device.alerts.size))
-                    .setBackground(R.color.warningTint)
-                    .setIcon(R.drawable.ic_warning_hex_filled)
-                binding.currentWeatherCardWithErrorContainer.setCardStroke(R.color.error, 2)
-            }
-            binding.multipleAlertsView.setVisible(true)
-        } else if (device.alerts.size == 1) {
-            binding.multipleAlertsView.setVisible(false)
-            when (device.alerts[0].alert) {
-                DeviceAlertType.OFFLINE -> onDeviceOffline(device.relation, device.profile)
-                DeviceAlertType.LOW_BATTERY -> {
-                    // TODO: Implement this.
-                }
-                DeviceAlertType.NEEDS_UPDATE -> {
-                    binding.currentWeatherCardWithErrorContainer.setCardStroke(R.color.warning, 2)
-                    binding.warningView.action(getString(R.string.update_station_now)) {
-                        analytics.trackEventPrompt(
-                            Analytics.ParamValue.OTA_AVAILABLE.paramValue,
-                            Analytics.ParamValue.WARN.paramValue,
-                            Analytics.ParamValue.ACTION.paramValue
-                        )
-                        navigator.showDeviceHeliumOTA(this, device, false)
-                    }.setVisible(true)
-                }
-            }
+        if (device.alerts.firstOrNull { it.alert == DeviceAlertType.OFFLINE } != null) {
+            onDeviceOfflineAlert(device.relation, device.profile)
+        } else {
+            binding.currentWeatherCardWithErrorContainer.setCardStroke(R.color.transparent, 0)
         }
     }
 
-    private fun onDeviceOffline(relation: DeviceRelation?, profile: DeviceProfile?) {
+    private fun onDeviceOfflineAlert(relation: DeviceRelation?, profile: DeviceProfile?) {
         if (relation == DeviceRelation.OWNED && profile == DeviceProfile.M5) {
             val m5TroubleshootingUrl = getString(R.string.troubleshooting_m5_url)
-            binding.errorView.htmlMessage(
+            binding.alert.htmlMessage(
                 getString(R.string.error_user_device_offline, m5TroubleshootingUrl)
             ) {
                 navigator.openWebsite(context, getString(R.string.troubleshooting_m5_url))
             }
         } else if (relation == DeviceRelation.OWNED && profile == DeviceProfile.Helium) {
             val heliumTroubleshootingUrl = getString(R.string.troubleshooting_helium_url)
-            binding.errorView.htmlMessage(
+            binding.alert.htmlMessage(
                 getString(R.string.error_user_device_offline, heliumTroubleshootingUrl)
             ) {
                 navigator.openWebsite(context, heliumTroubleshootingUrl)
             }
         } else {
-            binding.errorView.message(getString(R.string.no_data_message_public_device))
+            binding.alert.message(getString(R.string.no_data_message_public_device))
         }
         binding.currentWeatherCardWithErrorContainer.setCardStroke(R.color.error, 2)
-        binding.errorView.setVisible(true)
+        binding.alert.setVisible(true)
     }
 }

--- a/app/src/main/java/com/weatherxm/ui/home/devices/DevicesFragment.kt
+++ b/app/src/main/java/com/weatherxm/ui/home/devices/DevicesFragment.kt
@@ -216,14 +216,23 @@ class DevicesFragment : BaseFragment(), DeviceListener {
     }
 
     override fun onLowBatteryReadMoreClicked(device: UIDevice) {
-        if (device.profile == DeviceProfile.M5) {
-            navigator.openWebsite(context, getString(R.string.docs_url_low_battery_m5))
+        val url = if (device.profile == DeviceProfile.M5) {
+            getString(R.string.docs_url_low_battery_m5)
         } else {
-            navigator.openWebsite(context, getString(R.string.docs_url_low_battery_helium))
+            getString(R.string.docs_url_low_battery_helium)
         }
+        navigator.openWebsite(context, url)
+        analytics.trackEventSelectContent(
+            Analytics.ParamValue.WEB_DOCUMENTATION.paramValue,
+            Pair(FirebaseAnalytics.Param.ITEM_ID, url)
+        )
     }
 
     override fun onAlertsClicked(device: UIDevice) {
+        analytics.trackEventSelectContent(
+            Analytics.ParamValue.VIEW_ALL.paramValue,
+            Pair(FirebaseAnalytics.Param.ITEM_ID, Analytics.ParamValue.MULTIPLE_ISSUES.paramValue)
+        )
         navigator.showDeviceAlerts(context, device)
     }
 

--- a/app/src/main/java/com/weatherxm/ui/home/devices/DevicesFragment.kt
+++ b/app/src/main/java/com/weatherxm/ui/home/devices/DevicesFragment.kt
@@ -216,7 +216,7 @@ class DevicesFragment : BaseFragment(), DeviceListener {
     }
 
     override fun onLowBatteryReadMoreClicked(device: UIDevice) {
-        if(device.profile == DeviceProfile.M5) {
+        if (device.profile == DeviceProfile.M5) {
             navigator.openWebsite(context, getString(R.string.docs_url_low_battery_m5))
         } else {
             navigator.openWebsite(context, getString(R.string.docs_url_low_battery_helium))
@@ -224,7 +224,7 @@ class DevicesFragment : BaseFragment(), DeviceListener {
     }
 
     override fun onAlertsClicked(device: UIDevice) {
-        navigator.showDeviceAlerts(this, device)
+        navigator.showDeviceAlerts(context, device)
     }
 
     override fun onFollowBtnClicked(device: UIDevice) {

--- a/app/src/main/java/com/weatherxm/usecases/DeviceDetailsUseCaseImpl.kt
+++ b/app/src/main/java/com/weatherxm/usecases/DeviceDetailsUseCaseImpl.kt
@@ -53,12 +53,17 @@ class DeviceDetailsUseCaseImpl(
                         id, assignedFirmware
                     ) && isOwned()
                     val alerts = mutableListOf<DeviceAlert>()
-                    if (shouldShowOTAPrompt && profile == Helium && needsUpdate()) {
-                        alerts.add(DeviceAlert.createWarning(DeviceAlertType.NEEDS_UPDATE))
-                    }
-
                     if (isActive == false) {
                         alerts.add(DeviceAlert.createError(DeviceAlertType.OFFLINE))
+                    }
+
+                    // FIXME: Revert this testing code before going to production
+                    if (device.isOwned()) {
+                        alerts.add(DeviceAlert.createWarning(DeviceAlertType.LOW_BATTERY))
+                    }
+
+                    if (shouldShowOTAPrompt && profile == Helium && needsUpdate()) {
+                        alerts.add(DeviceAlert.createWarning(DeviceAlertType.NEEDS_UPDATE))
                     }
                     this.alerts = alerts.sortedByDescending { alert ->
                         alert.severity

--- a/app/src/main/java/com/weatherxm/usecases/DeviceDetailsUseCaseImpl.kt
+++ b/app/src/main/java/com/weatherxm/usecases/DeviceDetailsUseCaseImpl.kt
@@ -57,8 +57,7 @@ class DeviceDetailsUseCaseImpl(
                         alerts.add(DeviceAlert.createError(DeviceAlertType.OFFLINE))
                     }
 
-                    // FIXME: Revert this testing code before going to production
-                    if (device.isOwned()) {
+                    if (device.hasLowBattery() && device.isOwned()) {
                         alerts.add(DeviceAlert.createWarning(DeviceAlertType.LOW_BATTERY))
                     }
 

--- a/app/src/main/java/com/weatherxm/util/Analytics.kt
+++ b/app/src/main/java/com/weatherxm/util/Analytics.kt
@@ -195,7 +195,6 @@ class Analytics(
         NETWORK_STATS("network_stats"),
         DEVICE_DETAILS_FOLLOW("Device Details Follow"),
         DEVICE_DETAILS_SHARE("Device Details Share"),
-        DEVICE_DETAILS_ADDRESS("Device Details Address"),
         DEVICE_LIST_FOLLOW("Device List Follow"),
         EXPLORER_DEVICE_LIST_FOLLOW("Explorer Device List Follow"),
         FOLLOW("follow"),
@@ -223,12 +222,21 @@ class Analytics(
         OFF("off"),
         APP_SURVEY("App Survey"),
         USER_RESEARCH_PANEL("User Research Panel"),
-        WEB_DOCUMENTATION("WEB_DOCUMENTATION"),
+        WEB_DOCUMENTATION("Web Documentation"),
         INFO_DAILY_REWARDS("info_daily_rewards"),
         INFO_QOD("info_qod"),
         INFO_POL("info_pol"),
         INFO_CELL_POSITION("info_cell_position"),
-        INFO_CELL_CAPACITY("info_cell_capacity")
+        INFO_CELL_CAPACITY("info_cell_capacity"),
+        STATION_OFFLINE("station_offline"),
+        VIEW_ALL("View all"),
+        MULTIPLE_ISSUES("multiple_issue"),
+        STATION_DETAILS_CHIP("Station Details Chip"),
+        OTA_UPDATE_ID("ota_update"),
+        LOW_BATTERY_ID("low_battery"),
+        STATION_REGION_ID("station_region"),
+        REGION("Region"),
+        WARNINGS("Warnings")
     }
 
     // Custom Param Names

--- a/app/src/main/res/layout/activity_device_details.xml
+++ b/app/src/main/res/layout/activity_device_details.xml
@@ -81,41 +81,58 @@
                     tools:src="@drawable/ic_favorite"
                     tools:tint="@color/follow_heart_color" />
 
-                <com.google.android.material.chip.Chip
-                    android:id="@+id/address"
-                    style="@style/Widget.WeatherXM.Chip.Status"
-                    android:layout_width="wrap_content"
+                <HorizontalScrollView
+                    android:layout_width="match_parent"
                     android:layout_height="wrap_content"
                     android:layout_marginTop="@dimen/margin_small"
-                    android:ellipsize="end"
-                    app:chipBackgroundColor="@color/blueTint"
-                    app:chipIcon="@drawable/ic_hex"
-                    app:chipIconSize="12dp"
-                    app:chipIconTint="@color/colorOnSurface"
-                    app:layout_constrainedWidth="true"
-                    app:layout_constraintEnd_toStartOf="@id/status"
-                    app:layout_constraintHorizontal_bias="0"
-                    app:layout_constraintHorizontal_chainStyle="packed"
-                    app:layout_constraintStart_toStartOf="parent"
-                    app:layout_constraintTop_toBottomOf="@id/public_name"
-                    tools:ignore="KeyboardInaccessibleWidget"
-                    tools:text="Athens, GR" />
+                    android:scrollbars="none"
+                    app:layout_constraintTop_toBottomOf="@id/public_name">
 
-                <com.google.android.material.chip.Chip
-                    android:id="@+id/status"
-                    style="@style/Widget.WeatherXM.Chip.Status"
-                    android:layout_width="wrap_content"
-                    android:layout_height="0dp"
-                    android:layout_marginStart="@dimen/margin_small"
-                    android:layout_marginTop="@dimen/margin_small"
-                    app:layout_constraintEnd_toEndOf="parent"
-                    app:layout_constraintStart_toEndOf="@id/address"
-                    app:layout_constraintTop_toBottomOf="@id/public_name"
-                    tools:chipBackgroundColor="@color/status_chip_background_online"
-                    tools:chipIcon="@drawable/ic_wifi"
-                    tools:chipIconTint="@color/status_chip_content_online"
-                    tools:text="5 mins ago"
-                    tools:textColor="@color/status_chip_content_online" />
+                    <com.google.android.material.chip.ChipGroup
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:scrollbars="none">
+
+                        <com.google.android.material.chip.Chip
+                            android:id="@+id/alertChip"
+                            style="@style/Widget.WeatherXM.Chip.Status"
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            app:chipBackgroundColor="@color/warningTint"
+                            app:chipCornerRadius="@dimen/radius_small"
+                            app:chipIcon="@drawable/ic_warning_hex_filled"
+                            app:chipIconTint="@color/warning"
+                            tools:text="@string/update_required" />
+
+                        <com.google.android.material.chip.Chip
+                            android:id="@+id/status"
+                            style="@style/Widget.WeatherXM.Chip.Status"
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            app:chipCornerRadius="@dimen/radius_small"
+                            tools:chipBackgroundColor="@color/status_chip_background_online"
+                            tools:chipIcon="@drawable/ic_wifi"
+                            tools:chipIconTint="@color/status_chip_content_online"
+                            tools:text="5 mins ago"
+                            tools:textColor="@color/status_chip_content_online" />
+
+                        <com.google.android.material.chip.Chip
+                            android:id="@+id/address"
+                            style="@style/Widget.WeatherXM.Chip.Status"
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:layout_marginTop="@dimen/margin_small"
+                            android:ellipsize="end"
+                            app:chipBackgroundColor="@color/blueTint"
+                            app:chipCornerRadius="@dimen/radius_small"
+                            app:chipIcon="@drawable/ic_hex"
+                            app:chipIconSize="12dp"
+                            app:chipIconTint="@color/colorOnSurface"
+                            tools:ignore="KeyboardInaccessibleWidget"
+                            tools:text="Athens, GR" />
+
+                    </com.google.android.material.chip.ChipGroup>
+                </HorizontalScrollView>
 
             </androidx.constraintlayout.widget.ConstraintLayout>
 

--- a/app/src/main/res/layout/fragment_device_details_current.xml
+++ b/app/src/main/res/layout/fragment_device_details_current.xml
@@ -86,7 +86,7 @@
                     </com.google.android.material.card.MaterialCardView>
 
                     <com.weatherxm.ui.components.MessageCardView
-                        android:id="@+id/errorView"
+                        android:id="@+id/alert"
                         android:layout_width="match_parent"
                         android:layout_height="wrap_content"
                         android:layout_marginTop="-16dp"
@@ -99,31 +99,6 @@
                         app:message_includes_close_button="false"
                         app:message_title="@string/station_offline"
                         tools:visibility="visible" />
-
-                    <com.weatherxm.ui.components.MessageCardView
-                        android:id="@+id/warningView"
-                        android:layout_width="match_parent"
-                        android:layout_height="wrap_content"
-                        android:layout_marginTop="-16dp"
-                        android:background="@color/warningTint"
-                        android:elevation="0dp"
-                        android:paddingTop="16dp"
-                        android:visibility="gone"
-                        app:message_background_tint="@color/warningTint"
-                        app:message_icon="@drawable/ic_warning_hex_filled"
-                        app:message_includes_close_button="false"
-                        app:message_message="@string/updated_needed_desc"
-                        app:message_title="@string/updated_needed_title" />
-
-                    <com.weatherxm.ui.components.MultipleAlertsCardView
-                        android:id="@+id/multipleAlertsView"
-                        android:layout_width="match_parent"
-                        android:layout_height="wrap_content"
-                        android:layout_marginTop="-16dp"
-                        android:background="@color/errorTint"
-                        android:elevation="0dp"
-                        android:paddingTop="16dp"
-                        android:visibility="gone" />
                 </LinearLayout>
 
             </com.google.android.material.card.MaterialCardView>

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -1,5 +1,6 @@
 <resources xmlns:tools="http://schemas.android.com/tools">
     <!-- Default screen margins, per the Android Design guidelines. -->
+    <dimen name="radius_small">8dp</dimen>
     <dimen name="radius_medium">10dp</dimen>
     <dimen name="radius_large">20dp</dimen>
     <dimen name="radius_extra_large">30dp</dimen>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -536,9 +536,11 @@
 
     <!-- Alerts -->
     <string name="alerts">Alerts</string>
+    <string name="issues">%d issues</string>
     <string name="issues_detected">%d issues detected</string>
     <string name="alerts_detected">%d alerts detected</string>
     <string name="station_offline_alert_message">The station is offline. Check that it has batteries and internet connection. If the problem persists, contact our support team.</string>
+    <string name="update_required">Update Required</string>
     <string name="low_battery">Low Battery</string>
     <string name="low_battery_desc">Your station is reporting low battery. This may lead to data gaps at night, or in low-sunlight conditions and, eventually, lose rewards. Read more on how to replace your station batteries.</string>
 


### PR DESCRIPTION
## **Why?**
Integrate low battery warning in station details.

### **How?**
- Introduce the new `Chip` in the layout file, along with `ChipGroup` and `HorizontalScrollView`.
- Created a new function in `DeviceDetailsActivity` named `setAlerts` which handles the text/visibility of this "alert" `Chip`
- Removed the overflow cards below the weather card except the `offline` one where we will keep the same logic.
- When the device is offline make the status chip clickable, upon click the app navigates to the Alert screen.
- Add the respective code in `DeviceDetailsUseCaseImpl` to return the "Low Battery" alert (currently will return it **in all** owned devices as the testing code is there but marked with a `#FIXME` comment)

### **Testing**
Ensure that all 3 different type of alerts are shown correctly in the station details screen with any possible combination,