### PR TITLE
FE-800 Fix reward issues message showing "minor" when there is an error

### DIFF
--- a/app/src/main/java/com/weatherxm/ui/components/DailyRewardsCardView.kt
+++ b/app/src/main/java/com/weatherxm/ui/components/DailyRewardsCardView.kt
@@ -110,33 +110,30 @@ open class DailyRewardsCardView : LinearLayout, KoinComponent {
         useShortAnnotationText: Boolean,
         onViewDetails: (() -> Unit)? = null
     ) {
-        val severityLevels = annotations?.map {
-            it.severityLevel
-        }
-        val annotationsSize = annotations?.size ?: 0
+        val sortedSeverities = annotations?.map { it.severityLevel }?.sortedByDescending { it }
 
-        if (severityLevels.isNullOrEmpty()) {
+        if (sortedSeverities.isNullOrEmpty()) {
             binding.annotationCard.setVisible(false)
             binding.parentCard.strokeWidth = 0
             return
         }
 
-        if (severityLevels.contains(SeverityLevel.ERROR)) {
+        if (sortedSeverities.contains(SeverityLevel.ERROR)) {
             onAnnotation(
                 SeverityLevel.ERROR,
-                getAnnotationMessage(useShortAnnotationText, severityLevels, annotationsSize),
+                getAnnotationMessage(useShortAnnotationText, sortedSeverities, annotations.size),
                 onViewDetails
             )
-        } else if (severityLevels.contains(SeverityLevel.WARNING)) {
+        } else if (sortedSeverities.contains(SeverityLevel.WARNING)) {
             onAnnotation(
                 SeverityLevel.WARNING,
-                getAnnotationMessage(useShortAnnotationText, severityLevels, annotationsSize),
+                getAnnotationMessage(useShortAnnotationText, sortedSeverities, annotations.size),
                 onViewDetails
             )
-        } else if (severityLevels.contains(SeverityLevel.INFO)) {
+        } else if (sortedSeverities.contains(SeverityLevel.INFO)) {
             onAnnotation(
                 SeverityLevel.INFO,
-                getAnnotationMessage(useShortAnnotationText, severityLevels, annotationsSize),
+                getAnnotationMessage(useShortAnnotationText, sortedSeverities, annotations.size),
                 onViewDetails
             )
         }
@@ -144,21 +141,21 @@ open class DailyRewardsCardView : LinearLayout, KoinComponent {
 
     private fun getAnnotationMessage(
         useShortAnnotationText: Boolean,
-        severityLevels: List<SeverityLevel?>,
+        sortedSeverities: List<SeverityLevel?>,
         annotationsSize: Int
     ): String {
         return if (!useShortAnnotationText) {
-            if (severityLevels.contains(SeverityLevel.ERROR)) {
+            if (sortedSeverities.contains(SeverityLevel.ERROR)) {
                 context.getString(R.string.annotation_error_text)
-            } else if (severityLevels.contains(SeverityLevel.WARNING)) {
+            } else if (sortedSeverities.contains(SeverityLevel.WARNING)) {
                 context.getString(R.string.annotation_warn_text)
             } else {
                 context.getString(R.string.annotation_info_text)
             }
         } else {
-            if (severityLevels.contains(SeverityLevel.INFO) && annotationsSize > 1) {
+            if (sortedSeverities[0] == SeverityLevel.INFO && annotationsSize > 1) {
                 context.getString(R.string.annotation_issues_info_text, annotationsSize)
-            } else if (severityLevels.contains(SeverityLevel.INFO) && annotationsSize <= 1) {
+            } else if (sortedSeverities[0] == SeverityLevel.INFO && annotationsSize <= 1) {
                 context.getString(R.string.annotation_issue_info_text)
             } else if (annotationsSize > 1) {
                 context.getString(R.string.annotation_issues_warn_error_text, annotationsSize)


### PR DESCRIPTION
## **Why?**
Fix reward issues message showing "minor" when there is an error

### **How?**
Sort the severities before checking against them if the most important one is an info (minor) or an error/warning (non-minor).

### **Testing**
Test against various stations that have issues that the correct message is shown in the rewards tab and in the timeline (e.g. minor vs non-minor etc)
