### PR TITLE
FE-1116 Notification with device_id is stuck in loading state

### DIFF
--- a/app/src/main/java/com/weatherxm/ui/devicedetails/DeviceDetailsActivity.kt
+++ b/app/src/main/java/com/weatherxm/ui/devicedetails/DeviceDetailsActivity.kt
@@ -133,6 +133,13 @@ class DeviceDetailsActivity : BaseActivity() {
             }
         }
 
+        model.onDeviceFirstFetch().observe(this) {
+            if (it == null) {
+                toast(R.string.error_device_not_found)
+                finish()
+            }
+        }
+
         model.onFollowStatus().observe(this) {
             onFollowStatus(it, dialogOverlay)
         }

--- a/app/src/main/java/com/weatherxm/ui/devicedetails/DeviceDetailsViewModel.kt
+++ b/app/src/main/java/com/weatherxm/ui/devicedetails/DeviceDetailsViewModel.kt
@@ -50,9 +50,9 @@ class DeviceDetailsViewModel(
     private var isLoggedIn: Boolean? = null
     private val onDevicePolling = MutableLiveData<UIDevice>()
     private val onUpdatedDevice = MutableLiveData<UIDevice>()
-    private val onDeviceFirstFetch = MutableLiveData<UIDevice>()
+    private val onDeviceFirstFetch = MutableLiveData<UIDevice?>()
 
-    fun onDeviceFirstFetch(): LiveData<UIDevice> = onDeviceFirstFetch
+    fun onDeviceFirstFetch(): LiveData<UIDevice?> = onDeviceFirstFetch
     fun onDevicePolling(): LiveData<UIDevice> = onDevicePolling
     fun onUpdatedDevice(): LiveData<UIDevice> = onUpdatedDevice
     fun onFollowStatus(): LiveData<Resource<Unit>> = onFollowStatus
@@ -71,6 +71,11 @@ class DeviceDetailsViewModel(
             deviceDetailsUseCase.getUserOwnedDevice(deviceId).onRight {
                 onDeviceAutoRefresh(it)
             }.onLeft {
+                /**
+                 * Fetching the device failed, we should propagate null so that the Activity
+                 * terminates and not getting stuck in a loading state
+                 */
+                onDeviceFirstFetch.postValue(null)
                 analytics.trackEventFailure(it.code)
             }
         }

--- a/app/src/main/java/com/weatherxm/ui/devicedetails/forecast/ForecastFragment.kt
+++ b/app/src/main/java/com/weatherxm/ui/devicedetails/forecast/ForecastFragment.kt
@@ -13,8 +13,8 @@ import com.weatherxm.ui.common.DeviceRelation.UNFOLLOWED
 import com.weatherxm.ui.common.HourlyForecastAdapter
 import com.weatherxm.ui.common.blockParentViewPagerOnScroll
 import com.weatherxm.ui.common.classSimpleName
-import com.weatherxm.ui.common.setHtml
 import com.weatherxm.ui.common.invisible
+import com.weatherxm.ui.common.setHtml
 import com.weatherxm.ui.common.visible
 import com.weatherxm.ui.components.BaseFragment
 import com.weatherxm.ui.devicedetails.DeviceDetailsViewModel
@@ -89,9 +89,11 @@ class ForecastFragment : BaseFragment() {
             }
         }
 
-        parentModel.onDeviceFirstFetch().observe(viewLifecycleOwner) {
-            model.device = it
-            model.fetchForecast(true)
+        parentModel.onDeviceFirstFetch().observe(viewLifecycleOwner) { device ->
+            device?.let {
+                model.device = it
+                model.fetchForecast(true)
+            }
         }
 
         model.onForecast().observe(viewLifecycleOwner) {

--- a/app/src/main/java/com/weatherxm/ui/devicedetails/rewards/RewardsFragment.kt
+++ b/app/src/main/java/com/weatherxm/ui/devicedetails/rewards/RewardsFragment.kt
@@ -111,9 +111,11 @@ class RewardsFragment : BaseFragment() {
             showSnackbarMessage(binding.root, it.errorMessage, it.retryFunction)
         }
 
-        parentModel.onDeviceFirstFetch().observe(viewLifecycleOwner) {
-            model.device = it
-            model.fetchRewardsFromNetwork()
+        parentModel.onDeviceFirstFetch().observe(viewLifecycleOwner) { device ->
+            device?.let {
+                model.device = it
+                model.fetchRewardsFromNetwork()
+            }
         }
 
         binding.swiperefresh.setOnRefreshListener {


### PR DESCRIPTION
### **Why?**
Handle device first fetch error in device details in order to close the screen and show an error message.

### **How?**
On the first fetch when we have only the deviceId (which happens only in Notications) we had the following code:
```
deviceDetailsUseCase.getUserOwnedDevice(deviceId).onRight {
    onDeviceAutoRefresh(it)
}.onLeft {
    analytics.trackEventFailure(it.code)
}
```
So I transformed it to:
```
deviceDetailsUseCase.getUserOwnedDevice(deviceId).onRight {
    onDeviceAutoRefresh(it)
}.onLeft {
    /**
     * Fetching the device failed, we should propagate null so that the Activity
     * terminates and not getting stuck in a loading state
     */
    onDeviceFirstFetch.postValue(null)
    analytics.trackEventFailure(it.code)
}
```
And in the Activity we now have:
```
model.onDeviceFirstFetch().observe(this) {
    if (it == null) {
        Timber.d("Could not fetch device")
        toast(R.string.error_device_not_found)
        finish()
    }
}
```

### **Testing**
Send a test notification with a valid `deviceId` and one with invalid and ensure both behave properly.