### PR TITLE
FE-1065 Use Flavor-specific MIXPANEL_TOKEN

### DIFF
--- a/.github/workflows/on-main-firebase-distribution.yml
+++ b/.github/workflows/on-main-firebase-distribution.yml
@@ -19,8 +19,6 @@ env:
     ORG_GRADLE_PROJECT_DEBUG_KEY_PASSWORD: ${{ secrets.DEBUG_KEY_PASSWORD }}
     # Firebase distribution on tech team group
     ORG_GRADLE_PROJECT_FIREBASE_TEST_GROUP: ${{ secrets.FIREBASE_TECH_TEAM_TEST_GROUP }}
-    # Mixpanel Token
-    ORG_GRADLE_PROJECT_MIXPANEL_TOKEN: ${{ secrets.MIXPANEL_TOKEN }}
     # Gradle config
     GRADLE_USER_HOME: ${GITHUB_WORKSPACE}/.gradle
     GLOBAL_GRADLE_CACHE: gradle-cache-${GITHUB_REPOSITORY}
@@ -32,6 +30,8 @@ jobs:
             ORG_GRADLE_PROJECT_API_URL: ${{ secrets.API_URL }}
             # Claim DApp URL
             ORG_GRADLE_PROJECT_CLAIM_APP_URL: ${{ secrets.CLAIM_APP_URL }}
+            # Mixpanel Token
+            ORG_GRADLE_PROJECT_MIXPANEL_TOKEN: ${{ secrets.MIXPANEL_TOKEN }}
         runs-on: ubuntu-latest
         steps:
             -   name: Checkout

--- a/.github/workflows/on-pr.yml
+++ b/.github/workflows/on-pr.yml
@@ -17,8 +17,6 @@ env:
     ORG_GRADLE_PROJECT_RELEASE_KEY_PASSWORD: ${{ secrets.RELEASE_KEY_PASSWORD }}
     # Firebase distribution on tech team group
     ORG_GRADLE_PROJECT_FIREBASE_TEST_GROUP: ${{ secrets.FIREBASE_TECH_TEAM_TEST_GROUP }}
-    # Mixpanel Token
-    ORG_GRADLE_PROJECT_MIXPANEL_TOKEN: ${{ secrets.MIXPANEL_TOKEN }}
     # Gradle config
     GRADLE_USER_HOME: ${GITHUB_WORKSPACE}/.gradle
     GLOBAL_GRADLE_CACHE: gradle-cache-${GITHUB_REPOSITORY}
@@ -32,6 +30,8 @@ jobs:
             ORG_GRADLE_PROJECT_API_URL: ${{ secrets.API_URL }}
             # Claim DApp URL
             ORG_GRADLE_PROJECT_CLAIM_APP_URL: ${{ secrets.CLAIM_APP_URL }}
+            # Mixpanel Token
+            ORG_GRADLE_PROJECT_MIXPANEL_TOKEN: ${{ secrets.MIXPANEL_TOKEN }}
         runs-on: ubuntu-latest
         steps:
             -   name: Checkout
@@ -67,6 +67,8 @@ jobs:
             ORG_GRADLE_PROJECT_API_URL: ${{ secrets.API_URL }}
             # Claim DApp URL
             ORG_GRADLE_PROJECT_CLAIM_APP_URL: ${{ secrets.CLAIM_APP_URL }}
+            # Mixpanel Token
+            ORG_GRADLE_PROJECT_MIXPANEL_TOKEN: ${{ secrets.MIXPANEL_TOKEN }}
         runs-on: ubuntu-latest
         steps:
             -   name: Checkout
@@ -99,6 +101,8 @@ jobs:
             ORG_GRADLE_PROJECT_API_URL: ${{ secrets.API_URL }}
             # Claim DApp URL
             ORG_GRADLE_PROJECT_CLAIM_APP_URL: ${{ secrets.CLAIM_APP_URL }}
+            # Mixpanel Token
+            ORG_GRADLE_PROJECT_MIXPANEL_TOKEN: ${{ secrets.MIXPANEL_TOKEN }}
         runs-on: ubuntu-latest
         steps:
             -   name: Checkout
