### PR TITLE
FE-911 Fix validation of serial number & claiming key inputs

### DIFF
--- a/app/src/main/java/com/weatherxm/ui/claimdevice/wifi/manualdetails/ClaimWifiManualDetailsFragment.kt
+++ b/app/src/main/java/com/weatherxm/ui/claimdevice/wifi/manualdetails/ClaimWifiManualDetailsFragment.kt
@@ -117,21 +117,20 @@ class ClaimWifiManualDetailsFragment : BaseFragment() {
     }
 
     private fun validateAndSetDetails() {
-        if (!model.validateSerial(binding.serialNumber.text.toString())) {
+        val isSerialValid = model.validateSerial(binding.serialNumber.text.toString())
+        val isKeyValid = model.validateClaimingKey(binding.claimingKey.text.toString())
+
+        if (!isSerialValid) {
             binding.serialNumberContainer.error = getString(R.string.warn_validation_invalid_serial)
+        } else if (model.deviceType == DeviceType.D1_WIFI && !isKeyValid) {
+            binding.claimingKeyContainer.error =
+                getString(R.string.warn_validation_invalid_claiming_key)
         } else {
             model.setSerialNumber(binding.serialNumber.text.toString())
-        }
-        if (model.deviceType == DeviceType.M5_WIFI) {
-            model.next()
-        } else {
-            if (!model.validateClaimingKey(binding.claimingKey.text.toString())) {
-                binding.claimingKeyContainer.error =
-                    getString(R.string.warn_validation_invalid_claiming_key)
-            } else {
+            if (model.deviceType == DeviceType.D1_WIFI) {
                 model.setClaimingKey(binding.claimingKey.text.toString())
-                model.next()
             }
+            model.next()
         }
     }
 


### PR DESCRIPTION
## **Why?**
Fix validation of serial number & claiming key inputs as it allows to proceed with an invalid serial number by using the "Enter" key on the keyboard.

### **How?**
Refactor how we validate the input fields as before we didn't "terminate" the execution of the `fun` when an error was found.

### **Testing**
Ensure that it's not possible to proceed either with the button or with the enter in the keyboard when the serial number and/or the claiming key are invalid. Also check M5's manual input.