### PR TITLE
FE-845 FE-844 Feature/internal release fixes

### DIFF
--- a/app/src/main/java/com/weatherxm/ui/common/Views.kt
+++ b/app/src/main/java/com/weatherxm/ui/common/Views.kt
@@ -46,6 +46,7 @@ import androidx.core.text.toHtml
 import androidx.core.text.toSpanned
 import androidx.core.view.isVisible
 import androidx.fragment.app.Fragment
+import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
 import com.airbnb.lottie.LottieAnimationView
 import com.google.android.material.card.MaterialCardView
@@ -401,6 +402,11 @@ fun MaterialCardView.setBoostFallbackBackground() {
 private fun Context.hideKeyboard(view: View) {
     val inputMethodManager = getSystemService(Activity.INPUT_METHOD_SERVICE) as InputMethodManager
     inputMethodManager.hideSoftInputFromWindow(view.windowToken, 0)
+}
+
+fun RecyclerView.moveItemToCenter(position: Int, parentWidth: Int, itemWidth: Int) {
+    val centerOfScreen: Int = parentWidth / 2 - (itemWidth / 2)
+    (layoutManager as LinearLayoutManager).scrollToPositionWithOffset(position, centerOfScreen)
 }
 
 @Suppress("EmptyFunctionBlock")

--- a/app/src/main/java/com/weatherxm/ui/deviceforecast/DailyTileForecastAdapter.kt
+++ b/app/src/main/java/com/weatherxm/ui/deviceforecast/DailyTileForecastAdapter.kt
@@ -17,6 +17,7 @@ import java.time.LocalDate
 
 class DailyTileForecastAdapter(
     private var selectedDate: LocalDate,
+    private val onNewSelectedPosition: (Int, Int) -> Unit,
     private val onClickListener: (UIForecastDay) -> Unit
 ) : ListAdapter<UIForecastDay, DailyTileForecastAdapter.DailyTileViewHolder>(
     UIForecastDayDiffCallback()
@@ -64,6 +65,7 @@ class DailyTileForecastAdapter(
                     itemView.context.getColor(R.color.daily_selected_tile)
                 )
                 binding.root.setCardStroke(R.color.colorPrimary, 2)
+                onNewSelectedPosition.invoke(position, binding.root.width)
             } else {
                 binding.root.setCardBackgroundColor(
                     itemView.context.getColor(R.color.daily_unselected_tile)

--- a/app/src/main/java/com/weatherxm/ui/deviceforecast/ForecastDetailsActivity.kt
+++ b/app/src/main/java/com/weatherxm/ui/deviceforecast/ForecastDetailsActivity.kt
@@ -15,6 +15,7 @@ import com.weatherxm.ui.common.UIDevice
 import com.weatherxm.ui.common.UIForecastDay
 import com.weatherxm.ui.common.applyInsets
 import com.weatherxm.ui.common.boldText
+import com.weatherxm.ui.common.moveItemToCenter
 import com.weatherxm.ui.common.parcelable
 import com.weatherxm.ui.common.screenLocation
 import com.weatherxm.ui.common.setColor
@@ -201,15 +202,24 @@ class ForecastDetailsActivity : BaseActivity() {
     }
 
     private fun setupDailyAdapter(forecastDay: UIForecastDay, selectedDayPosition: Int) {
-        dailyAdapter = DailyTileForecastAdapter(forecastDay.date) {
-            analytics.trackEventSelectContent(
-                Analytics.ParamValue.DAILY_CARD.paramValue,
-                Pair(FirebaseAnalytics.Param.ITEM_ID, Analytics.ParamValue.DAILY_DETAILS.paramValue)
-            )
-            // Get selected position before we change it to the new one in order to reset the stroke
-            dailyAdapter.notifyItemChanged(dailyAdapter.getSelectedPosition())
-            updateUI(it)
-        }
+        dailyAdapter = DailyTileForecastAdapter(
+            forecastDay.date,
+            onNewSelectedPosition = { position, width ->
+                binding.dailyTilesRecycler.moveItemToCenter(position, binding.root.width, width)
+            },
+            onClickListener = {
+                analytics.trackEventSelectContent(
+                    Analytics.ParamValue.DAILY_CARD.paramValue,
+                    Pair(
+                        FirebaseAnalytics.Param.ITEM_ID,
+                        Analytics.ParamValue.DAILY_DETAILS.paramValue
+                    )
+                )
+                // Get selected position before we update it in order to reset the stroke
+                dailyAdapter.notifyItemChanged(dailyAdapter.getSelectedPosition())
+                updateUI(it)
+            }
+        )
         binding.dailyTilesRecycler.adapter = dailyAdapter
         dailyAdapter.submitList(model.forecast().forecastDays)
         binding.dailyTilesRecycler.scrollToPosition(selectedDayPosition)

--- a/app/src/main/java/com/weatherxm/usecases/ChartsUseCaseImpl.kt
+++ b/app/src/main/java/com/weatherxm/usecases/ChartsUseCaseImpl.kt
@@ -73,7 +73,8 @@ class ChartsUseCaseImpl(private val context: Context) : ChartsUseCase {
                 } ?: precipProbabilityEntries.add(emptyEntry)
 
                 // Get the wind speed and direction formatted
-                val windSpeedValue = Weather.convertWindSpeed(hourlyWeather.windSpeed)?.toFloat()
+                val windSpeedValue = convertWindSpeed(hourlyWeather.windSpeed)?.toFloat()
+                val windGustValue = convertWindSpeed(hourlyWeather.windGust)?.toFloat()
                 val windDirection: Drawable? =
                     Weather.getWindDirectionDrawable(context, hourlyWeather.windDirection)
                 hourlyWeather.windDirection?.let {
@@ -86,7 +87,7 @@ class ChartsUseCaseImpl(private val context: Context) : ChartsUseCase {
                  * wind speed || wind gust are not null and greater than zero
                  */
                 val shouldShowDirection = windDirection != null &&
-                    ((windSpeedValue ?: 0.0F) > 0 || (hourlyWeather.windGust ?: 0.0F) > 0)
+                    ((windSpeedValue ?: 0.0F) > 0 || (windGustValue ?: 0.0F) > 0)
 
                 windSpeedValue?.let {
                     if (shouldShowDirection) {
@@ -96,8 +97,8 @@ class ChartsUseCaseImpl(private val context: Context) : ChartsUseCase {
                     }
                 } ?: windSpeedEntries.add(emptyEntry)
 
-                hourlyWeather.windGust?.let {
-                    windGustEntries.add(Entry(counter, convertWindSpeed(it) as Float))
+                windGustValue?.let {
+                    windGustEntries.add(Entry(counter, it))
                 } ?: windGustEntries.add(emptyEntry)
 
                 hourlyWeather.pressure?.let {


### PR DESCRIPTION
## **Why?**
1. Fixed a crash in historical screen when using bf as a wind unit.
2. Optimized auto-scrolling on selection in daily tiles in forecast details

### **How?**
- Fixed the crash by proper handling the conversion of wind gust values, the same way as we handle already the wind speed values.
- Created extension function `moveItemToCenter` which auto-scrolls the item to the center of the screen on a `RecyclerView`.

### **Testing**
1. Use `bf` as a wind unit and ensure everything is OK in the historical charts.
2. Scroll and select through daily tiles in forecast details