### PR TITLE
FE-919 Add D1 and Pulse in device profiles

### DIFF
--- a/app/src/main/java/com/weatherxm/data/ApiModels.kt
+++ b/app/src/main/java/com/weatherxm/data/ApiModels.kt
@@ -679,7 +679,9 @@ data class WalletRewards(
 
 enum class DeviceProfile {
     M5,
-    Helium
+    Helium,
+    D1,
+    Pulse
 }
 
 @Suppress("EnumNaming")


### PR DESCRIPTION
### **How?**
Add `D1` and `Pulse` in `enum class DeviceProfile`.