### PR TITLE
FE-1097 Fix crashes in 4.1.1

### DIFF
--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -30,6 +30,9 @@
  -keep,allowobfuscation,allowshrinking interface retrofit2.Call
  -keep,allowobfuscation,allowshrinking class retrofit2.Response
 
+ # For the network response adapter (https://github.com/skydoves/retrofit-adapters/issues/24)
+ -keep,allowobfuscation,allowshrinking class arrow.core.Either
+
  # With R8 full mode generic signatures are stripped for classes that are not
  # kept. Suspend functions are wrapped in continuations where the type argument
  # is used.


### PR DESCRIPTION
### **Why?**
Crashes taking place in 4.1.1.

### **How?**
Add Proguard rules for keeping Either due to using it in the network response adapter.