@@ -139,6 +143,8 @@ jobs:
             ORG_GRADLE_PROJECT_API_URL: ${{ secrets.API_URL }}
             # Claim DApp URL
             ORG_GRADLE_PROJECT_CLAIM_APP_URL: ${{ secrets.CLAIM_APP_URL }}
+            # Mixpanel Token
+            ORG_GRADLE_PROJECT_MIXPANEL_TOKEN: ${{ secrets.MIXPANEL_TOKEN }}
         runs-on: ubuntu-latest
         steps:
             -   name: Checkout

--- a/.github/workflows/on-qa-firebase-distribution.yml
+++ b/.github/workflows/on-qa-firebase-distribution.yml
@@ -32,8 +32,6 @@ env:
     ORG_GRADLE_PROJECT_DEBUG_KEY_PASSWORD: ${{ secrets.DEBUG_KEY_PASSWORD }}
     # Firebase distribution only on QA Group
     ORG_GRADLE_PROJECT_FIREBASE_TEST_GROUP: ${{ secrets.FIREBASE_QA_TEST_GROUP }}
-    # Mixpanel Token
-    ORG_GRADLE_PROJECT_MIXPANEL_TOKEN: ${{ secrets.MIXPANEL_TOKEN }}
     # Gradle config
     GRADLE_USER_HOME: ${GITHUB_WORKSPACE}/.gradle
     GLOBAL_GRADLE_CACHE: gradle-cache-${GITHUB_REPOSITORY}
@@ -45,6 +43,8 @@ jobs:
             ORG_GRADLE_PROJECT_API_URL: ${{ secrets.API_URL }}
             # Claim DApp URL
             ORG_GRADLE_PROJECT_CLAIM_APP_URL: ${{ secrets.CLAIM_APP_URL }}
+            # Mixpanel Token
+            ORG_GRADLE_PROJECT_MIXPANEL_TOKEN: ${{ secrets.MIXPANEL_TOKEN }}
         runs-on: ubuntu-latest
         steps:
             -   name: Checkout

--- a/.github/workflows/production-distribution.yml
+++ b/.github/workflows/production-distribution.yml
@@ -15,8 +15,6 @@ env:
     ORG_GRADLE_PROJECT_RELEASE_KEY_PASSWORD: ${{ secrets.RELEASE_KEY_PASSWORD }}
     # Firebase distribution on tech team group
     ORG_GRADLE_PROJECT_FIREBASE_TEST_GROUP: ${{ secrets.FIREBASE_TECH_TEAM_TEST_GROUP }}
-    # Mixpanel Token
-    ORG_GRADLE_PROJECT_MIXPANEL_TOKEN: ${{ secrets.MIXPANEL_TOKEN }}
     # Gradle config
     GRADLE_USER_HOME: ${GITHUB_WORKSPACE}/.gradle
     GLOBAL_GRADLE_CACHE: gradle-cache-${GITHUB_REPOSITORY}
@@ -28,6 +26,8 @@ jobs:
             ORG_GRADLE_PROJECT_API_URL: ${{ secrets.API_URL }}
             # Claim DApp URL
             ORG_GRADLE_PROJECT_CLAIM_APP_URL: ${{ secrets.CLAIM_APP_URL }}
