### PR TITLE
FE-1029 Feature/user properties owned stations wallet

### DIFF
--- a/app/src/main/java/com/weatherxm/analytics/AnalyticsService.kt
+++ b/app/src/main/java/com/weatherxm/analytics/AnalyticsService.kt
@@ -269,6 +269,8 @@ interface AnalyticsService {
         INCHES("in"),
         HPA("hpa"),
         INHG("inhg"),
+        STATIONS_OWN("STATIONS_OWN"),
+        HAS_WALLET("HAS_WALLET")
     }
 
     fun setUserId(userId: String)

--- a/app/src/main/java/com/weatherxm/analytics/AnalyticsWrapper.kt
+++ b/app/src/main/java/com/weatherxm/analytics/AnalyticsWrapper.kt
@@ -18,6 +18,16 @@ class AnalyticsWrapper(
     private var areAnalyticsEnabled: Boolean = false
     private var displayMode: String = AnalyticsService.UserProperty.SYSTEM.propertyName
     private var devicesSortFilterOptions: List<String> = mutableListOf()
+    private var devicesOwn: Int = 0
+    private var hasWallet: Boolean = false
+
+    fun setDevicesOwn(devicesOwn: Int) {
+        this.devicesOwn = devicesOwn
+    }
+
+    fun setHasWallet(hasWallet: Boolean) {
+        this.hasWallet = hasWallet
+    }
 
     fun setUserId(userId: String) {
         if (userId.isNotEmpty()) {
@@ -150,6 +160,14 @@ class AnalyticsWrapper(
                 )
             )
         }
+
+        userParams.add(
+            Pair(AnalyticsService.UserProperty.STATIONS_OWN.propertyName, devicesOwn.toString())
+        )
+
+        userParams.add(
+            Pair(AnalyticsService.UserProperty.HAS_WALLET.propertyName, hasWallet.toString())
+        )
 
         analytics.forEach { it.setUserProperties(userParams) }
         return userParams

--- a/app/src/main/java/com/weatherxm/analytics/AnalyticsWrapper.kt
+++ b/app/src/main/java/com/weatherxm/analytics/AnalyticsWrapper.kt
@@ -11,6 +11,8 @@ import com.weatherxm.ui.common.DevicesSortOrder
 import com.weatherxm.ui.common.empty
 import com.weatherxm.util.Weather
 
+// Suppress it as it's just a bunch of set/get functions
+@Suppress("TooManyFunctions")
 class AnalyticsWrapper(
     private var analytics: List<AnalyticsService>,
     private val context: Context

--- a/app/src/main/java/com/weatherxm/app/AnalyticsInitializer.kt
+++ b/app/src/main/java/com/weatherxm/app/AnalyticsInitializer.kt
@@ -19,6 +19,8 @@ class AnalyticsInitializer : Initializer<Unit>, KoinComponent {
         analyticsWrapper.setAnalyticsEnabled(enabled)
         analyticsWrapper.setUserId(cacheService.getUserId())
         analyticsWrapper.setDevicesSortFilterOptions(cacheService.getDevicesSortFilterOptions())
+        analyticsWrapper.setDevicesOwn(cacheService.getDevicesOwn())
+        analyticsWrapper.setHasWallet(cacheService.hasWallet())
         analyticsWrapper.setUserProperties()
         return
     }

--- a/app/src/main/java/com/weatherxm/data/services/CacheService.kt
+++ b/app/src/main/java/com/weatherxm/data/services/CacheService.kt
@@ -40,6 +40,8 @@ class CacheService(
         const val KEY_DEVICES_SORT = "devices_sort"
         const val KEY_DEVICES_FILTER = "devices_filter"
         const val KEY_DEVICES_GROUP_BY = "devices_group_by"
+        const val KEY_DEVICES_OWN = "devices_own"
+        const val KEY_HAS_WALLET = "has_wallet"
         const val WIDGET_ID = "widget_id"
         const val KEY_USER_ID = "user_id"
         const val KEY_INSTALLATION_ID = "installation_id"
@@ -155,6 +157,11 @@ class CacheService(
 
     fun setWalletAddress(address: String) {
         this.walletAddress = address
+        preferences.edit().putBoolean(KEY_HAS_WALLET, true).apply()
+    }
+
+    fun hasWallet(): Boolean {
+        return preferences.getBoolean(KEY_HAS_WALLET, false)
     }
 
     fun getUser(): Either<Failure, User> {
@@ -302,6 +309,11 @@ class CacheService(
 
     fun setUserDevicesIds(ids: List<String>) {
         userStationsIds = ids
+        preferences.edit().putInt(KEY_DEVICES_OWN, ids.size).apply()
+    }
+
+    fun getDevicesOwn(): Int {
+        return preferences.getInt(KEY_DEVICES_OWN, 0)
     }
 
     fun getCountriesInfo(): List<CountryInfo> {

--- a/app/src/test/java/com/weatherxm/analytics/AnalyticsWrapperTest.kt
+++ b/app/src/test/java/com/weatherxm/analytics/AnalyticsWrapperTest.kt
@@ -27,6 +27,8 @@ class AnalyticsWrapperTest : KoinTest, BehaviorSpec({
     val verifier = AnalyticsWrapperTestCallVerifier(service1, service2, analyticsWrapper)
     val testUserID = "test123"
     val testDisplayMode = "dark"
+    val testDevicesOwn = 6
+    val testHasWallet = true
 
     fun AnalyticsService.mockResponses() {
         every { setAnalyticsEnabled(any() as Boolean) } just Runs
@@ -81,10 +83,12 @@ class AnalyticsWrapperTest : KoinTest, BehaviorSpec({
     context("Set user params and track events") {
         given("some predefined users params") {
             analyticsWrapper.setUserId(testUserID)
+            analyticsWrapper.setDevicesOwn(testDevicesOwn)
+            analyticsWrapper.setHasWallet(testHasWallet)
             analyticsWrapper.setDisplayMode(testDisplayMode)
             analyticsWrapper.setDevicesSortFilterOptions(listOf("DATE_ADDED", "ALL", "NO_GROUPING"))
             with(analyticsWrapper.setUserProperties()) {
-                size shouldBe 9
+                size shouldBe 11
                 this[0] shouldBe ("theme" to testDisplayMode)
                 this[1] shouldBe ("UNIT_TEMPERATURE" to "c")
                 this[2] shouldBe ("UNIT_WIND" to "mps")
@@ -94,6 +98,8 @@ class AnalyticsWrapperTest : KoinTest, BehaviorSpec({
                 this[6] shouldBe ("SORT_BY" to "date_added")
                 this[7] shouldBe ("FILTER" to "all")
                 this[8] shouldBe ("GROUP_BY" to "no_grouping")
+                this[9] shouldBe ("STATIONS_OWN" to "$testDevicesOwn")
+                this[10] shouldBe ("HAS_WALLET" to "$testHasWallet")
             }
             verifier.verifyUserIdSet(testUserID)
             verifier.verifyUserPropertiesSet()


### PR DESCRIPTION
### **Why?**
Add in Analytics User Properties the `STATIONS_OWN` and `HAS_WALLET` params.

### **How?**
Save the respective entries in `SharedPreferences` and use them on `AnalyticsInitializer` in order to set them as user params.

### **Testing**
Ensure that these params are logged correctly **after** the first run (as the cache needs to be initialized first) by checking the logger in Android Studio.