### PR TITLE
FE-1135 Fix solar chart axis minimum

### DIFF
--- a/app/src/main/java/com/weatherxm/util/Charts.kt
+++ b/app/src/main/java/com/weatherxm/util/Charts.kt
@@ -510,12 +510,6 @@ fun LineChart.initSolarChart(
         }
         dataSets.addAll(radiationDataEmptyLineDataSets)
 
-        with(axisRight) {
-            isEnabled = true
-            isGranularityEnabled = true
-            granularity = 1F
-            axisMinimum = 0F
-        }
         radiationDataLineDataSetsWithValues.size + radiationDataEmptyLineDataSets.size
     } else {
         0
@@ -542,6 +536,7 @@ fun LineChart.initSolarChart(
         isGranularityEnabled = true
         granularity = 1F
     }
+    axisRight.axisMinimum = 0F
 
     // X axis settings
     xAxis.valueFormatter = CustomXAxisFormatter(uvData.timestamps)


### PR DESCRIPTION
### **Why?**
Solar irradiance "trend line" never gets to 0 on X axis.

### **How?**
Moved the `axisRight.axisMinimum = 0F` to the correct place (after `setDefaultSettings(...)`).

### **Testing**
Ensure that solar radiation line gets to 0.