+            # Mixpanel Token
+            ORG_GRADLE_PROJECT_MIXPANEL_TOKEN: ${{ secrets.MIXPANEL_TOKEN }}
         runs-on: ubuntu-latest
         steps:
             -   name: Checkout

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -88,8 +88,6 @@ android {
         resValue("string", "mapbox_access_token", getStringProperty("MAPBOX_ACCESS_TOKEN"))
         resValue("string", "mapbox_style", getStringProperty("MAPBOX_STYLE"))
 
-        buildConfigField("String", "MIXPANEL_TOKEN", "\"${getStringProperty("MIXPANEL_TOKEN")}\"")
-
         // Instrumented Tests
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }
@@ -125,6 +123,7 @@ android {
         create("mock") {
             val apiURL = getFlavorProperty("API_URL", "remotemock.env")
             val claimDAppUrl = getFlavorProperty("CLAIM_APP_URL", "remotemock.env")
+            val mixpanelToken = getFlavorProperty("MIXPANEL_TOKEN", "remotemock.env")
             dimension = "server"
             applicationIdSuffix = ".mock"
             resValue("string", "app_name", "WXM Remote Mock")
@@ -133,10 +132,12 @@ android {
             buildConfigField("String", "API_URL", "\"$apiURL\"")
             buildConfigField("String", "AUTH_URL", "\"$apiURL\"")
             buildConfigField("String", "CLAIM_APP_URL", "\"$claimDAppUrl\"")
+            buildConfigField("String", "MIXPANEL_TOKEN", "\"$mixpanelToken\"")
         }
         create("staging") {
             val apiURL = getFlavorProperty("API_URL", "staging.env")
             val claimDAppUrl = getFlavorProperty("CLAIM_APP_URL", "staging.env")
+            val mixpanelToken = getFlavorProperty("MIXPANEL_TOKEN", "staging.env")
             dimension = "server"
             applicationIdSuffix = ".staging"
             resValue("string", "app_name", "WXM Staging")
@@ -145,6 +146,7 @@ android {
             buildConfigField("String", "API_URL", "\"$apiURL\"")
             buildConfigField("String", "AUTH_URL", "\"$apiURL\"")
             buildConfigField("String", "CLAIM_APP_URL", "\"$claimDAppUrl\"")
+            buildConfigField("String", "MIXPANEL_TOKEN", "\"$mixpanelToken\"")
             firebaseAppDistribution {
                 artifactType = "APK"
                 releaseNotes = "Release notes for staging version"
@@ -155,6 +157,7 @@ android {
         create("dev") {
             val apiURL = getFlavorProperty("API_URL", "development.env")
             val claimDAppUrl = getFlavorProperty("CLAIM_APP_URL", "development.env")
+            val mixpanelToken = getFlavorProperty("MIXPANEL_TOKEN", "development.env")
             dimension = "server"
             applicationIdSuffix = ".dev"
             resValue("string", "app_name", "WXM Dev")
@@ -163,6 +166,7 @@ android {
             buildConfigField("String", "API_URL", "\"$apiURL\"")
             buildConfigField("String", "AUTH_URL", "\"$apiURL\"")
             buildConfigField("String", "CLAIM_APP_URL", "\"$claimDAppUrl\"")
+            buildConfigField("String", "MIXPANEL_TOKEN", "\"$mixpanelToken\"")
             firebaseAppDistribution {
                 artifactType = "APK"
                 releaseNotes = "Release notes for development version"
@@ -173,6 +177,7 @@ android {
         create("prod") {
             val apiURL = getFlavorProperty("API_URL", "production.env")
             val claimDAppUrl = getFlavorProperty("CLAIM_APP_URL", "production.env")
+            val mixpanelToken = getFlavorProperty("MIXPANEL_TOKEN", "production.env")
             dimension = "server"
             resValue("string", "app_name", "WeatherXM")
             manifestPlaceholders["auth_host"] = "app.weatherxm.com"
@@ -180,6 +185,7 @@ android {
             buildConfigField("String", "API_URL", "\"$apiURL\"")
             buildConfigField("String", "AUTH_URL", "\"$apiURL\"")
             buildConfigField("String", "CLAIM_APP_URL", "\"$claimDAppUrl\"")
+            buildConfigField("String", "MIXPANEL_TOKEN", "\"$mixpanelToken\"")
             firebaseAppDistribution {
                 artifactType = "APK"
                 releaseNotes = "Release notes for production version"


### PR DESCRIPTION
### **Why?**
Use Flavor-specific `MIXPANEL_TOKEN` in order to integrate the new `DEV` token for the Mixpanel.

### **How?**
1. In `app/build.gradle` get the `MIXPANEL_TOKEN` through `getFlavorProperty` which takes the property from the flavor-specific `.env` and if it doesn't exist it uses the default one.
2. Use the `environment` variables in GitHub workflows to get the `MIXPANEL_TOKEN`
3. Updated those environment variables in this repo.

### **Testing**
Ensure that events are logged in the dev project when running a dev flavor.