### PR TITLE
FE-1104 Fix map blinking

### DIFF
--- a/app/src/main/java/com/weatherxm/data/Modules.kt
+++ b/app/src/main/java/com/weatherxm/data/Modules.kt
@@ -504,7 +504,7 @@ private val usecases = module {
         StartupUseCaseImpl(androidContext(), get(), get(), get())
     }
     single<ExplorerUseCase> {
-        ExplorerUseCaseImpl(get(), get(), get(), get(), get(), get(), get())
+        ExplorerUseCaseImpl(get(), get(), get(), get(), get())
     }
     single<DeviceDetailsUseCase> {
         DeviceDetailsUseCaseImpl(get(), get(), get(), get(), get())

--- a/app/src/main/java/com/weatherxm/ui/explorer/ExplorerActivity.kt
+++ b/app/src/main/java/com/weatherxm/ui/explorer/ExplorerActivity.kt
@@ -14,8 +14,8 @@ import com.weatherxm.ui.common.Animation.ShowAnimation.SlideInFromBottom
 import com.weatherxm.ui.common.Contracts.ARG_CELL_CENTER
 import com.weatherxm.ui.common.hide
 import com.weatherxm.ui.common.parcelable
-import com.weatherxm.ui.common.visible
 import com.weatherxm.ui.common.show
+import com.weatherxm.ui.common.visible
 import com.weatherxm.ui.components.BaseActivity
 import com.weatherxm.ui.components.BaseMapFragment
 import dev.chrisbanes.insetter.applyInsetter
@@ -48,7 +48,7 @@ class ExplorerActivity : BaseActivity(), BaseMapFragment.OnMapDebugInfoListener 
             }
         }
 
-        model.explorerState().observe(this) { resource ->
+        model.onStatus().observe(this) { resource ->
             Timber.d("Status updated: ${resource.status}")
             when (resource.status) {
                 Status.SUCCESS -> {
@@ -65,11 +65,6 @@ class ExplorerActivity : BaseActivity(), BaseMapFragment.OnMapDebugInfoListener 
                 }
             }
         }
-
-        model.onCellSelected().observe(this) {
-            navigator.showCellInfo(this, it)
-        }
-
         binding.networkStatsBtn.setOnClickListener {
             navigator.showNetworkStats(this)
         }

--- a/app/src/main/java/com/weatherxm/ui/explorer/ExplorerUIModels.kt
+++ b/app/src/main/java/com/weatherxm/ui/explorer/ExplorerUIModels.kt
@@ -8,6 +8,7 @@ import com.mapbox.maps.plugin.annotation.generated.PolygonAnnotationOptions
 import com.squareup.moshi.JsonClass
 import com.weatherxm.data.Bundle
 import com.weatherxm.data.Location
+import com.weatherxm.data.PublicHex
 import com.weatherxm.ui.common.BundleName
 import com.weatherxm.ui.common.DeviceRelation
 import com.weatherxm.ui.common.UIDevice
@@ -18,8 +19,9 @@ import timber.log.Timber
 @Keep
 @JsonClass(generateAdapter = true)
 data class ExplorerData(
-    var geoJsonSource: GeoJsonSource,
-    var polygonPoints: List<PolygonAnnotationOptions>,
+    val geoJsonSource: GeoJsonSource,
+    val publicHexes: List<PublicHex>,
+    var polygonsToDraw: List<PolygonAnnotationOptions> = listOf()
 )
 
 @Keep

--- a/app/src/main/java/com/weatherxm/ui/home/HomeActivity.kt
+++ b/app/src/main/java/com/weatherxm/ui/home/HomeActivity.kt
@@ -19,7 +19,6 @@ import com.weatherxm.ui.common.parcelable
 import com.weatherxm.ui.common.visible
 import com.weatherxm.ui.components.BaseActivity
 import com.weatherxm.ui.components.BaseMapFragment
-import com.weatherxm.ui.explorer.ExplorerData
 import com.weatherxm.ui.explorer.ExplorerViewModel
 import com.weatherxm.ui.home.devices.DevicesViewModel
 import dev.chrisbanes.insetter.applyInsetter
@@ -53,11 +52,7 @@ class HomeActivity : BaseActivity(), BaseMapFragment.OnMapDebugInfoListener {
         // Setup navigation view
         binding.navView.setupWithNavController(navController)
 
-        explorerModel.onCellSelected().observe(this) {
-            navigator.showCellInfo(this, it)
-        }
-
-        explorerModel.explorerState().observe(this) { resource ->
+        explorerModel.onStatus().observe(this) { resource ->
             onExplorerState(resource)
         }
 
@@ -173,7 +168,7 @@ class HomeActivity : BaseActivity(), BaseMapFragment.OnMapDebugInfoListener {
         }
     }
 
-    private fun onExplorerState(resource: Resource<ExplorerData>) {
+    private fun onExplorerState(resource: Resource<Unit>) {
         Timber.d("Status updated: ${resource.status}")
         when (resource.status) {
             Status.SUCCESS -> {

--- a/app/src/main/java/com/weatherxm/usecases/ExplorerUseCase.kt
+++ b/app/src/main/java/com/weatherxm/usecases/ExplorerUseCase.kt
@@ -1,7 +1,6 @@
 package com.weatherxm.usecases
 
 import arrow.core.Either
-import com.mapbox.geojson.Point
 import com.weatherxm.data.Failure
 import com.weatherxm.data.Location
 import com.weatherxm.ui.common.UIDevice
@@ -14,7 +13,6 @@ interface ExplorerUseCase {
         const val DEVICE_COUNT_KEY = "device_count"
     }
 
-    fun polygonPointsToLatLng(pointsOfPolygon: List<Location>): List<MutableList<Point>>
     suspend fun getCells(): Either<Failure, ExplorerData>
     suspend fun getCellDevices(cell: UICell): Either<Failure, List<UIDevice>>
     suspend fun getCellDevice(index: String, deviceId: String): Either<Failure, UIDevice>


### PR DESCRIPTION
### **Why?**
Fix map blinking by checking if new cells have been added in the explorer and using new onStatus, onExplorerData, onNewPolygons in order to populate the UI.

### **How?**
- Moved some functions in MapboxUtils where they should have been located
- Instead of using `explorerState` for everything (holding the data, showing the status of the network call, updating the UI), we created 3 different `LiveData`:
    - `onExplorerData` which is responsible for holding the data of the explorer
    - `onStatus`  which is responsible for representing the status of the network call (success/loading/error)
    -  `onNewPolygons` which is responsible for sending an event to the UI to draw the new Polygons (after the first fetch)
- Afterwards on `fetch` we handle everything accordingly and use the event we need in each case. We have created a `hexesIndexes` list in the `ExplorerViewModel` which is a list of the current hex indexes, in order for a quick comparison when new data arrive (due to comparing `strings` vs `string` it's much faster - much = seconds - than comparing `PolygonAnnotationOptions`).
- Removed `onPolygonClick` function and `onCellSelected` as they were unnecessary.

### **Testing**
Ensure that visiting the explorer, going to another screen and coming back to the explorer doesn't involve any blinking after the data are loaded.