### PR TITLE
FE-1016 Better non-fatal reporting in some cases.

### DIFF
--- a/app/src/main/java/com/weatherxm/data/bluetooth/BluetoothConnectionManager.kt
+++ b/app/src/main/java/com/weatherxm/data/bluetooth/BluetoothConnectionManager.kt
@@ -189,13 +189,21 @@ class BluetoothConnectionManager(
             Timber.w(e, "Connection to peripheral failed with ConnectionRejectedException")
             Either.Left(BluetoothError.ConnectionRejectedError())
         } catch (e: CancellationException) {
-            Timber.w(e, "Connection to peripheral failed with CancellationException")
+            /**
+             * Timber.d because that we do not need to log in our Crashlytics that the device
+             * has been disconnected because the user cancelled the connection
+             */
+            Timber.d(e, "Connection to peripheral failed with CancellationException")
             Either.Left(BluetoothError.CancellationError())
         } catch (e: BluetoothDisabledException) {
             Timber.w(e, "Connection to peripheral failed with BluetoothDisabledException")
             Either.Left(BluetoothError.BluetoothDisabledException())
         } catch (e: ConnectionLostException) {
-            Timber.w(e, "Connection to peripheral failed with ConnectionLostException")
+            /**
+             * Timber.d because that we do not need to log in our Crashlytics that the device
+             * has been disconnected probably because it's too far away
+             */
+            Timber.d(e, "Connection to peripheral failed with ConnectionLostException")
             Either.Left(BluetoothError.ConnectionLostException())
         } catch (e: GattRequestRejectedException) {
             Timber.w(e, "Connection to peripheral failed with GattRequestRejectedException")
@@ -236,9 +244,7 @@ class BluetoothConnectionManager(
             peripheral.write(descriptor, ENABLE_NOTIFICATION_VALUE)
         } catch (e: GattWriteException) {
             Timber.w(
-                e,
-                "[enable descriptor notification]: " +
-                    "GattWriteException - Result: ${e.result}, Name: ${e.result.name}"
+                e, "[enable descriptor notification]: GattWriteException - Result: ${e.result}"
             )
         } catch (e: GattRequestRejectedException) {
             Timber.w(e, "[enable descriptor notification]: GattRequestRejectedException")

--- a/app/src/main/java/com/weatherxm/ui/widgets/currentweather/CurrentWeatherWidgetWorkerUpdate.kt
+++ b/app/src/main/java/com/weatherxm/ui/widgets/currentweather/CurrentWeatherWidgetWorkerUpdate.kt
@@ -121,10 +121,6 @@ class CurrentWeatherWidgetWorkerUpdate(
                 }
             }
             .getOrElse { failure ->
-                Timber.w(
-                    Exception("Fetching user device for widget failed: ${failure.code}"),
-                    failure.toString()
-                )
                 when (failure) {
                     is UserNotLoggedInError -> Result.success()
                     is ForbiddenError -> {
@@ -132,7 +128,13 @@ class CurrentWeatherWidgetWorkerUpdate(
                         context.sendBroadcast(intent)
                         Result.success()
                     }
-                    else -> Result.retry()
+                    else -> {
+                        Timber.w(
+                            Exception("Fetching user device for widget failed: ${failure.code}"),
+                            failure.toString()
+                        )
+                        Result.retry()
+                    }
                 }
             }
     }


### PR DESCRIPTION
### **Why?**
Better non-fatal reporting in some cases as we do not need some reports we had (e.g. user cancelled reported as non-fatal error).

### **How?**
- Replaced in 2 instances `Timber.w` with `Timber.d` in order not to record it on Crashlytics and left a respective comment
- In Widget Updater Worker record on Crashlytics only the failures associated with `Result.retry` which are the unexpected ones we need to find their cause and solve them.