### PR TITLE
FE-961 Fix add button not visible

### DIFF
--- a/app/src/main/java/com/weatherxm/ui/home/HomeActivity.kt
+++ b/app/src/main/java/com/weatherxm/ui/home/HomeActivity.kt
@@ -156,14 +156,19 @@ class HomeActivity : BaseActivity(), BaseMapFragment.OnMapDebugInfoListener {
         // Fetch user's devices
         devicesViewModel.fetch()
 
-        /*
-        * Changing the theme from Profile -> Settings and going back to profile
-        * shows the "Add Device" floating button visible again. This code is to fix this.
+        /**
+         * Changing the theme from Profile -> Settings and going back to profile
+         * shows the "Add Device" floating button visible again. This code is to fix this.
          */
         val navDestination = navController.currentDestination?.id
         binding.networkStatsBtn.visible(navDestination == R.id.navigation_explorer)
         binding.myLocationBtn.visible(navDestination == R.id.navigation_explorer)
-        binding.addDevice.visible(navDestination == R.id.navigation_devices)
+        /**
+         * https://linear.app/weatherxm/issue/FE-961/add-button-is-not-visible
+         */
+        if (navDestination == R.id.navigation_profile) {
+            binding.addDevice.hide()
+        }
     }
 
     private fun onExplorerState(resource: Resource<ExplorerData>) {

--- a/app/src/main/java/com/weatherxm/ui/home/HomeActivity.kt
+++ b/app/src/main/java/com/weatherxm/ui/home/HomeActivity.kt
@@ -164,7 +164,9 @@ class HomeActivity : BaseActivity(), BaseMapFragment.OnMapDebugInfoListener {
         binding.networkStatsBtn.visible(navDestination == R.id.navigation_explorer)
         binding.myLocationBtn.visible(navDestination == R.id.navigation_explorer)
         /**
-         * https://linear.app/weatherxm/issue/FE-961/add-button-is-not-visible
+         * Don't use the visible function for the addButton 
+         * because of a specific case hiding it in the devices list.
+         * Therefore we use the hide() function which fits our purpose.
          */
         if (navDestination == R.id.navigation_profile) {
             binding.addDevice.hide()


### PR DESCRIPTION
## **Why?**
Issue with a screen recording can be found [here](https://linear.app/weatherxm/issue/FE-961/add-button-is-not-visible).

### **How?**
Don't use the `visible` function in any case for the `addButton` and better handling of the previous caught bug.

### **Testing**
Watch the video [here](https://linear.app/weatherxm/issue/FE-961/add-button-is-not-visible) and ensure that this behavior is not taking place anymore.