### PR TITLE
FE-934 Some code optimizations regarding DeviceAlerts and shouldShowOTAPrompt check

### DIFF
--- a/app/src/main/java/com/weatherxm/data/repository/DeviceOTARepository.kt
+++ b/app/src/main/java/com/weatherxm/data/repository/DeviceOTARepository.kt
@@ -8,7 +8,7 @@ import java.util.concurrent.TimeUnit
 interface DeviceOTARepository {
     suspend fun getFirmware(deviceId: String): Either<Failure, ByteArray>
     fun onUpdateSuccess(deviceId: String, otaVersion: String)
-    fun shouldShowOTAPrompt(deviceId: String, assignedOtaVersion: String?): Boolean
+    fun userShouldNotifiedOfOTA(deviceId: String, assignedOtaVersion: String?): Boolean
 }
 
 class DeviceOTARepositoryImpl(
@@ -27,7 +27,7 @@ class DeviceOTARepositoryImpl(
         deviceOTADataSource.setDeviceLastOtaTimestamp(deviceId)
     }
 
-    override fun shouldShowOTAPrompt(deviceId: String, assignedOtaVersion: String?): Boolean {
+    override fun userShouldNotifiedOfOTA(deviceId: String, assignedOtaVersion: String?): Boolean {
         return if (assignedOtaVersion.isNullOrEmpty()) {
             false
         } else {

--- a/app/src/main/java/com/weatherxm/ui/claimdevice/helium/result/ClaimHeliumResultFragment.kt
+++ b/app/src/main/java/com/weatherxm/ui/claimdevice/helium/result/ClaimHeliumResultFragment.kt
@@ -7,8 +7,6 @@ import android.view.View
 import android.view.ViewGroup
 import com.weatherxm.R
 import com.weatherxm.analytics.AnalyticsService
-import com.weatherxm.data.DeviceProfile.Helium
-import com.weatherxm.data.DeviceProfile.M5
 import com.weatherxm.data.Resource
 import com.weatherxm.data.Status
 import com.weatherxm.databinding.FragmentClaimHeliumResultBinding
@@ -113,7 +111,7 @@ class ClaimHeliumResultFragment : BaseFragment() {
         when (resource.status) {
             Status.SUCCESS -> {
                 val device = resource.data
-                if (device != null && device.profile == Helium && device.needsUpdate()) {
+                if (device != null && device.shouldPromptUpdate()) {
                     analytics.trackEventPrompt(
                         AnalyticsService.ParamValue.OTA_AVAILABLE.paramValue,
                         AnalyticsService.ParamValue.WARN.paramValue,
@@ -134,7 +132,7 @@ class ClaimHeliumResultFragment : BaseFragment() {
                         secondaryActionText = getString(R.string.action_view_station)
                     )
                     binding.bleActionFlow.onShowInformationCard()
-                } else if (device != null && (device.profile == M5 || !device.needsUpdate())) {
+                } else if (device != null) {
                     binding.bleActionFlow.setSuccessOneButtonOnlyListener {
                         onViewDevice(device)
                     }

--- a/app/src/main/java/com/weatherxm/ui/common/UIModels.kt
+++ b/app/src/main/java/com/weatherxm/ui/common/UIModels.kt
@@ -115,8 +115,11 @@ data class UIDevice(
 
     fun isFollowed(): Boolean = relation == DeviceRelation.FOLLOWED
 
-    fun needsUpdate(): Boolean {
-        return !currentFirmware.equals(assignedFirmware) && !assignedFirmware.isNullOrEmpty()
+    fun shouldPromptUpdate(): Boolean {
+        return isOwned()
+            && !currentFirmware.equals(assignedFirmware)
+            && !assignedFirmware.isNullOrEmpty()
+            && profile == DeviceProfile.Helium
     }
 
     fun getDefaultOrFriendlyName(): String {
@@ -133,18 +136,32 @@ data class UIDevice(
             ?: String.empty()
     }
 
-    fun toNormalizedName(): String {
-        return name.replace(" ", "-").lowercase()
-    }
-
     fun isEmpty() = id.isEmpty() && name.isEmpty() && cellIndex.isEmpty()
     fun isOnline() = isActive != null && isActive == true
-    fun hasLowBattery() = hasLowBattery != null && hasLowBattery == true
 
     fun hasErrors(): Boolean {
         return alerts.firstOrNull {
             it.severity == SeverityLevel.ERROR
         } != null
+    }
+
+    fun createDeviceAlerts(userShouldNotifiedOfOTA: Boolean): List<DeviceAlert> {
+        val alerts = mutableListOf<DeviceAlert>()
+        if (isActive == false) {
+            alerts.add(DeviceAlert.createError(DeviceAlertType.OFFLINE))
+        }
+
+        if (hasLowBattery == true && isOwned()) {
+            alerts.add(DeviceAlert.createWarning(DeviceAlertType.LOW_BATTERY))
+        }
+
+        if (userShouldNotifiedOfOTA && shouldPromptUpdate()) {
+            alerts.add(DeviceAlert.createWarning(DeviceAlertType.NEEDS_UPDATE))
+        }
+        this.alerts = alerts.sortedByDescending { alert ->
+            alert.severity
+        }
+        return alerts
     }
 }
 

--- a/app/src/main/java/com/weatherxm/ui/devicedetails/DeviceDetailsViewModel.kt
+++ b/app/src/main/java/com/weatherxm/ui/devicedetails/DeviceDetailsViewModel.kt
@@ -7,6 +7,7 @@ import androidx.lifecycle.viewModelScope
 import arrow.core.getOrElse
 import com.weatherxm.R
 import com.weatherxm.analytics.AnalyticsService
+import com.weatherxm.analytics.AnalyticsWrapper
 import com.weatherxm.data.ApiError
 import com.weatherxm.data.Failure
 import com.weatherxm.data.Resource
@@ -17,7 +18,6 @@ import com.weatherxm.ui.explorer.UICell
 import com.weatherxm.usecases.AuthUseCase
 import com.weatherxm.usecases.DeviceDetailsUseCase
 import com.weatherxm.usecases.FollowUseCase
-import com.weatherxm.analytics.AnalyticsWrapper
 import com.weatherxm.util.Failure.getDefaultMessage
 import com.weatherxm.util.RefreshHandler
 import com.weatherxm.util.Resources
@@ -96,7 +96,7 @@ class DeviceDetailsViewModel(
 
     fun createNormalizedName(): String {
         return if (!device.isEmpty()) {
-            device.toNormalizedName()
+            device.name.replace(" ", "-").lowercase()
         } else {
             String.empty()
         }

--- a/app/src/main/java/com/weatherxm/ui/devicesettings/DeviceSettingsViewModel.kt
+++ b/app/src/main/java/com/weatherxm/ui/devicesettings/DeviceSettingsViewModel.kt
@@ -220,9 +220,7 @@ class DeviceSettingsViewModel(
                 }
             }
             device.currentFirmware?.let { current ->
-                if (device.needsUpdate() && device.isOwned()
-                    && usecase.shouldShowOTAPrompt(device)
-                ) {
+                if (usecase.userShouldNotifiedOfOTA(device) && device.shouldPromptUpdate()) {
                     add(
                         UIDeviceInfo(
                             resources.getString(R.string.firmware_version),

--- a/app/src/main/java/com/weatherxm/ui/home/devices/DevicesAdapter.kt
+++ b/app/src/main/java/com/weatherxm/ui/home/devices/DevicesAdapter.kt
@@ -247,7 +247,6 @@ class DeviceAdapter(private val deviceListener: DeviceListener) :
                 oldItem.currentWeather?.feelsLike == newItem.currentWeather?.feelsLike &&
                 oldItem.currentWeather?.timestamp == newItem.currentWeather?.timestamp &&
                 oldItem.profile == newItem.profile &&
-                oldItem.needsUpdate() == newItem.needsUpdate() &&
                 oldItem.alerts.size == newItem.alerts.size &&
                 oldItem.currentFirmware == newItem.currentFirmware &&
                 oldItem.assignedFirmware == newItem.assignedFirmware &&

--- a/app/src/main/java/com/weatherxm/usecases/DeviceListUseCaseImpl.kt
+++ b/app/src/main/java/com/weatherxm/usecases/DeviceListUseCaseImpl.kt
@@ -1,13 +1,10 @@
 package com.weatherxm.usecases
 
 import arrow.core.Either
-import com.weatherxm.data.DeviceProfile.Helium
 import com.weatherxm.data.Failure
 import com.weatherxm.data.repository.DeviceOTARepository
 import com.weatherxm.data.repository.DeviceRepository
 import com.weatherxm.data.repository.UserPreferencesRepository
-import com.weatherxm.ui.common.DeviceAlert
-import com.weatherxm.ui.common.DeviceAlertType
 import com.weatherxm.ui.common.DevicesFilterType
 import com.weatherxm.ui.common.DevicesGroupBy
 import com.weatherxm.ui.common.DevicesSortFilterOptions
@@ -16,32 +13,14 @@ import com.weatherxm.ui.common.UIDevice
 
 class DeviceListUseCaseImpl(
     private val deviceRepository: DeviceRepository,
-    private val deviceOTARepository: DeviceOTARepository,
+    private val deviceOTARepo: DeviceOTARepository,
     private val userPreferencesRepository: UserPreferencesRepository
 ) : DeviceListUseCase {
     override suspend fun getUserDevices(): Either<Failure, List<UIDevice>> {
         return deviceRepository.getUserDevices().map { response ->
             val devices = response.map {
-                val device = it.toUIDevice()
-                val shouldShowOTAPrompt = deviceOTARepository.shouldShowOTAPrompt(
-                    device.id, device.assignedFirmware
-                ) && device.isOwned()
-                val alerts = mutableListOf<DeviceAlert>()
-                if (!device.isOnline()) {
-                    alerts.add(DeviceAlert.createError(DeviceAlertType.OFFLINE))
-                }
-
-                if (device.hasLowBattery() && device.isOwned()) {
-                    alerts.add(DeviceAlert.createWarning(DeviceAlertType.LOW_BATTERY))
-                }
-
-                if (shouldShowOTAPrompt && device.profile == Helium && device.needsUpdate()) {
-                    alerts.add(DeviceAlert.createWarning(DeviceAlertType.NEEDS_UPDATE))
-                }
-                device.apply {
-                    this.alerts = alerts.sortedByDescending { alert ->
-                        alert.severity
-                    }
+                it.toUIDevice().apply {
+                    createDeviceAlerts(deviceOTARepo.userShouldNotifiedOfOTA(id, assignedFirmware))
                 }
             }
 

--- a/app/src/main/java/com/weatherxm/usecases/StationSettingsUseCase.kt
+++ b/app/src/main/java/com/weatherxm/usecases/StationSettingsUseCase.kt
@@ -10,7 +10,7 @@ interface StationSettingsUseCase {
     suspend fun setFriendlyName(deviceId: String, friendlyName: String): Either<Failure, Unit>
     suspend fun clearFriendlyName(deviceId: String): Either<Failure, Unit>
     suspend fun removeDevice(serialNumber: String, id: String): Either<Failure, Unit>
-    fun shouldShowOTAPrompt(device: UIDevice): Boolean
+    fun userShouldNotifiedOfOTA(device: UIDevice): Boolean
     suspend fun getCountryAndFrequencies(lat: Double?, lon: Double?): CountryAndFrequencies
     suspend fun getDeviceInfo(deviceId: String): Either<Failure, DeviceInfo>
 }

--- a/app/src/main/java/com/weatherxm/usecases/StationSettingsUseCaseImpl.kt
+++ b/app/src/main/java/com/weatherxm/usecases/StationSettingsUseCaseImpl.kt
@@ -3,7 +3,6 @@ package com.weatherxm.usecases
 import arrow.core.Either
 import com.weatherxm.data.CountryAndFrequencies
 import com.weatherxm.data.DeviceInfo
-import com.weatherxm.data.DeviceProfile
 import com.weatherxm.data.Failure
 import com.weatherxm.data.Frequency
 import com.weatherxm.data.Location
@@ -33,9 +32,8 @@ class StationSettingsUseCaseImpl(
         return deviceRepository.removeDevice(serialNumber, id)
     }
 
-    override fun shouldShowOTAPrompt(device: UIDevice): Boolean {
-        return deviceOTARepository.shouldShowOTAPrompt(device.id, device.assignedFirmware)
-            && device.profile?.equals(DeviceProfile.Helium) == true
+    override fun userShouldNotifiedOfOTA(device: UIDevice): Boolean {
+        return deviceOTARepository.userShouldNotifiedOfOTA(device.id, device.assignedFirmware)
     }
 
     override suspend fun getCountryAndFrequencies(


### PR DESCRIPTION
## **Why?**
🍝 code. 😢 

### **How?**
- Better name of `shouldShowOTAPrompt` function, renamed to `userShouldNotifiedOfOTA` which better shows what this function does
- Created an extension function in `UIDevice` called `shouldPromptUpdate` which make all the checks needed in case we should prompt the user for an update or not
- Created an extension function in `UIDevice` called `createDeviceAlerts` which creates a list of `DeviceAlert` alerts so that UseCases call this function and not have duplicate code

### **Testing**
Ensure that OTA prompts are shown correctly when/if needed (you can try with mock version also).