### PR TITLE
FE-901 Indication in allocated rewards

### DIFF
--- a/app/src/main/java/com/weatherxm/ui/home/profile/ProfileFragment.kt
+++ b/app/src/main/java/com/weatherxm/ui/home/profile/ProfileFragment.kt
@@ -153,16 +153,22 @@ class ProfileFragment : BaseFragment() {
 
             if (parentModel.hasDevices() == false) {
                 binding.rewardsContainerCard.setCardStroke(R.color.colorPrimary, 2)
-                binding.buyStationCard.actionPrimaryBtn(
-                    getString(R.string.action_buy_station),
-                    AppCompatResources.getDrawable(requireContext(), R.drawable.ic_cart),
-                ) {
-                    navigator.openWebsite(requireContext(), getString(R.string.shop_url))
-                }.setVisible(true)
+                binding.allocatedRewardsSecondaryCard
+                    .title(R.string.start_earning)
+                    .message(R.string.start_earning_desc)
+                    .actionPrimaryBtn(
+                        getString(R.string.action_buy_station),
+                        AppCompatResources.getDrawable(requireContext(), R.drawable.ic_cart),
+                    ) {
+                        navigator.openWebsite(requireContext(), getString(R.string.shop_url))
+                    }
+                    .setVisible(true)
             }
         } else {
             binding.rewardsContainerCard.strokeWidth = 0
-            binding.buyStationCard.setVisible(false)
+            binding.allocatedRewardsSecondaryCard
+                .htmlMessage(getString(R.string.allocated_rewards_alternative_claiming))
+                .setVisible(true)
             binding.rewards
                 .subtitle(
                     getString(

--- a/app/src/main/res/layout/fragment_profile.xml
+++ b/app/src/main/res/layout/fragment_profile.xml
@@ -182,7 +182,7 @@
                             app:profile_item_title="@string/allocated_rewards" />
 
                         <com.weatherxm.ui.components.MessageCardView
-                            android:id="@+id/buyStationCard"
+                            android:id="@+id/allocatedRewardsSecondaryCard"
                             android:layout_width="match_parent"
                             android:layout_height="wrap_content"
                             android:layout_marginTop="-16dp"
@@ -191,8 +191,8 @@
                             android:paddingTop="16dp"
                             android:visibility="gone"
                             app:message_includes_close_button="false"
-                            app:message_message="@string/start_earning_desc"
-                            app:message_title="@string/start_earning"
+                            tools:message_message="@string/start_earning_desc"
+                            tools:message_title="@string/start_earning"
                             tools:visibility="visible" />
 
                     </LinearLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -110,6 +110,7 @@
     <string name="total_claimed_desc">Total Claimed reflects the tokens you\'ve successfully claimed and withdrawn into your personal wallet. These are the rewards you\'ve converted from your earned tokens for personal use or other purposes.</string>
     <string name="allocated_rewards">Allocated Rewards</string>
     <string name="no_allocated_rewards">Νο allocated rewards yet!</string>
+    <string name="allocated_rewards_alternative_claiming"><![CDATA[You can also claim your allocated rewards by visiting <b>claim.weatherxm.com</b> from a desktop web browser.]]></string>
     <string name="preferences_settings">Preferences &amp; Settings</string>
     <string name="preferences_desc">Set your preferences and app settings</string>
     <string name="start_earning">Start earning now!</string>


### PR DESCRIPTION
## **Why?**
Add helpful indication in allocated rewards that desktop claiming is available as well

### **How?**
Reuse the same `MessageCardView` we had for the "Buy Station" prompt for this case as well. And set the stroke/title/messages accordingly on each case.

### **Testing**
Ensure that both cases (Buy Station and Claim via Web) are visible correctly.