### PR TITLE
FE-1071 Use 2 decimals on tokens

### DIFF
--- a/app/src/main/java/com/weatherxm/util/Rewards.kt
+++ b/app/src/main/java/com/weatherxm/util/Rewards.kt
@@ -45,7 +45,7 @@ object Rewards {
     }
 
     fun formatTokens(amount: BigDecimal): String {
-        val decimalFormat = DecimalFormat("0.00##")
+        val decimalFormat = DecimalFormat("0.00")
         decimalFormat.roundingMode = RoundingMode.HALF_UP
         return decimalFormat.format(amount)
     }

--- a/app/src/test/java/com/weatherxm/util/RewardsTest.kt
+++ b/app/src/test/java/com/weatherxm/util/RewardsTest.kt
@@ -79,11 +79,9 @@ class RewardsTest : BehaviorSpec({
                 }
             }
             When("it has >=3 decimals") {
-                then("the formatter should return the amount with 3 or 4 decimals") {
-                    formatTokens(10.001F) shouldBe "10.001"
-                    formatTokens(10.0001F) shouldBe "10.0001"
-                    formatTokens(10.0006F) shouldBe "10.0006"
-                    formatTokens(10.00006F) shouldBe "10.0001"
+                then("the formatter should return the amount with 2 decimals") {
+                    formatTokens(10.001F) shouldBe "10.00"
+                    formatTokens(10.005F) shouldBe "10.01"
                 }
             }
         }
@@ -97,7 +95,7 @@ class RewardsTest : BehaviorSpec({
             }
             When("it is bigger than zero") {
                 then("the validator should return make the conversion and format the tokens") {
-                    formatTokens(weiToETH(9.9999999E14F.toBigDecimal())) shouldBe "0.001"
+                    formatTokens(weiToETH(BigDecimal.valueOf(10000000000000000))) shouldBe "0.01"
                 }
             }
         }


### PR DESCRIPTION
### **Why?**
$WXM should be displayed with two decimals places

### **How?**
In `formatTokens` instead of `val decimalFormat = DecimalFormat("0.00##")` use `val decimalFormat = DecimalFormat("0.00")`

### **Testing**
Ensure that all screens affected (as reported in the Linear issue) are OK.