### PR TITLE
FE-803 Fix unexpected stroke on devices list

### DIFF
--- a/app/src/main/java/com/weatherxm/ui/home/devices/DevicesAdapter.kt
+++ b/app/src/main/java/com/weatherxm/ui/home/devices/DevicesAdapter.kt
@@ -143,6 +143,7 @@ class DeviceAdapter(private val deviceListener: DeviceListener) :
             } else {
                 binding.multipleAlerts.setVisible(false)
                 binding.alert.setVisible(false)
+                binding.root.strokeWidth = 0
             }
         }
 


### PR DESCRIPTION
## **Why?**
When there are >1 devices with alerts and others with no alerts, clear the stroke due to unexpected results on refreshing (e.g. stroke showing on devices with no alerts).

### **How?**
`binding.root.strokeWidth = 0` when there are no alerts.

### **Testing**
Have in your devices list stations with alerts and no alerts, swipe down to refresh and ensure that the stroke is not visible in your "OK" stations.