### PR TITLE
FE-1013 Prevent a crash and print some logs in FirebaseCrashlytics

### DIFF
--- a/app/src/main/java/com/weatherxm/ui/deviceforecast/ForecastDetailsActivity.kt
+++ b/app/src/main/java/com/weatherxm/ui/deviceforecast/ForecastDetailsActivity.kt
@@ -21,9 +21,9 @@ import com.weatherxm.ui.common.parcelable
 import com.weatherxm.ui.common.screenLocation
 import com.weatherxm.ui.common.setColor
 import com.weatherxm.ui.common.setDisplayTimezone
-import com.weatherxm.ui.common.visible
 import com.weatherxm.ui.common.setWeatherAnimation
 import com.weatherxm.ui.common.toast
+import com.weatherxm.ui.common.visible
 import com.weatherxm.ui.components.BaseActivity
 import com.weatherxm.ui.components.LineChartView
 import com.weatherxm.util.DateTimeHelper.getRelativeDayAndShort

--- a/app/src/main/java/com/weatherxm/ui/deviceforecast/ForecastDetailsViewModel.kt
+++ b/app/src/main/java/com/weatherxm/ui/deviceforecast/ForecastDetailsViewModel.kt
@@ -94,7 +94,8 @@ class ForecastDetailsViewModel(
              * Temporary code so we can figure out why some crashes occur, in which cases/dates
              */
             val allDates = forecast.forecastDays.joinToString(" : ") { it.date.toString() }
-            Timber.e("Could not find selected day in forecast: $selectedISODate $allDates")
+            Timber.e("Could not find selected day " +
+                "($selectedISODate - $selectedLocalDate) in forecast: $allDates")
             0
         } else {
             position

--- a/app/src/main/java/com/weatherxm/ui/deviceforecast/ForecastDetailsViewModel.kt
+++ b/app/src/main/java/com/weatherxm/ui/deviceforecast/ForecastDetailsViewModel.kt
@@ -5,6 +5,7 @@ import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.weatherxm.R
+import com.weatherxm.analytics.AnalyticsWrapper
 import com.weatherxm.data.ApiError
 import com.weatherxm.data.Failure
 import com.weatherxm.data.HourlyWeather
@@ -16,7 +17,6 @@ import com.weatherxm.ui.common.UIForecast
 import com.weatherxm.ui.common.UIForecastDay
 import com.weatherxm.usecases.ChartsUseCase
 import com.weatherxm.usecases.ForecastUseCase
-import com.weatherxm.analytics.AnalyticsWrapper
 import com.weatherxm.util.Failure.getDefaultMessage
 import com.weatherxm.util.Resources
 import kotlinx.coroutines.launch
@@ -80,13 +80,24 @@ class ForecastDetailsViewModel(
     }
 
     fun getSelectedDayPosition(selectedISODate: String?): Int {
-        return if (selectedISODate != null) {
-            val selectedLocalDate = LocalDate.parse(selectedISODate)
-            forecast.forecastDays.indexOfFirst {
-                it.date == selectedLocalDate
-            }
-        } else {
+        if (selectedISODate == null) {
+            return 0
+        }
+
+        val selectedLocalDate = LocalDate.parse(selectedISODate)
+        val position = forecast.forecastDays.indexOfFirst {
+            it.date == selectedLocalDate
+        }
+
+        return if (position == -1) {
+            /**
+             * Temporary code so we can figure out why some crashes occur, in which cases/dates
+             */
+            val allDates = forecast.forecastDays.joinToString(" : ") { it.date.toString() }
+            Timber.e("Could not find selected day in forecast: $selectedISODate $allDates")
             0
+        } else {
+            position
         }
     }
 


### PR DESCRIPTION
### **Why?**
Prevent a crash and print some logs in FirebaseCrashlytics so we can figure out the cases it happens in Forecast Details.

### **How?**
If `position == -1` (which produces a crash afterwards), catch it, return `0` as the fallback and print the error through `Timber.e` so we can try to reproduce it afterwards.

### **Testing**
Not testable as I haven't reproduced it yet. So I'm printing some logs in Firebase Crashlytics in case they help.