### PR TITLE
FE-948 Use Plurals and get them as quantity strings where applicable

### DIFF
--- a/app/src/local/assets/mock_files/get_device_rewards_timeline.json
+++ b/app/src/local/assets/mock_files/get_device_rewards_timeline.json
@@ -15,7 +15,14 @@
             "base_reward_score": 50,
             "annotation_summary": [
                 {
-                    "severity_level": "WARNING",
+                    "severity_level": "INFO",
+                    "group": "SENSOR_PROBLEMS",
+                    "title": "Minor Sensor Issues",
+                    "message": "Station is doing great! Minor issues detected during our data quality checks, that may be related to occasional sensor inaccuracies. That can happen once in a while.",
+                    "doc_url": "https://docs.weatherxm.com/project/rewards-troubleshooting#sensor-problems"
+                },
+                {
+                    "severity_level": "ERROR",
                     "group": "SENSOR_PROBLEMS",
                     "title": "Minor Sensor Issues",
                     "message": "Station is doing great! Minor issues detected during our data quality checks, that may be related to occasional sensor inaccuracies. That can happen once in a while.",

--- a/app/src/main/java/com/weatherxm/ui/cellinfo/CellInfoActivity.kt
+++ b/app/src/main/java/com/weatherxm/ui/cellinfo/CellInfoActivity.kt
@@ -158,10 +158,9 @@ class CellInfoActivity : BaseActivity(), CellDeviceListener {
 
     private fun updateCellStats(data: List<UIDevice>) {
         data.count { it.isOnline() }.apply {
-            if (this > 1) {
-                binding.activeChip.text = getString(R.string.cell_active_stations, this)
-            } else if (this == 1) {
-                binding.activeChip.text = getString(R.string.cell_active_station)
+            if (this >= 1) {
+                binding.activeChip.text =
+                    resources.getQuantityString(R.plurals.cell_active_station, this, this)
             } else {
                 binding.activeChip.setVisible(false)
             }

--- a/app/src/main/java/com/weatherxm/ui/components/DailyRewardsCardView.kt
+++ b/app/src/main/java/com/weatherxm/ui/components/DailyRewardsCardView.kt
@@ -153,14 +153,14 @@ open class DailyRewardsCardView : LinearLayout, KoinComponent {
                 context.getString(R.string.annotation_info_text)
             }
         } else {
-            if (sortedSeverities[0] == SeverityLevel.INFO && annotationsSize > 1) {
-                context.getString(R.string.annotation_issues_info_text, annotationsSize)
-            } else if (sortedSeverities[0] == SeverityLevel.INFO && annotationsSize <= 1) {
-                context.getString(R.string.annotation_issue_info_text)
-            } else if (annotationsSize > 1) {
-                context.getString(R.string.annotation_issues_warn_error_text, annotationsSize)
+            if (sortedSeverities[0] == SeverityLevel.INFO) {
+                resources.getQuantityString(
+                    R.plurals.annotation_issue_info_text, annotationsSize, annotationsSize
+                )
             } else {
-                context.getString(R.string.annotation_issue_warn_error_text)
+                resources.getQuantityString(
+                    R.plurals.annotation_issue_warn_error_text, annotationsSize, annotationsSize
+                )
             }
         }
     }

--- a/app/src/main/java/com/weatherxm/ui/rewarddetails/RewardDetailsActivity.kt
+++ b/app/src/main/java/com/weatherxm/ui/rewarddetails/RewardDetailsActivity.kt
@@ -149,20 +149,19 @@ class RewardDetailsActivity : BaseActivity(), RewardBoostListener {
             binding.issueCard.setVisible(false)
         } else {
             val issuesSize = sortedIssues.size
-            val topIssue = sortedIssues[0]
             binding.issuesDesc.setHtml(
-                if (topIssue.isInfo() && issuesSize > 1) {
-                    getString(R.string.annotation_issues_info_text, issuesSize)
-                } else if (topIssue.isInfo() && issuesSize <= 1) {
-                    getString(R.string.annotation_issue_info_text)
-                } else if (issuesSize > 1) {
-                    getString(R.string.annotation_issues_warn_error_text, issuesSize)
+                if (sortedIssues[0].isInfo()) {
+                    resources.getQuantityString(
+                        R.plurals.annotation_issue_info_text, issuesSize, issuesSize
+                    )
                 } else {
-                    getString(R.string.annotation_issue_warn_error_text)
+                    resources.getQuantityString(
+                        R.plurals.annotation_issue_warn_error_text, issuesSize, issuesSize
+                    )
                 }
             )
 
-            onIssueCard(topIssue, issuesSize > 1)
+            onIssueCard(sortedIssues[0], issuesSize > 1)
         }
     }
 

--- a/app/src/main/res/values/plurals.xml
+++ b/app/src/main/res/values/plurals.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <plurals name="annotation_issue_info_text">
+        <item quantity="one"><![CDATA[<b>1 minor issue</b> affecting station rewards.]]></item>
+        <item quantity="other"><![CDATA[<b>%d minor issues</b> affecting station rewards.]]></item>
+    </plurals>
+    <plurals name="annotation_issue_warn_error_text">
+        <item quantity="one"><![CDATA[<b>1 issue</b> affecting station rewards.]]></item>
+        <item quantity="other"><![CDATA[<b>%d issues</b> affecting station rewards.]]></item>
+    </plurals>
+    <plurals name="cell_active_station">
+        <item quantity="one">1 active station</item>
+        <item quantity="other">%d active stations</item>
+    </plurals>
+</resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -246,10 +246,6 @@
     <string name="annotation_info_text"><![CDATA[Minor issues slightly affected your rewards. This may happen occasionally, but we thought you should know. View reward details to identify and fix problems.]]></string>
     <string name="annotation_warn_text"><![CDATA[Some issues prevent your station from getting the full rewards. View reward details to identify and fix problems.]]></string>
     <string name="annotation_error_text"><![CDATA[Serious problems were detected, that prevent the station from getting the full rewards. View reward details to identify and fix problems.]]></string>
-    <string name="annotation_issue_info_text"><![CDATA[<b>1 minor issue</b> affecting station rewards.]]></string>
-    <string name="annotation_issues_info_text"><![CDATA[<b>%d minor issues</b> affecting station rewards.]]></string>
-    <string name="annotation_issue_warn_error_text"><![CDATA[<b>1 issue</b> affecting station rewards.]]></string>
-    <string name="annotation_issues_warn_error_text"><![CDATA[<b>%d issues</b> affecting station rewards.]]></string>
     <string name="rewards_empty_title">Rewards Coming Soon!</string>
     <string name="rewards_empty_message">Station hasn’t received any rewards yet. Sit back and relax, while our systems are validating the station’s location and data. The station should start receiving rewards in the next couple of days.</string>
     <string name="rewards_empty_pro_tip">Pro Tip</string>
@@ -550,8 +546,6 @@
 
 
     <!-- Cell Info -->
-    <string name="cell_active_station">1 active station</string>
-    <string name="cell_active_stations">%d active stations</string>
     <string name="cell_stations_present">%d/10 stations present</string>
     <string name="cell_capacity">Cell Capacity</string>
     <string name="cell_capacity_explanation">Cell capacity is a parameter that is used to define the maximum number of stations that are eligible for rewards in a specific cell. Every cell has a predefined capacity that depends on its geospatial characteristics*\n\nEvery station is ranked in its cell daily, based on its reward score and its seniority. As long as the station’s ranking is above the capacity threshold, it will be rewarded, whereas getting below it will lead to zero rewards. For example, in a cell with a max capacity of 5 stations, if a station is ranked 3rd it will get rewarded, but if it is ranked 7th, it won’t receive any rewards.\n\nRead more about how our Cell Capacity algorithm works.\n\n* The cell capacity is currently set to the fixed value of 10 rewardable stations, for every cell.</string>


### PR DESCRIPTION
## **Why?**
Use Plurals and get them as quantity strings where applicable.

### **How?**
- Created a `plurals.xml` values file where we setup our new quantity strings
- Removed the now deprecated strings from `strings.xml`
- Use `getQuantityString` function as described [here](https://stackoverflow.com/questions/41950952/how-to-use-android-quantity-strings-plurals](https://stackoverflow.com/questions/41950952/how-to-use-android-quantity-strings-plurals) in order to get the correct string which eventually reduces the number of `if...else` checks and simplifies the code.

### **Testing**
1. Ensure that the following screens work correctly for 0, 1 and more than 1 alerts/issues. Try either against the API or by playing with local mock.
    - Rewards Timeline - `get_device_rewards_timeline.json`
    - Reward Details -  `get_device_reward_details.json`

2. Ensure that the "Active Stations" in the cell details work correctly for 0, 1 and more than 1 stations.