### PR TITLE
FE-827 Feature/refactor claim set location

### DIFF
--- a/app/src/main/java/com/weatherxm/ui/Navigator.kt
+++ b/app/src/main/java/com/weatherxm/ui/Navigator.kt
@@ -319,21 +319,32 @@ class Navigator(private val analytics: AnalyticsWrapper) {
         )
     }
 
-    fun showClaimHeliumFlow(context: Context) {
-        // Launch claim activity
-        context.startActivity(
-            Intent(context, ClaimHeliumActivity::class.java)
-                .addFlags(Intent.FLAG_ACTIVITY_SINGLE_TOP or Intent.FLAG_ACTIVITY_CLEAR_TOP)
-        )
+    fun showClaimWifiFlow(
+        activityResultLauncher: ActivityResultLauncher<Intent>?,
+        context: Context,
+        deviceType: DeviceType
+    ) {
+        val intent = Intent(context, ClaimWifiActivity::class.java)
+            .addFlags(Intent.FLAG_ACTIVITY_SINGLE_TOP or Intent.FLAG_ACTIVITY_CLEAR_TOP)
+            .putExtra(ARG_DEVICE_TYPE, deviceType as Parcelable)
+        if (activityResultLauncher == null) {
+            context.startActivity(intent)
+        } else {
+            activityResultLauncher.launch(intent)
+        }
     }
 
-    fun showClaimWifiFlow(context: Context, deviceType: DeviceType) {
-        // Launch claim activity
-        context.startActivity(
-            Intent(context, ClaimWifiActivity::class.java)
-                .addFlags(Intent.FLAG_ACTIVITY_SINGLE_TOP or Intent.FLAG_ACTIVITY_CLEAR_TOP)
-                .putExtra(ARG_DEVICE_TYPE, deviceType as Parcelable)
-        )
+    fun showClaimHeliumFlow(
+        activityResultLauncher: ActivityResultLauncher<Intent>?,
+        context: Context
+    ) {
+        val intent = Intent(context, ClaimHeliumActivity::class.java)
+            .addFlags(Intent.FLAG_ACTIVITY_SINGLE_TOP or Intent.FLAG_ACTIVITY_CLEAR_TOP)
+        if (activityResultLauncher == null) {
+            context.startActivity(intent)
+        } else {
+            activityResultLauncher.launch(intent)
+        }
     }
 
     fun showDeviceHeliumOTA(fragment: Fragment, device: UIDevice?, deviceIsBleConnected: Boolean) {

--- a/app/src/main/java/com/weatherxm/ui/claimdevice/helium/result/ClaimHeliumResultFragment.kt
+++ b/app/src/main/java/com/weatherxm/ui/claimdevice/helium/result/ClaimHeliumResultFragment.kt
@@ -1,5 +1,6 @@
 package com.weatherxm.ui.claimdevice.helium.result
 
+import android.app.Activity
 import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
@@ -198,6 +199,7 @@ class ClaimHeliumResultFragment : BaseFragment() {
         )
         model.disconnectFromPeripheral()
         navigator.showDeviceDetails(activity, device = device)
+        activity?.setResult(Activity.RESULT_OK)
         activity?.finish()
     }
 

--- a/app/src/main/java/com/weatherxm/ui/claimdevice/location/ClaimLocationFragment.kt
+++ b/app/src/main/java/com/weatherxm/ui/claimdevice/location/ClaimLocationFragment.kt
@@ -101,10 +101,10 @@ class ClaimLocationFragment : BaseFragment(), EditLocationListener {
             }
             model.setInstallationLocation(markerLocation.lat, markerLocation.lon)
 
-            if (model.getDeviceType() == DeviceType.M5_WIFI) {
-                wifiParentModel.next()
-            } else {
+            if (model.getDeviceType() == DeviceType.HELIUM) {
                 heliumParentModel.next()
+            } else {
+                wifiParentModel.next()
             }
         }
 

--- a/app/src/main/java/com/weatherxm/ui/claimdevice/selectstation/SelectStationTypeActivity.kt
+++ b/app/src/main/java/com/weatherxm/ui/claimdevice/selectstation/SelectStationTypeActivity.kt
@@ -1,6 +1,8 @@
 package com.weatherxm.ui.claimdevice.selectstation
 
+import android.app.Activity
 import android.os.Bundle
+import androidx.activity.result.contract.ActivityResultContracts
 import com.weatherxm.analytics.AnalyticsService
 import com.weatherxm.databinding.ActivityClaimSelectStationBinding
 import com.weatherxm.ui.common.DeviceType
@@ -9,6 +11,14 @@ import com.weatherxm.ui.components.BaseActivity
 
 class SelectStationTypeActivity : BaseActivity() {
     private lateinit var binding: ActivityClaimSelectStationBinding
+
+    // Register the launcher for the edit location activity and wait for a possible result
+    private val claimingLauncher =
+        registerForActivityResult(ActivityResultContracts.StartActivityForResult()) {
+            if (it.resultCode == Activity.RESULT_OK) {
+                finish()
+            }
+        }
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -20,15 +30,15 @@ class SelectStationTypeActivity : BaseActivity() {
         }
 
         binding.m5WifiCard.listener {
-            navigator.showClaimWifiFlow(this, DeviceType.M5_WIFI)
+            navigator.showClaimWifiFlow(claimingLauncher, this, DeviceType.M5_WIFI)
         }
 
         binding.d1WifiCard.listener {
-            navigator.showClaimWifiFlow(this, DeviceType.D1_WIFI)
+            navigator.showClaimWifiFlow(claimingLauncher, this, DeviceType.D1_WIFI)
         }
 
         binding.heliumCard.listener {
-            navigator.showClaimHeliumFlow(this)
+            navigator.showClaimHeliumFlow(claimingLauncher, this)
         }
     }
 

--- a/app/src/main/res/layout/activity_claim_wifi_device.xml
+++ b/app/src/main/res/layout/activity_claim_wifi_device.xml
@@ -11,6 +11,7 @@
         android:id="@+id/app_bar"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
+        android:background="@drawable/background_rounded_bottom"
         app:layout_constraintTop_toTopOf="parent">
 
         <com.google.android.material.appbar.MaterialToolbar

--- a/app/src/main/res/layout/fragment_claim_set_location.xml
+++ b/app/src/main/res/layout/fragment_claim_set_location.xml
@@ -7,6 +7,7 @@
     android:layout_height="match_parent">
 
     <com.google.android.material.card.MaterialCardView
+        android:id="@+id/heliumRoot"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
         app:contentPadding="0dp">
@@ -24,72 +25,16 @@
                 app:contentPadding="0dp"
                 app:layout_constraintTop_toTopOf="parent">
 
-                <LinearLayout
+                <com.google.android.material.textview.MaterialTextView
+                    android:id="@+id/title"
                     android:layout_width="match_parent"
-                    android:layout_height="match_parent"
-                    android:orientation="vertical">
-
-                    <androidx.constraintlayout.widget.ConstraintLayout
-                        android:layout_width="match_parent"
-                        android:layout_height="match_parent">
-
-                        <com.google.android.material.textview.MaterialTextView
-                            android:id="@+id/title"
-                            android:layout_width="match_parent"
-                            android:layout_height="wrap_content"
-                            android:padding="@dimen/margin_normal"
-                            android:text="@string/location_of_installation"
-                            android:textAppearance="@style/TextAppearance.WeatherXM.Default.HeadlineSmall.SansSerifMedium"
-                            app:layout_constraintEnd_toEndOf="parent"
-                            app:layout_constraintStart_toStartOf="parent"
-                            app:layout_constraintTop_toTopOf="parent" />
-
-                        <com.google.android.material.materialswitch.MaterialSwitch
-                            android:id="@+id/installationToggle"
-                            android:layout_width="wrap_content"
-                            android:layout_height="wrap_content"
-                            android:layout_marginStart="@dimen/margin_normal"
-                            android:visibility="gone"
-                            app:layout_constraintStart_toStartOf="parent"
-                            app:layout_constraintTop_toBottomOf="@id/title" />
-
-                        <com.google.android.material.textview.MaterialTextView
-                            android:id="@+id/toggleDescription"
-                            android:layout_width="wrap_content"
-                            android:layout_height="wrap_content"
-                            android:padding="@dimen/margin_normal"
-                            android:text="@string/installation_toggle_unchecked"
-                            android:textAppearance="@style/TextAppearance.WeatherXM.Default.BodyMedium"
-                            android:visibility="gone"
-                            app:layout_constraintBottom_toBottomOf="@id/installationToggle"
-                            app:layout_constraintStart_toEndOf="@id/installationToggle"
-                            app:layout_constraintTop_toTopOf="@id/installationToggle" />
-
-                        <com.google.android.material.textview.MaterialTextView
-                            android:id="@+id/needHelpInstallation"
-                            android:layout_width="match_parent"
-                            android:layout_height="wrap_content"
-                            android:layout_marginHorizontal="@dimen/margin_normal"
-                            android:text="@string/need_help_installation"
-                            android:textAppearance="@style/TextAppearance.WeatherXM.Default.BodyMedium"
-                            android:visibility="gone"
-                            app:layout_constraintTop_toBottomOf="@id/installationToggle" />
-
-                    </androidx.constraintlayout.widget.ConstraintLayout>
-
-                    <com.weatherxm.ui.components.MessageCardView
-                        android:id="@+id/warningBox"
-                        android:layout_width="match_parent"
-                        android:layout_height="wrap_content"
-                        android:visibility="gone"
-                        app:layout_constraintTop_toBottomOf="@id/needHelpInstallation"
-                        app:message_background_tint="@color/warningTint"
-                        app:message_icon="@drawable/ic_warn"
-                        app:message_icon_color="@color/warning"
-                        app:message_includes_close_button="true"
-                        app:message_message="@string/installation_location_warning_text"
-                        app:message_title="@string/important_message" />
-                </LinearLayout>
+                    android:layout_height="wrap_content"
+                    android:padding="@dimen/margin_normal"
+                    android:text="@string/confirm_station_location"
+                    android:textAppearance="@style/TextAppearance.WeatherXM.Default.HeadlineSmall.SansSerifMedium"
+                    app:layout_constraintEnd_toEndOf="parent"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintTop_toTopOf="parent" />
 
             </com.google.android.material.card.MaterialCardView>
 
@@ -166,5 +111,98 @@
         </androidx.constraintlayout.widget.ConstraintLayout>
 
     </com.google.android.material.card.MaterialCardView>
+
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:id="@+id/wifiRoot"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:background="@color/alternativeBackground"
+        android:visibility="gone">
+
+        <com.google.android.material.textview.MaterialTextView
+            android:id="@+id/wifiTitle"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:text="@string/confirm_station_location"
+            android:textAppearance="@style/TextAppearance.WeatherXM.Default.BodyLarge"
+            android:textColor="@color/darkestBlue"
+            android:textSize="20sp"
+            android:textStyle="bold"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent" />
+
+        <com.google.android.material.textview.MaterialTextView
+            android:id="@+id/wifiDesc"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:paddingBottom="@dimen/padding_normal"
+            android:text="@string/confirm_station_location_desc"
+            android:textAppearance="@style/TextAppearance.WeatherXM.Default.BodyMedium"
+            android:textColor="@color/alternativeTextColor"
+            app:layout_constraintTop_toBottomOf="@id/wifiTitle" />
+
+        <androidx.constraintlayout.widget.ConstraintLayout
+            android:id="@+id/wifiMapContainer"
+            android:layout_width="match_parent"
+            android:layout_height="0dp"
+            android:layout_marginTop="@dimen/margin_small"
+            android:layout_marginBottom="@dimen/margin_small_to_normal"
+            app:layout_constraintBottom_toTopOf="@id/wifiConfirmLocationToggle"
+            app:layout_constraintTop_toBottomOf="@id/wifiDesc">
+
+            <com.google.android.material.card.MaterialCardView
+                android:id="@+id/wifiMapViewContainer"
+                android:layout_width="match_parent"
+                android:layout_height="match_parent"
+                app:contentPadding="0dp">
+
+                <androidx.fragment.app.FragmentContainerView
+                    android:id="@+id/wifiMapView"
+                    android:name="com.weatherxm.ui.components.EditLocationMapFragment"
+                    android:layout_width="match_parent"
+                    android:layout_height="match_parent"
+                    tools:layout="@layout/fragment_map" />
+            </com.google.android.material.card.MaterialCardView>
+
+            <com.weatherxm.ui.components.AddressSearchView
+                android:id="@+id/wifiAddressSearchView"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_margin="@dimen/margin_normal"
+                app:layout_constraintTop_toTopOf="@id/wifiMapViewContainer" />
+
+        </androidx.constraintlayout.widget.ConstraintLayout>
+
+        <com.google.android.material.materialswitch.MaterialSwitch
+            android:id="@+id/wifiConfirmLocationToggle"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:gravity="top"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="@id/wifiConfirmLocationText" />
+
+        <com.google.android.material.textview.MaterialTextView
+            android:id="@+id/wifiConfirmLocationText"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="@dimen/margin_small"
+            android:layout_marginBottom="@dimen/margin_small_to_normal"
+            android:text="@string/confirm_location_description"
+            android:textAppearance="@style/TextAppearance.WeatherXM.Default.BodyMedium"
+            app:layout_constraintBottom_toTopOf="@id/wifiConfirm"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toEndOf="@id/wifiConfirmLocationToggle" />
+
+        <com.google.android.material.button.MaterialButton
+            android:id="@+id/wifiConfirm"
+            style="@style/Widget.WeatherXM.Button"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginBottom="@dimen/margin_large"
+            android:enabled="false"
+            android:text="@string/confirm_and_proceed"
+            android:textAllCaps="false"
+            app:layout_constraintBottom_toBottomOf="parent" />
+    </androidx.constraintlayout.widget.ConstraintLayout>
 
 </androidx.coordinatorlayout.widget.CoordinatorLayout>

--- a/app/src/main/res/layout/fragment_claim_wifi_connect_wifi.xml
+++ b/app/src/main/res/layout/fragment_claim_wifi_connect_wifi.xml
@@ -155,7 +155,6 @@
         android:id="@+id/button_bar"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:background="@color/colorSurface"
         android:elevation="@dimen/elevation_normal"
         android:paddingTop="@dimen/padding_large"
         android:paddingBottom="@dimen/padding_large"

--- a/app/src/main/res/layout/fragment_claim_wifi_manual_details.xml
+++ b/app/src/main/res/layout/fragment_claim_wifi_manual_details.xml
@@ -141,7 +141,6 @@
         android:id="@+id/button_bar"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:background="@color/colorSurface"
         android:elevation="@dimen/elevation_normal"
         android:paddingTop="@dimen/padding_large"
         android:paddingBottom="@dimen/padding_large"

--- a/app/src/main/res/layout/fragment_claim_wifi_manual_details.xml
+++ b/app/src/main/res/layout/fragment_claim_wifi_manual_details.xml
@@ -81,6 +81,7 @@
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:visibility="gone"
+                app:boxBackgroundColor="@color/alternativeBackground"
                 app:helperTextEnabled="true"
                 app:hintEnabled="false"
                 app:layout_constraintTop_toBottomOf="@id/claimingKeyTitle"
@@ -116,6 +117,7 @@
                 style="@style/Widget.WeatherXM.TextInputEditText.OutlinedBox.Dense"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
+                app:boxBackgroundColor="@color/alternativeBackground"
                 app:helperTextEnabled="true"
                 app:hintEnabled="false"
                 app:layout_constraintTop_toBottomOf="@id/serialNumberTitle">

--- a/app/src/main/res/layout/fragment_claim_wifi_prepare_claiming.xml
+++ b/app/src/main/res/layout/fragment_claim_wifi_prepare_claiming.xml
@@ -104,7 +104,6 @@
         android:id="@+id/button_bar"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:background="@color/colorSurface"
         android:elevation="@dimen/elevation_normal"
         android:paddingTop="@dimen/padding_large"
         android:paddingBottom="@dimen/padding_large"

--- a/app/src/main/res/layout/fragment_claim_wifi_result.xml
+++ b/app/src/main/res/layout/fragment_claim_wifi_result.xml
@@ -1,73 +1,65 @@
 <?xml version="1.0" encoding="utf-8"?>
-<androidx.coordinatorlayout.widget.CoordinatorLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:id="@+id/root"
     android:layout_width="match_parent"
-    android:layout_height="match_parent">
+    android:layout_height="match_parent"
+    android:background="@color/alternativeBackground">
 
-    <com.google.android.material.card.MaterialCardView
+    <com.weatherxm.ui.components.EmptyView
+        android:id="@+id/statusView"
         android:layout_width="match_parent"
-        android:layout_height="match_parent">
+        android:layout_height="0dp"
+        android:layout_gravity="center"
+        app:empty_animation="@raw/anim_loading"
+        app:empty_subtitle="@string/success_claim_device"
+        app:empty_title="@string/station_claimed"
+        app:layout_constraintBottom_toTopOf="@id/goToStationBtn"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
 
-        <androidx.constraintlayout.widget.ConstraintLayout
-            android:layout_width="match_parent"
-            android:layout_height="match_parent">
+    <com.google.android.material.button.MaterialButton
+        android:id="@+id/goToStationBtn"
+        style="@style/Widget.WeatherXM.Button"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginBottom="@dimen/margin_normal"
+        android:layout_weight="2"
+        android:text="@string/action_go_to"
+        android:textAllCaps="false"
+        android:visibility="gone"
+        app:layout_constraintBottom_toBottomOf="parent"
+        tools:visibility="visible" />
 
-            <com.weatherxm.ui.components.EmptyView
-                android:id="@+id/statusView"
-                android:layout_width="match_parent"
-                android:layout_height="0dp"
-                android:layout_gravity="center"
-                app:empty_animation="@raw/anim_loading"
-                app:empty_subtitle="@string/success_claim_device"
-                app:empty_title="@string/station_claimed"
-                app:layout_constraintBottom_toTopOf="@id/goToStationBtn"
-                app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toTopOf="parent" />
+    <com.google.android.material.button.MaterialButton
+        android:id="@+id/cancel"
+        style="@style/Widget.WeatherXM.Button.Subtle.Borders"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginEnd="@dimen/margin_small"
+        android:layout_marginBottom="@dimen/margin_normal"
+        android:layout_weight="1"
+        android:text="@string/action_cancel_claiming"
+        android:textAllCaps="false"
+        android:visibility="gone"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toStartOf="@id/retry"
+        app:layout_constraintStart_toStartOf="parent" />
 
-            <com.google.android.material.button.MaterialButton
-                android:id="@+id/goToStationBtn"
-                style="@style/Widget.WeatherXM.Button"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:layout_weight="2"
-                android:text="@string/action_go_to"
-                android:textAllCaps="false"
-                android:visibility="gone"
-                app:layout_constraintBottom_toBottomOf="parent"
-                tools:visibility="visible" />
-
-            <com.google.android.material.button.MaterialButton
-                android:id="@+id/cancel"
-                style="@style/Widget.WeatherXM.Button.Subtle.Borders"
-                android:layout_width="0dp"
-                android:layout_height="wrap_content"
-                android:layout_marginEnd="@dimen/margin_small"
-                android:layout_weight="1"
-                android:text="@string/action_cancel_claiming"
-                android:textAllCaps="false"
-                android:visibility="gone"
-                app:layout_constraintBottom_toBottomOf="parent"
-                app:layout_constraintEnd_toStartOf="@id/retry"
-                app:layout_constraintStart_toStartOf="parent" />
-
-            <com.google.android.material.button.MaterialButton
-                android:id="@+id/retry"
-                style="@style/Widget.WeatherXM.Button"
-                android:layout_width="0dp"
-                android:layout_height="wrap_content"
-                android:layout_marginStart="@dimen/margin_small"
-                android:layout_weight="1"
-                android:text="@string/action_retry_claiming"
-                android:textAllCaps="false"
-                android:visibility="gone"
-                app:layout_constraintBottom_toBottomOf="parent"
-                app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintStart_toEndOf="@id/cancel" />
-        </androidx.constraintlayout.widget.ConstraintLayout>
-
-    </com.google.android.material.card.MaterialCardView>
-
-</androidx.coordinatorlayout.widget.CoordinatorLayout>
+    <com.google.android.material.button.MaterialButton
+        android:id="@+id/retry"
+        style="@style/Widget.WeatherXM.Button"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="@dimen/margin_small"
+        android:layout_marginBottom="@dimen/margin_normal"
+        android:layout_weight="1"
+        android:text="@string/action_retry_claiming"
+        android:textAllCaps="false"
+        android:visibility="gone"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toEndOf="@id/cancel" />
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/fragment_claim_wifi_result.xml
+++ b/app/src/main/res/layout/fragment_claim_wifi_result.xml
@@ -22,51 +22,50 @@
                 app:empty_animation="@raw/anim_loading"
                 app:empty_subtitle="@string/success_claim_device"
                 app:empty_title="@string/station_claimed"
-                app:layout_constraintBottom_toTopOf="@id/viewStationOnlyBtn"
+                app:layout_constraintBottom_toTopOf="@id/goToStationBtn"
                 app:layout_constraintEnd_toEndOf="parent"
                 app:layout_constraintStart_toStartOf="parent"
                 app:layout_constraintTop_toTopOf="parent" />
 
             <com.google.android.material.button.MaterialButton
-                android:id="@+id/viewStationOnlyBtn"
+                android:id="@+id/goToStationBtn"
                 style="@style/Widget.WeatherXM.Button"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:layout_weight="2"
-                android:text="@string/action_view_station"
+                android:text="@string/action_go_to"
                 android:textAllCaps="false"
                 android:visibility="gone"
                 app:layout_constraintBottom_toBottomOf="parent"
                 tools:visibility="visible" />
 
-            <LinearLayout
-                android:id="@+id/failureButtons"
-                android:layout_width="match_parent"
+            <com.google.android.material.button.MaterialButton
+                android:id="@+id/cancel"
+                style="@style/Widget.WeatherXM.Button.Subtle.Borders"
+                android:layout_width="0dp"
                 android:layout_height="wrap_content"
-                android:orientation="horizontal"
+                android:layout_marginEnd="@dimen/margin_small"
+                android:layout_weight="1"
+                android:text="@string/action_cancel_claiming"
+                android:textAllCaps="false"
                 android:visibility="gone"
-                android:weightSum="2"
-                app:layout_constraintBottom_toBottomOf="parent">
+                app:layout_constraintBottom_toBottomOf="parent"
+                app:layout_constraintEnd_toStartOf="@id/retry"
+                app:layout_constraintStart_toStartOf="parent" />
 
-                <com.google.android.material.button.MaterialButton
-                    android:id="@+id/quit"
-                    style="@style/Widget.WeatherXM.Button.Subtle.Borders"
-                    android:layout_width="0dp"
-                    android:layout_height="wrap_content"
-                    android:layout_marginEnd="@dimen/margin_normal"
-                    android:layout_weight="1"
-                    android:text="@string/action_quit_claiming"
-                    android:textAllCaps="false" />
-
-                <com.google.android.material.button.MaterialButton
-                    android:id="@+id/retry"
-                    style="@style/Widget.WeatherXM.Button"
-                    android:layout_width="0dp"
-                    android:layout_height="wrap_content"
-                    android:layout_weight="1"
-                    android:text="@string/action_retry_claiming"
-                    android:textAllCaps="false" />
-            </LinearLayout>
+            <com.google.android.material.button.MaterialButton
+                android:id="@+id/retry"
+                style="@style/Widget.WeatherXM.Button"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="@dimen/margin_small"
+                android:layout_weight="1"
+                android:text="@string/action_retry_claiming"
+                android:textAllCaps="false"
+                android:visibility="gone"
+                app:layout_constraintBottom_toBottomOf="parent"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toEndOf="@id/cancel" />
         </androidx.constraintlayout.widget.ConstraintLayout>
 
     </com.google.android.material.card.MaterialCardView>

--- a/app/src/main/res/layout/view_marker.xml
+++ b/app/src/main/res/layout/view_marker.xml
@@ -15,7 +15,7 @@
         android:layout_height="wrap_content"
         android:layout_gravity="center_horizontal"
         app:cardElevation="@dimen/elevation_normal"
-        app:contentPadding="@dimen/padding_small">
+        app:contentPadding="@dimen/padding_small_to_normal">
 
         <com.google.android.material.textview.MaterialTextView
             android:id="@+id/address"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -396,14 +396,17 @@
     <string name="search_location">Search for location</string>
     <string name="confirm_and_proceed">Confirm and Proceed</string>
     <string name="action_view_station">View Station</string>
+    <string name="action_go_to">Go to Station</string>
     <string name="action_quit_claiming">Quit Claiming</string>
+    <string name="action_cancel_claiming">Cancel Claiming</string>
     <string name="action_retry_claiming">Retry Claiming</string>
     <string name="confirm_location_description">I acknowledge that the deployment location above is correct and will be used to verify the eligibility of the station’s rewards.</string>
     <string name="set_and_claim">Set and Claim</string>
     <string name="station_claimed">Station Claimed</string>
     <string name="claiming_station">Claiming Station…</string>
     <string name="claiming_station_helium_desc"><![CDATA[Sit tight, we’re pairing your account with your WeatherXM device! <b>This process could take up to 2 minutes due to the Helium\'s network bandwidth limitations!<b>]]></string>
-    <string name="success_claim_device"><![CDATA[Your station is claimed under your account:<br><b>%s</b>]]></string>
+    <string name="claiming_station_m5_desc"><![CDATA[Sit tight, we’re pairing your account with your WeatherXM gateway! <b>This process could take up to 2 minutes!<b>]]></string>
+    <string name="success_claim_device"><![CDATA[Your station is claimed under your account!<br><b>%s</b>]]></string>
     <string name="ble_connection_lost">Connection Failed</string>
     <string name="ble_connection_lost_desc"><![CDATA[Something went wrong with the connection. Make sure you are <b>near your weather station</b> and retry claiming. If connection still fails, please <b>unpair the station and restart the claiming process</b>. For more details check our <a href="%1$s">troubleshooting guide</a>.<br><br>Alternatively, you can contact our support.]]></string>
     <string name="setting_station_frequency">Setting Station Frequency</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -391,16 +391,14 @@
     <string name="d1_wifi">D1 | WiFi</string>
 
     <!-- Claim device -->
-    <string name="location_of_installation">Location of Installation</string>
+    <string name="confirm_station_location">Confirm station location</string>
+    <string name="confirm_station_location_desc">You need to confirm the station’s exact deployment location.</string>
     <string name="search_location">Search for location</string>
-    <string name="installation_toggle_unchecked">Not yet, will install at a later time!</string>
-    <string name="need_help_installation"><![CDATA[Need help with proper weather station installation?<br><b><a href="%1$s">View our installation guide</a></b>]]></string>
-    <string name="installation_location_warning_text">Your device will be claimed, but until you properly install it, it will not get any $WXM rewards.\n\nOnce you do so, you can enable your device by switching the toggle to “Installed and ready!” on your device details screen.</string>
     <string name="confirm_and_proceed">Confirm and Proceed</string>
     <string name="action_view_station">View Station</string>
     <string name="action_quit_claiming">Quit Claiming</string>
     <string name="action_retry_claiming">Retry Claiming</string>
-    <string name="confirm_location_description">I acknowledge that the deployment location above is correct and can be used to verify the eligibility of the station’s rewards.</string>
+    <string name="confirm_location_description">I acknowledge that the deployment location above is correct and will be used to verify the eligibility of the station’s rewards.</string>
     <string name="set_and_claim">Set and Claim</string>
     <string name="station_claimed">Station Claimed</string>
     <string name="claiming_station">Claiming Station…</string>


### PR DESCRIPTION
## **Why?**
Claim Wizard step 4: Confirm station Location.

### **How?**
Created a different M5/D1 container in the same layout as the current "set location" screen and toggle visibility & handling in the Fragment depending on which `DeviceType` we have.

This is a **temp & simple workaround** until the design team updates the Helium screens as well, which is already WIP.

### **Testing**
Ensure that the M5/D1 step matches the design and the Helium's respective step is OK as well. Also try some claiming tests in M5 and D1 and ensure everything is OK.