### PR TITLE
FE-936 Add support for AS923_1B and map it to Malaysia

### DIFF
--- a/app/src/main/assets/countries_information.json
+++ b/app/src/main/assets/countries_information.json
@@ -1069,7 +1069,7 @@
     },
     {
         "code": "MY",
-        "helium_frequency": "AS923_1",
+        "helium_frequency": "AS923_1B",
         "map_center": {
             "lat": 4.210484,
             "lon": 101.975766

--- a/app/src/main/java/com/weatherxm/data/DataModels.kt
+++ b/app/src/main/java/com/weatherxm/data/DataModels.kt
@@ -56,6 +56,7 @@ enum class Frequency {
     IN865,
     RU864,
     AS923_1,
+    AS923_1B,
     AS923_2,
     AS923_3,
     AS923_4

--- a/app/src/main/java/com/weatherxm/data/FrequencyHelper.kt
+++ b/app/src/main/java/com/weatherxm/data/FrequencyHelper.kt
@@ -50,6 +50,7 @@ fun frequencyToHeliumBleBandValue(frequency: Frequency): Int {
         Frequency.IN865 -> 7
         Frequency.RU864 -> 9
         Frequency.AS923_1 -> 10
+        Frequency.AS923_1B -> 14
         Frequency.AS923_2 -> 11
         Frequency.AS923_3 -> 12
         Frequency.AS923_4 -> 13


### PR DESCRIPTION
### **How?**
- Added the respective entry in `enum class Frequency` and in the `frequencyToHeliumBleBandValue` mapping function.
- Map Malaysia to `AS923_1B`.


### **Testing**
The `AS923_1B` should be available in the frequencies list in the Change Frequency screen.