### PR TITLE
FE-794 Push the layout up when keyboard is shown on webview activity

### DIFF
--- a/app/src/main/java/com/weatherxm/ui/rewardsclaim/RewardsClaimActivity.kt
+++ b/app/src/main/java/com/weatherxm/ui/rewardsclaim/RewardsClaimActivity.kt
@@ -32,6 +32,7 @@ class RewardsClaimActivity : BaseActivity() {
         setContentView(binding.root)
 
         binding.root.applyInsets()
+        binding.root.setFitsSystemWindows(true)
         binding.toolbar.title = getString(R.string.claim_rewards)
         binding.toolbar.setNavigationOnClickListener {
             onBackPressedDispatcher.onBackPressed()

--- a/app/src/main/res/layout/activity_webview.xml
+++ b/app/src/main/res/layout/activity_webview.xml
@@ -4,8 +4,7 @@
     android:id="@+id/root"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:animateLayoutChanges="true"
-    android:fitsSystemWindows="false">
+    android:animateLayoutChanges="true">
 
     <com.google.android.material.appbar.AppBarLayout
         android:id="@+id/app_bar"


### PR DESCRIPTION
## **Why?**
Push the layout up when keyboard is shown on webview activity

### **How?**
1. Removed the `android:fitsSystemWindows="false"` from the webview XML file.
Added `binding.root.setFitsSystemWindows(true)` in the Rewards Claiming activity.


### **Testing**
Try a claim and ensure the layout gets pushed up when keyboard is shown when clicking the "amount" section.

### **Screenshots (if applicable)**
![e____a](https://github.com/WeatherXM/wxm-android/assets/19330987/21585198-5017-4514-8dd0-fa7a3b6e774e)