### PR TITLE
FE-1022 Use STATE instead of STATUS in token claiming result event

### DIFF
--- a/app/src/main/java/com/weatherxm/ui/home/profile/ProfileFragment.kt
+++ b/app/src/main/java/com/weatherxm/ui/home/profile/ProfileFragment.kt
@@ -217,7 +217,7 @@ class ProfileFragment : BaseFragment() {
         analytics.trackEventViewContent(
             contentName = AnalyticsService.ParamValue.TOKEN_CLAIMING_RESULT.paramValue,
             contentId = null,
-            customParams = arrayOf(Pair(AnalyticsService.CustomParam.STATUS.paramName, statusValue))
+            customParams = arrayOf(Pair(AnalyticsService.CustomParam.STATE.paramName, statusValue))
         )
     }
 


### PR DESCRIPTION
### **How?**
Replaced `STATUS` with `STATE`.