### PR TITLE
FE-993 Add installationId as a suffix in App Version in settings

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -249,7 +249,6 @@ android {
         variant.resValue("string", "app_version", version)
 
         // Proper apk file name
-
         variant.outputs
             .map { it as com.android.build.gradle.internal.api.ApkVariantOutputImpl }
             .forEach { output ->

--- a/app/src/main/java/com/weatherxm/data/Modules.kt
+++ b/app/src/main/java/com/weatherxm/data/Modules.kt
@@ -541,7 +541,7 @@ private val usecases = module {
         ConnectWalletUseCaseImpl(get())
     }
     single<PreferencesUseCase> {
-        PreferencesUseCaseImpl(get(), get())
+        PreferencesUseCaseImpl(get(), get(), get())
     }
     single<SendFeedbackUseCase> {
         SendFeedbackUseCaseImpl(get())

--- a/app/src/main/java/com/weatherxm/ui/preferences/PreferenceFragment.kt
+++ b/app/src/main/java/com/weatherxm/ui/preferences/PreferenceFragment.kt
@@ -52,27 +52,22 @@ class PreferenceFragment : PreferenceFragmentCompat() {
     override fun onCreatePreferences(savedInstanceState: Bundle?, rootKey: String?) {
         setPreferencesFromResource(R.xml.preferences, rootKey)
 
-        val openDocumentationButton: Preference? =
-            findPreference(getString(R.string.documentation_title))
+        val openDocsButton: Preference? = findPreference(getString(R.string.documentation_title))
         val announcementsButton: Preference? =
             findPreference(getString(R.string.announcements_title))
         val contactSupportButton: Preference? =
             findPreference(getString(R.string.contact_support_title))
-        val userResearchButton: Preference? =
-            findPreference(getString(R.string.user_panel_title))
-        val displayPreference =
-            findPreference<ListPreference>(getString(R.string.key_theme))
-        val shortWxmSurvey: Preference? =
-            findPreference(getString(R.string.short_app_survey))
+        val userResearchButton: Preference? = findPreference(getString(R.string.user_panel_title))
+        val displayPreference = findPreference<ListPreference>(getString(R.string.key_theme))
+        val shortWxmSurvey: Preference? = findPreference(getString(R.string.short_app_survey))
         val analyticsPreference =
             findPreference<SwitchPreferenceCompat>(getString(R.string.key_google_analytics))
         val notificationsPreference =
             findPreference<SwitchPreferenceCompat>(getString(R.string.notifications_preference_key))
         val logoutBtn: Preference? = findPreference(getString(R.string.action_logout))
-        val resetPassBtn: Preference? =
-            findPreference(getString(R.string.change_password))
-        val deleteAccountButton: Preference? =
-            findPreference(getString(R.string.delete_account))
+        val resetPassBtn: Preference? = findPreference(getString(R.string.change_password))
+        val deleteAccountButton: Preference? = findPreference(getString(R.string.delete_account))
+        val appVersionPref: Preference? = findPreference(getString(R.string.title_app_version))
 
         /*
          * Disable switching of notifications toggle as we prompt user to do it via the settings
@@ -80,7 +75,7 @@ class PreferenceFragment : PreferenceFragmentCompat() {
         notificationsPreference?.setOnPreferenceChangeListener { _, _ ->
             false
         }
-        openDocumentationButton?.onPreferenceClickListener = Preference.OnPreferenceClickListener {
+        openDocsButton?.onPreferenceClickListener = Preference.OnPreferenceClickListener {
             analytics.trackEventSelectContent(AnalyticsService.ParamValue.DOCUMENTATION.paramValue)
             navigator.openWebsite(context, getString(R.string.docs_url))
             true
@@ -101,10 +96,15 @@ class PreferenceFragment : PreferenceFragmentCompat() {
             navigator.openWebsite(this.context, getString(R.string.user_panel_url))
             true
         }
-
         displayPreference?.setOnPreferenceChangeListener { _, newValue ->
             displayModeHelper.setDisplayMode(newValue.toString())
             true
+        }
+        /**
+         * If `installationId` is available, append it at the end of the app version
+         */
+        model.getInstallationId()?.let {
+            appVersionPref?.summary = getString(R.string.app_version) + "-$it"
         }
 
         model.isLoggedIn().observe(this) { result ->

--- a/app/src/main/java/com/weatherxm/ui/preferences/PreferenceViewModel.kt
+++ b/app/src/main/java/com/weatherxm/ui/preferences/PreferenceViewModel.kt
@@ -70,4 +70,6 @@ class PreferenceViewModel(
         preferencesUseCase.setAnalyticsEnabled(enabled)
         analytics.setAnalyticsEnabled(enabled)
     }
+
+    fun getInstallationId(): String? = preferencesUseCase.getInstallationId()
 }

--- a/app/src/main/java/com/weatherxm/usecases/PreferencesUseCase.kt
+++ b/app/src/main/java/com/weatherxm/usecases/PreferencesUseCase.kt
@@ -2,6 +2,7 @@ package com.weatherxm.usecases
 
 import arrow.core.Either
 import com.weatherxm.data.Failure
+import com.weatherxm.data.repository.AppConfigRepository
 import com.weatherxm.data.repository.AuthRepository
 import com.weatherxm.data.repository.UserPreferencesRepository
 
@@ -11,10 +12,12 @@ interface PreferencesUseCase {
     fun hasDismissedSurveyPrompt(): Boolean
     fun dismissSurveyPrompt()
     fun setAnalyticsEnabled(enabled: Boolean)
+    fun getInstallationId(): String?
 }
 
 class PreferencesUseCaseImpl(
     private val authRepository: AuthRepository,
+    private val appConfigRepository: AppConfigRepository,
     private val userPreferencesRepository: UserPreferencesRepository
 ) : PreferencesUseCase {
 
@@ -36,5 +39,9 @@ class PreferencesUseCaseImpl(
 
     override fun setAnalyticsEnabled(enabled: Boolean) {
         return userPreferencesRepository.setAnalyticsEnabled(enabled)
+    }
+
+    override fun getInstallationId(): String? {
+        return appConfigRepository.getInstallationId()
     }
 }

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -141,6 +141,7 @@
         <Preference
             app:enableCopying="true"
             app:iconSpaceReserved="false"
+            app:key="@string/title_app_version"
             app:summary="@string/app_version"
             app:title="@string/title_app_version" />
     </PreferenceCategory>


### PR DESCRIPTION
## **Why?**
Add installationId as a suffix in App Version in settings

### **How?**
Get `installationId` through Repo -> UseCase -> ViewModel -> Fragment and then append it at the currently shown "app version".
```
        /**
         * If `installationId` is available, append it at the end of the app version
         */
        model.getInstallationId()?.let {
            appVersionPref?.summary = getString(R.string.app_version) + "-$it"
        }
```

### **Testing**
Ensure that the installationId is there.