### PR TITLE
FE-1081 Remove app survey prompt from the settings

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -219,7 +219,7 @@
             android:screenOrientation="portrait"
             android:theme="@style/Theme.WeatherXM" />
         <activity
-            android:name="com.weatherxm.ui.sendfeedback.SendFeedbackActivity"
+            android:name="com.weatherxm.ui.deleteaccountsurvey.DeleteAccountSurveyActivity"
             android:screenOrientation="portrait"
             android:theme="@style/Theme.WeatherXM" />
         <activity

--- a/app/src/main/java/com/weatherxm/analytics/AnalyticsService.kt
+++ b/app/src/main/java/com/weatherxm/analytics/AnalyticsService.kt
@@ -216,7 +216,6 @@ interface AnalyticsService {
         NOTIFICATIONS("notifications"),
         ON("on"),
         OFF("off"),
-        APP_SURVEY("App Survey"),
         USER_RESEARCH_PANEL("User Research Panel"),
         WEB_DOCUMENTATION("Web Documentation"),
         INFO_DAILY_REWARDS("info_daily_rewards"),

--- a/app/src/main/java/com/weatherxm/data/Modules.kt
+++ b/app/src/main/java/com/weatherxm/data/Modules.kt
@@ -159,6 +159,7 @@ import com.weatherxm.ui.claimdevice.pulse.ClaimPulseViewModel
 import com.weatherxm.ui.claimdevice.wifi.ClaimWifiViewModel
 import com.weatherxm.ui.connectwallet.ConnectWalletViewModel
 import com.weatherxm.ui.deleteaccount.DeleteAccountViewModel
+import com.weatherxm.ui.deleteaccountsurvey.DeleteAccountSurveyViewModel
 import com.weatherxm.ui.devicedetails.DeviceDetailsViewModel
 import com.weatherxm.ui.devicedetails.current.CurrentViewModel
 import com.weatherxm.ui.devicedetails.forecast.ForecastViewModel
@@ -186,7 +187,6 @@ import com.weatherxm.ui.rewardboosts.RewardBoostViewModel
 import com.weatherxm.ui.rewarddetails.RewardDetailsViewModel
 import com.weatherxm.ui.rewardsclaim.RewardsClaimViewModel
 import com.weatherxm.ui.rewardslist.RewardsListViewModel
-import com.weatherxm.ui.deleteaccountsurvey.DeleteAccountSurveyViewModel
 import com.weatherxm.ui.signup.SignupViewModel
 import com.weatherxm.ui.startup.StartupViewModel
 import com.weatherxm.ui.updateprompt.UpdatePromptViewModel
@@ -208,6 +208,8 @@ import com.weatherxm.usecases.ClaimDeviceUseCase
 import com.weatherxm.usecases.ClaimDeviceUseCaseImpl
 import com.weatherxm.usecases.ConnectWalletUseCase
 import com.weatherxm.usecases.ConnectWalletUseCaseImpl
+import com.weatherxm.usecases.DeleteAccountSurveyUseCase
+import com.weatherxm.usecases.DeleteAccountSurveyUseCaseImpl
 import com.weatherxm.usecases.DeleteAccountUseCase
 import com.weatherxm.usecases.DeleteAccountUseCaseImpl
 import com.weatherxm.usecases.DeviceDetailsUseCase
@@ -230,8 +232,6 @@ import com.weatherxm.usecases.PreferencesUseCase
 import com.weatherxm.usecases.PreferencesUseCaseImpl
 import com.weatherxm.usecases.RewardsUseCase
 import com.weatherxm.usecases.RewardsUseCaseImpl
-import com.weatherxm.usecases.SendFeedbackUseCase
-import com.weatherxm.usecases.SendFeedbackUseCaseImpl
 import com.weatherxm.usecases.StartupUseCase
 import com.weatherxm.usecases.StartupUseCaseImpl
 import com.weatherxm.usecases.StationSettingsUseCase
@@ -521,8 +521,8 @@ private val usecases = module {
     single<PreferencesUseCase> {
         PreferencesUseCaseImpl(get(), get(), get())
     }
-    single<SendFeedbackUseCase> {
-        SendFeedbackUseCaseImpl(get())
+    single<DeleteAccountSurveyUseCase> {
+        DeleteAccountSurveyUseCaseImpl(get())
     }
     single<DeleteAccountUseCase> {
         DeleteAccountUseCaseImpl(get(), get())

--- a/app/src/main/java/com/weatherxm/data/Modules.kt
+++ b/app/src/main/java/com/weatherxm/data/Modules.kt
@@ -186,7 +186,7 @@ import com.weatherxm.ui.rewardboosts.RewardBoostViewModel
 import com.weatherxm.ui.rewarddetails.RewardDetailsViewModel
 import com.weatherxm.ui.rewardsclaim.RewardsClaimViewModel
 import com.weatherxm.ui.rewardslist.RewardsListViewModel
-import com.weatherxm.ui.sendfeedback.SendFeedbackViewModel
+import com.weatherxm.ui.deleteaccountsurvey.DeleteAccountSurveyViewModel
 import com.weatherxm.ui.signup.SignupViewModel
 import com.weatherxm.ui.startup.StartupViewModel
 import com.weatherxm.ui.updateprompt.UpdatePromptViewModel
@@ -965,7 +965,7 @@ private val viewmodels = module {
         )
     }
     viewModel { params -> RewardBoostViewModel(params.get(), get(), get(), get()) }
-    viewModel { SendFeedbackViewModel(get(), get(), get()) }
+    viewModel { DeleteAccountSurveyViewModel(get(), get()) }
     viewModel { SignupViewModel(get(), get(), get()) }
     viewModel { UpdatePromptViewModel(get()) }
     viewModel { UrlRouterViewModel(get(), get(), get()) }

--- a/app/src/main/java/com/weatherxm/data/datasource/UserPreferenceDataSource.kt
+++ b/app/src/main/java/com/weatherxm/data/datasource/UserPreferenceDataSource.kt
@@ -7,8 +7,6 @@ interface UserPreferenceDataSource {
     fun setAnalyticsEnabled(enabled: Boolean)
     fun getDevicesSortFilterOptions(): List<String>
     fun setDevicesSortFilterOptions(sortOrder: String, filter: String, groupBy: String)
-    fun hasDismissedSurveyPrompt(): Boolean
-    fun dismissSurveyPrompt()
     fun setWalletWarningDismissTimestamp()
     fun getWalletWarningDismissTimestamp(): Long
 }
@@ -31,14 +29,6 @@ class UserPreferenceDataSourceImpl(
 
     override fun setDevicesSortFilterOptions(sortOrder: String, filter: String, groupBy: String) {
         cacheService.setDevicesSortFilterOptions(sortOrder, filter, groupBy)
-    }
-
-    override fun hasDismissedSurveyPrompt(): Boolean {
-        return cacheService.hasDismissedSurveyPrompt()
-    }
-
-    override fun dismissSurveyPrompt() {
-        cacheService.dismissSurveyPrompt()
     }
 
     override fun setWalletWarningDismissTimestamp() {

--- a/app/src/main/java/com/weatherxm/data/repository/UserPreferencesRepository.kt
+++ b/app/src/main/java/com/weatherxm/data/repository/UserPreferencesRepository.kt
@@ -6,8 +6,6 @@ interface UserPreferencesRepository {
     fun shouldShowAnalyticsOptIn(): Boolean
     fun setAnalyticsEnabled(enabled: Boolean)
     fun getWalletWarningDismissTimestamp(): Long
-    fun hasDismissedSurveyPrompt(): Boolean
-    fun dismissSurveyPrompt()
     fun setWalletWarningDismissTimestamp()
     fun getDevicesSortFilterOptions(): List<String>
     fun setDevicesSortFilterOptions(sortOrder: String, filter: String, groupBy: String)
@@ -23,14 +21,6 @@ class UserPreferencesRepositoryImpl(
 
     override fun setAnalyticsEnabled(enabled: Boolean) {
         datasource.setAnalyticsEnabled(enabled)
-    }
-
-    override fun hasDismissedSurveyPrompt(): Boolean {
-        return datasource.hasDismissedSurveyPrompt()
-    }
-
-    override fun dismissSurveyPrompt() {
-        datasource.dismissSurveyPrompt()
     }
 
     override fun setWalletWarningDismissTimestamp() {

--- a/app/src/main/java/com/weatherxm/data/services/CacheService.kt
+++ b/app/src/main/java/com/weatherxm/data/services/CacheService.kt
@@ -34,7 +34,6 @@ class CacheService(
         const val KEY_LAST_REMINDED_VERSION = "last_reminded_version"
         const val KEY_ANALYTICS_OPT_IN_OR_OUT_TIMESTAMP = "analytics_opt_in_or_out_timestamp"
         const val KEY_USERNAME = "username"
-        const val KEY_DISMISSED_SURVEY_PROMPT = "dismissed_survey_prompt"
         const val KEY_WALLET_WARNING_DISMISSED_TIMESTAMP = "wallet_warning_dismissed_timestamp"
         const val KEY_CURRENT_WEATHER_WIDGET_IDS = "current_weather_widget_ids"
         const val KEY_DEVICES_SORT = "devices_sort"
@@ -205,14 +204,6 @@ class CacheService(
 
     fun setSuggestionLocation(suggestion: SearchSuggestion, location: Location) {
         locations[suggestion.id] = location
-    }
-
-    fun hasDismissedSurveyPrompt(): Boolean {
-        return preferences.getBoolean(KEY_DISMISSED_SURVEY_PROMPT, false)
-    }
-
-    fun dismissSurveyPrompt() {
-        preferences.edit().putBoolean(KEY_DISMISSED_SURVEY_PROMPT, true).apply()
     }
 
     fun setWalletWarningDismissTimestamp() {

--- a/app/src/main/java/com/weatherxm/ui/Navigator.kt
+++ b/app/src/main/java/com/weatherxm/ui/Navigator.kt
@@ -39,7 +39,6 @@ import com.weatherxm.ui.common.Contracts.ARG_DEVICE_ID
 import com.weatherxm.ui.common.Contracts.ARG_DEVICE_TYPE
 import com.weatherxm.ui.common.Contracts.ARG_EXPLORER_CELL
 import com.weatherxm.ui.common.Contracts.ARG_FORECAST_SELECTED_DAY
-import com.weatherxm.ui.common.Contracts.ARG_IS_DELETE_ACCOUNT_FORM
 import com.weatherxm.ui.common.Contracts.ARG_OPEN_EXPLORER_ON_BACK
 import com.weatherxm.ui.common.Contracts.ARG_REMOTE_MESSAGE
 import com.weatherxm.ui.common.Contracts.ARG_REWARD
@@ -56,6 +55,7 @@ import com.weatherxm.ui.components.LoginPromptDialogFragment
 import com.weatherxm.ui.components.MessageDialogFragment
 import com.weatherxm.ui.connectwallet.ConnectWalletActivity
 import com.weatherxm.ui.deleteaccount.DeleteAccountActivity
+import com.weatherxm.ui.deleteaccountsurvey.DeleteAccountSurveyActivity
 import com.weatherxm.ui.devicealerts.DeviceAlertsActivity
 import com.weatherxm.ui.devicedetails.DeviceDetailsActivity
 import com.weatherxm.ui.deviceeditlocation.DeviceEditLocationActivity
@@ -79,7 +79,6 @@ import com.weatherxm.ui.rewarddetails.RewardDetailsActivity
 import com.weatherxm.ui.rewardissues.RewardIssuesActivity
 import com.weatherxm.ui.rewardsclaim.RewardsClaimActivity
 import com.weatherxm.ui.rewardslist.RewardsListActivity
-import com.weatherxm.ui.sendfeedback.SendFeedbackActivity
 import com.weatherxm.ui.signup.SignupActivity
 import com.weatherxm.ui.startup.StartupActivity
 import com.weatherxm.ui.updateprompt.UpdatePromptActivity
@@ -231,14 +230,12 @@ class Navigator(private val analytics: AnalyticsWrapper) {
         context.startActivity(Intent.createChooser(intent, context.getString(R.string.share)))
     }
 
-    fun showSendFeedback(
+    fun showDeleteAccountSurvey(
         activityResultLauncher: ActivityResultLauncher<Intent>,
-        context: Context,
-        isDeleteAccountForm: Boolean = false
+        context: Context
     ) {
-        val intent = Intent(context, SendFeedbackActivity::class.java)
+        val intent = Intent(context, DeleteAccountSurveyActivity::class.java)
             .addFlags(Intent.FLAG_ACTIVITY_SINGLE_TOP or Intent.FLAG_ACTIVITY_CLEAR_TOP)
-            .putExtra(ARG_IS_DELETE_ACCOUNT_FORM, isDeleteAccountForm)
         activityResultLauncher.launch(intent)
     }
 
@@ -320,18 +317,6 @@ class Navigator(private val analytics: AnalyticsWrapper) {
             Intent(context, ConnectWalletActivity::class.java)
                 .addFlags(Intent.FLAG_ACTIVITY_SINGLE_TOP or Intent.FLAG_ACTIVITY_CLEAR_TOP)
         )
-    }
-
-    fun showSendFeedback(
-        activityResultLauncher: ActivityResultLauncher<Intent>,
-        fragment: Fragment
-    ) {
-        fragment.context?.let {
-            activityResultLauncher.launch(
-                Intent(it, SendFeedbackActivity::class.java)
-                    .addFlags(Intent.FLAG_ACTIVITY_SINGLE_TOP or Intent.FLAG_ACTIVITY_CLEAR_TOP)
-            )
-        }
     }
 
     fun showClaimSelectStationType(context: Context) {

--- a/app/src/main/java/com/weatherxm/ui/common/Contracts.kt
+++ b/app/src/main/java/com/weatherxm/ui/common/Contracts.kt
@@ -5,7 +5,6 @@ object Contracts {
     const val ARG_DEVICE_TYPE = "device_type"
     const val ARG_BLE_DEVICE_CONNECTED = "ble_device_connected"
     const val ARG_USER_MESSAGE = "user_message"
-    const val ARG_IS_DELETE_ACCOUNT_FORM = "is_delete_account_form"
     const val ARG_IS_CUSTOM_APPWIDGET_UPDATE = "is_custom_appwidget_update"
     const val ARG_WIDGET_TYPE = "widget_type"
     const val ARG_WIDGET_ID = "widget_id"

--- a/app/src/main/java/com/weatherxm/ui/deleteaccount/DeleteAccountActivity.kt
+++ b/app/src/main/java/com/weatherxm/ui/deleteaccount/DeleteAccountActivity.kt
@@ -3,7 +3,6 @@ package com.weatherxm.ui.deleteaccount
 import android.app.Activity
 import android.os.Bundle
 import androidx.activity.addCallback
-import androidx.activity.result.ActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
 import com.weatherxm.R
 import com.weatherxm.analytics.AnalyticsService
@@ -25,11 +24,9 @@ class DeleteAccountActivity : BaseActivity() {
     private val model: DeleteAccountViewModel by viewModel()
 
     // Register the launcher for the claim device activity and wait for a possible result
-    private val sendFeedbackLauncher =
-        registerForActivityResult(
-            ActivityResultContracts.StartActivityForResult()
-        ) { result: ActivityResult ->
-            if (result.resultCode == Activity.RESULT_OK) {
+    private val surveyLauncher =
+        registerForActivityResult(ActivityResultContracts.StartActivityForResult()) {
+            if (it.resultCode == Activity.RESULT_OK) {
                 toast(getString(R.string.thank_you_feedback))
             }
         }
@@ -109,7 +106,7 @@ class DeleteAccountActivity : BaseActivity() {
             }
 
             takeSurvey.setOnClickListener {
-                navigator.showDeleteAccountSurvey(sendFeedbackLauncher, this@DeleteAccountActivity)
+                navigator.showDeleteAccountSurvey(surveyLauncher, this@DeleteAccountActivity)
             }
 
             retryDeletion.setOnClickListener {

--- a/app/src/main/java/com/weatherxm/ui/deleteaccount/DeleteAccountActivity.kt
+++ b/app/src/main/java/com/weatherxm/ui/deleteaccount/DeleteAccountActivity.kt
@@ -109,7 +109,7 @@ class DeleteAccountActivity : BaseActivity() {
             }
 
             takeSurvey.setOnClickListener {
-                navigator.showSendFeedback(sendFeedbackLauncher, this@DeleteAccountActivity, true)
+                navigator.showDeleteAccountSurvey(sendFeedbackLauncher, this@DeleteAccountActivity)
             }
 
             retryDeletion.setOnClickListener {

--- a/app/src/main/java/com/weatherxm/ui/deleteaccountsurvey/DeleteAccountSurveyActivity.kt
+++ b/app/src/main/java/com/weatherxm/ui/deleteaccountsurvey/DeleteAccountSurveyActivity.kt
@@ -1,26 +1,24 @@
-package com.weatherxm.ui.sendfeedback
+package com.weatherxm.ui.deleteaccountsurvey
 
 import android.annotation.SuppressLint
 import android.app.Activity
 import android.os.Bundle
 import android.webkit.WebView
 import android.webkit.WebViewClient
+import com.weatherxm.R
 import com.weatherxm.databinding.ActivityWebviewBinding
-import com.weatherxm.ui.common.Contracts.ARG_IS_DELETE_ACCOUNT_FORM
 import com.weatherxm.ui.components.BaseActivity
 import org.koin.androidx.viewmodel.ext.android.viewModel
 
-class SendFeedbackActivity : BaseActivity() {
+class DeleteAccountSurveyActivity : BaseActivity() {
     private lateinit var binding: ActivityWebviewBinding
-    private val model: SendFeedbackViewModel by viewModel()
+    private val model: DeleteAccountSurveyViewModel by viewModel()
 
     @SuppressLint("SetJavaScriptEnabled")
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         binding = ActivityWebviewBinding.inflate(layoutInflater)
         setContentView(binding.root)
-
-        val isDeleteAccountForm = intent?.extras?.getBoolean(ARG_IS_DELETE_ACCOUNT_FORM) ?: false
 
         binding.toolbar.setNavigationOnClickListener {
             onBackPressedDispatcher.onBackPressed()
@@ -31,11 +29,8 @@ class SendFeedbackActivity : BaseActivity() {
         binding.webview.webViewClient = object : WebViewClient() {
             override fun onPageFinished(view: WebView, url: String) {
                 // Hack way to make some fields hidden (like userID)
-                if (isDeleteAccountForm) {
-                    view.loadUrl(model.getJavascriptInjectionCodeDeleteForm())
-                } else {
-                    view.loadUrl(model.getJavascriptInjectionCodeSurveyForm())
-                }
+                view.loadUrl(model.getJavascriptInjectionCode())
+
                 if (model.isUrlFormResponse(url)) {
                     setResult(Activity.RESULT_OK)
                 }
@@ -43,6 +38,7 @@ class SendFeedbackActivity : BaseActivity() {
             }
         }
 
-        binding.webview.loadUrl(model.getPrefilledSurveyFormUrl(isDeleteAccountForm))
+        val surveyUrl = getString(R.string.delete_account_survey_url)
+        binding.webview.loadUrl(model.getPrefilledSurveyFormUrl(surveyUrl))
     }
 }

--- a/app/src/main/java/com/weatherxm/ui/deleteaccountsurvey/DeleteAccountSurveyViewModel.kt
+++ b/app/src/main/java/com/weatherxm/ui/deleteaccountsurvey/DeleteAccountSurveyViewModel.kt
@@ -2,10 +2,10 @@ package com.weatherxm.ui.deleteaccountsurvey
 
 import androidx.lifecycle.ViewModel
 import com.weatherxm.data.ClientIdentificationHelper
-import com.weatherxm.usecases.SendFeedbackUseCase
+import com.weatherxm.usecases.DeleteAccountSurveyUseCase
 
 class DeleteAccountSurveyViewModel(
-    private val useCase: SendFeedbackUseCase,
+    private val useCase: DeleteAccountSurveyUseCase,
     private val clientIdentificationHelper: ClientIdentificationHelper
 ) : ViewModel() {
     companion object {

--- a/app/src/main/java/com/weatherxm/ui/deleteaccountsurvey/DeleteAccountSurveyViewModel.kt
+++ b/app/src/main/java/com/weatherxm/ui/deleteaccountsurvey/DeleteAccountSurveyViewModel.kt
@@ -1,29 +1,21 @@
-package com.weatherxm.ui.sendfeedback
+package com.weatherxm.ui.deleteaccountsurvey
 
 import androidx.lifecycle.ViewModel
-import com.weatherxm.R
 import com.weatherxm.data.ClientIdentificationHelper
 import com.weatherxm.usecases.SendFeedbackUseCase
-import com.weatherxm.util.Resources
 
-class SendFeedbackViewModel(
+class DeleteAccountSurveyViewModel(
     private val useCase: SendFeedbackUseCase,
-    private val clientIdentificationHelper: ClientIdentificationHelper,
-    private val resources: Resources
+    private val clientIdentificationHelper: ClientIdentificationHelper
 ) : ViewModel() {
     companion object {
         const val USER_ID_ENTRY = "entry.695293761"
         const val APP_ID_ENTRY = "entry.2052436656"
     }
 
-    fun getPrefilledSurveyFormUrl(isDeleteAccount: Boolean): String {
+    fun getPrefilledSurveyFormUrl(feedbackUrl: String): String {
         val clientIdentifier = clientIdentificationHelper.getInterceptorClientIdentifier()
         val userId = useCase.getUserId()
-        val feedbackUrl = if (isDeleteAccount) {
-            resources.getString(R.string.delete_account_survey_url)
-        } else {
-            resources.getString(R.string.short_app_survey_url)
-        }
 
         return if (userId.isNotEmpty()) {
             "$feedbackUrl&$APP_ID_ENTRY=$clientIdentifier&$USER_ID_ENTRY=$userId"
@@ -32,15 +24,7 @@ class SendFeedbackViewModel(
         }
     }
 
-    fun getJavascriptInjectionCodeSurveyForm(): String {
-        return "javascript:(function() { " +
-            "document.getElementsByClassName('Dq4amc')[0].style.display='none'; " +
-            "document.getElementsByClassName('Qr7Oae')[5].style.display='none'; " +
-            "document.getElementsByClassName('Qr7Oae')[6].style.display='none'; " +
-            "})()"
-    }
-
-    fun getJavascriptInjectionCodeDeleteForm(): String {
+    fun getJavascriptInjectionCode(): String {
         return "javascript:(function() { " +
             "document.getElementsByClassName('Dq4amc')[0].style.display='none'; " +
             "document.getElementsByClassName('Qr7Oae')[2].style.display='none'; " +

--- a/app/src/main/java/com/weatherxm/ui/preferences/PreferenceActivity.kt
+++ b/app/src/main/java/com/weatherxm/ui/preferences/PreferenceActivity.kt
@@ -5,17 +5,14 @@ import android.content.Intent
 import android.content.SharedPreferences
 import android.os.Bundle
 import android.view.MenuItem
-import com.weatherxm.R
 import com.weatherxm.analytics.AnalyticsService
 import com.weatherxm.databinding.ActivityPreferencesBinding
 import com.weatherxm.ui.common.Contracts
 import com.weatherxm.ui.common.classSimpleName
-import com.weatherxm.ui.common.visible
 import com.weatherxm.ui.components.BaseActivity
 import com.weatherxm.util.WidgetHelper
 import org.koin.android.ext.android.inject
 import org.koin.androidx.viewmodel.ext.android.viewModel
-import timber.log.Timber
 
 class PreferenceActivity : BaseActivity() {
     private lateinit var binding: ActivityPreferencesBinding
@@ -30,30 +27,6 @@ class PreferenceActivity : BaseActivity() {
 
         binding.toolbar.setNavigationOnClickListener {
             onBackPressedDispatcher.onBackPressed()
-        }
-
-        binding.surveyPrompt.action(getString(R.string.short_app_survey_prompt_desc), null) {
-            model.showSurveyScreen()
-        }
-
-        binding.surveyPrompt.closeButton {
-            model.dismissSurveyPrompt()
-        }
-
-        if (model.hasDismissedSurveyPrompt()) {
-            binding.surveyPrompt.visible(false)
-        }
-
-        model.onDismissSurveyPrompt().observe(this) {
-            if (it) binding.surveyPrompt.visible(true)
-        }
-
-        model.isLoggedIn().observe(this) { result ->
-            result
-                .mapLeft {
-                    Timber.d("Not logged in. Hide survey prompt.")
-                    binding.surveyPrompt.visible(false)
-                }
         }
 
         model.onLogout().observe(this) { hasLoggedOut ->

--- a/app/src/main/java/com/weatherxm/ui/preferences/PreferenceViewModel.kt
+++ b/app/src/main/java/com/weatherxm/ui/preferences/PreferenceViewModel.kt
@@ -24,15 +24,7 @@ class PreferenceViewModel(
     // Needed for passing info to the activity to when logging out
     private val onLogout = MutableLiveData(false)
 
-    // Needed for passing info to the fragment when user has clicked the start survey button
-    private val onShowSurveyScreen = MutableLiveData(false)
-
-    // Needed for passing info to the activity when the survey has been completed
-    private val onDismissSurveyPrompt = MutableLiveData(false)
-
     fun onLogout() = onLogout
-    fun onShowSurveyScreen() = onShowSurveyScreen
-    fun onDismissSurveyPrompt() = onDismissSurveyPrompt
 
     fun isLoggedIn(): LiveData<Either<Failure, Boolean>> = isLoggedIn
 
@@ -44,25 +36,12 @@ class PreferenceViewModel(
         }
     }
 
-    fun showSurveyScreen() {
-        onShowSurveyScreen.postValue(true)
-    }
-
     fun logout() {
         viewModelScope.launch(Dispatchers.IO) {
             analytics.onLogout()
             preferencesUseCase.logout()
             onLogout.postValue(true)
         }
-    }
-
-    fun hasDismissedSurveyPrompt(): Boolean {
-        return preferencesUseCase.hasDismissedSurveyPrompt()
-    }
-
-    fun dismissSurveyPrompt() {
-        preferencesUseCase.dismissSurveyPrompt()
-        onDismissSurveyPrompt.postValue(true)
     }
 
     fun setAnalyticsEnabled(enabled: Boolean) {

--- a/app/src/main/java/com/weatherxm/usecases/DeleteAccountSurveyUseCase.kt
+++ b/app/src/main/java/com/weatherxm/usecases/DeleteAccountSurveyUseCase.kt
@@ -2,11 +2,13 @@ package com.weatherxm.usecases
 
 import com.weatherxm.data.repository.UserRepository
 
-interface SendFeedbackUseCase {
+interface DeleteAccountSurveyUseCase {
     fun getUserId(): String
 }
 
-class SendFeedbackUseCaseImpl(private val userRepository: UserRepository) : SendFeedbackUseCase {
+class DeleteAccountSurveyUseCaseImpl(
+    private val userRepository: UserRepository
+) : DeleteAccountSurveyUseCase {
     override fun getUserId(): String {
         return userRepository.getUserId()
     }

--- a/app/src/main/java/com/weatherxm/usecases/PreferencesUseCase.kt
+++ b/app/src/main/java/com/weatherxm/usecases/PreferencesUseCase.kt
@@ -9,8 +9,6 @@ import com.weatherxm.data.repository.UserPreferencesRepository
 interface PreferencesUseCase {
     suspend fun isLoggedIn(): Either<Failure, Boolean>
     suspend fun logout()
-    fun hasDismissedSurveyPrompt(): Boolean
-    fun dismissSurveyPrompt()
     fun setAnalyticsEnabled(enabled: Boolean)
     fun getInstallationId(): String?
 }
@@ -27,14 +25,6 @@ class PreferencesUseCaseImpl(
 
     override suspend fun logout() {
         authRepository.logout()
-    }
-
-    override fun hasDismissedSurveyPrompt(): Boolean {
-        return userPreferencesRepository.hasDismissedSurveyPrompt()
-    }
-
-    override fun dismissSurveyPrompt() {
-        return userPreferencesRepository.dismissSurveyPrompt()
     }
 
     override fun setAnalyticsEnabled(enabled: Boolean) {

--- a/app/src/main/res/layout/activity_preferences.xml
+++ b/app/src/main/res/layout/activity_preferences.xml
@@ -33,27 +33,11 @@
             android:layout_width="match_parent"
             android:layout_height="match_parent">
 
-            <com.weatherxm.ui.components.MessageCardView
-                android:id="@+id/surveyPrompt"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:layout_marginHorizontal="@dimen/margin_normal"
-                android:visibility="gone"
-                app:layout_constraintTop_toTopOf="parent"
-                app:message_background_tint="@color/blueTint"
-                app:message_icon="@drawable/ic_survey"
-                app:message_icon_color="@color/colorPrimaryVariant"
-                app:message_includes_close_button="true"
-                app:message_stroke_color="@color/infoStrokeColor"
-                app:message_title="@string/short_app_survey"
-                tools:visibility="visible" />
-
             <androidx.fragment.app.FragmentContainerView
                 android:id="@+id/preferencesFragment"
                 android:name="com.weatherxm.ui.preferences.PreferenceFragment"
                 android:layout_width="match_parent"
-                android:layout_height="match_parent"
-                app:layout_constraintTop_toBottomOf="@id/surveyPrompt" />
+                android:layout_height="match_parent" />
 
         </androidx.constraintlayout.widget.ConstraintLayout>
 

--- a/app/src/main/res/values/company_info.xml
+++ b/app/src/main/res/values/company_info.xml
@@ -8,7 +8,6 @@
     <string name="troubleshooting_helium_url">https://docs.weatherxm.com/wxm-devices/helium/troubleshooting</string>
     <string name="troubleshooting_pulse_url">https://docs.weatherxm.com/wxm-devices/pulse/troubleshooting</string>
     <string name="user_panel_url">https://docs.google.com/forms/d/e/1FAIpQLSc35pJdxM0tosVh-az0goKEjE1xzBs_OVo5V23coC8z1ayD6g/viewform</string>
-    <string name="short_app_survey_url">https://docs.google.com/forms/d/e/1FAIpQLSc1T-odUwpXa01nODavwEtLgO00AfPxqfrdhbn_G5Lss0dD2w/viewform?usp=pp_url</string>
     <string name="delete_account_survey_url">https://docs.google.com/forms/d/e/1FAIpQLSdWPLpyUx2fNIiohQ-XaskbkZuoUSqYhwIkGGjupJ7IDEX_aA/viewform?usp=pp_url</string>
     <string name="market_url">market://details?id=%s</string>
     <string name="m5_connect_wifi_instructional_video">https://www.youtube.com/watch?v=sUJEwuFq1CE</string>

--- a/app/src/main/res/values/preferences.xml
+++ b/app/src/main/res/values/preferences.xml
@@ -21,9 +21,6 @@
     <string name="feedback">Feedback</string>
     <string name="user_panel_title">Join the WeatherXM User Panel</string>
     <string name="user_panel_desc">You may join the WeatherXM user research panel, share your insights and help shape the future of  WeatherXM apps and services.</string>
-    <string name="short_app_survey">Short App Survey</string>
-    <string name="short_app_survey_prompt_desc">Your feedback matters. Tap to take a very quick survey.</string>
-    <string name="short_app_survey_desc">Share your feedback by taking the WeatherXM app quick survey. It only has 2 mandatory questions!</string>
 
     <!-- Sorting & Filtering -->
     <string name="sort_filter">Sort &amp; Filter</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -463,7 +463,7 @@
     <string name="edit_name_helper_text">This friendly name is private. It will be visible only to you when you are logged in.</string>
     <string name="edit_name_hint">Enter a new friendly name</string>
 
-    <!-- Feedback -->
+    <!-- Delete Account Survey -->
     <string name="send_feedback">Short App Survey</string>
     <string name="thank_you_feedback">Thank you for your feedback!</string>
 

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -44,12 +44,6 @@
             app:key="@string/user_panel_title"
             app:summary="@string/user_panel_desc"
             app:title="@string/user_panel_title" />
-
-        <Preference
-            app:iconSpaceReserved="false"
-            app:key="@string/short_app_survey"
-            app:summary="@string/short_app_survey_desc"
-            app:title="@string/short_app_survey" />
     </PreferenceCategory>
 
     <PreferenceCategory

--- a/app/src/test/java/com/weatherxm/data/repository/UserPreferencesRepositoryTest.kt
+++ b/app/src/test/java/com/weatherxm/data/repository/UserPreferencesRepositoryTest.kt
@@ -19,7 +19,6 @@ class UserPreferencesRepositoryTest : BehaviorSpec({
 
     beforeSpec {
         justRun { dataSource.setAnalyticsEnabled(any()) }
-        justRun { dataSource.dismissSurveyPrompt() }
         justRun { dataSource.setWalletWarningDismissTimestamp() }
         every { dataSource.getWalletWarningDismissTimestamp() } returns 0
         justRun { dataSource.setDevicesSortFilterOptions(sort, filter, group) }
@@ -52,27 +51,6 @@ class UserPreferencesRepositoryTest : BehaviorSpec({
             every { dataSource.getAnalyticsOptInTimestamp() } returns 1
             then("return false") {
                 repo.shouldShowAnalyticsOptIn() shouldBe false
-            }
-        }
-    }
-
-    context("Get/Set Survey Prompt Dismiss Information") {
-        When("we have not dismissed the survey prompt") {
-            every { dataSource.hasDismissedSurveyPrompt() } returns false
-            then("return false") {
-                repo.hasDismissedSurveyPrompt() shouldBe false
-            }
-        }
-        When("we have dismissed the survey prompt") {
-            every { dataSource.hasDismissedSurveyPrompt() } returns true
-            then("return true") {
-                repo.hasDismissedSurveyPrompt() shouldBe true
-            }
-        }
-        When("we dismiss the survey prompt") {
-            then("dismiss it") {
-                repo.dismissSurveyPrompt()
-                verify(exactly = 1) { dataSource.dismissSurveyPrompt() }
             }
         }
     }


### PR DESCRIPTION
### **Why?**
Remove "Short App survey" option in Preferences & Settings screen

### **How?**
- Removed all relevant entries from the station settings, the data sources, the repositories and the cache
- Renamed `SendFeedbackXXX` to `DeleteAccountSurveyXXX` as this is the only use-case it currently serves as an in-app webview with JS Injection

### **Testing**
Ensure that the option is not visible anymore in settings.