### PR TITLE
FE-1144 FE-1142 Fixing of 2 crashes

### DIFF
--- a/app/src/main/java/com/weatherxm/ui/claimdevice/pulse/ClaimPulseActivity.kt
+++ b/app/src/main/java/com/weatherxm/ui/claimdevice/pulse/ClaimPulseActivity.kt
@@ -66,7 +66,7 @@ class ClaimPulseActivity : BaseActivity() {
             if (model.validateSerial(savedSn)) {
                 model.setSerialNumber(savedSn)
             }
-            val savedKey = it.getString(CLAIMING_KEY, null)
+            val savedKey = it.getString(CLAIMING_KEY, String.empty())
             if (model.validateClaimingKey(savedKey)) {
                 model.setClaimingKey(savedKey)
             }

--- a/app/src/main/java/com/weatherxm/ui/components/RangeSelectorView.kt
+++ b/app/src/main/java/com/weatherxm/ui/components/RangeSelectorView.kt
@@ -32,13 +32,14 @@ class RangeSelectorView : ConstraintLayout {
     fun checkWeek() = binding.chartRangeSelector.check(R.id.week)
     fun checkMonth() = binding.chartRangeSelector.check(R.id.month)
     fun checkYear() = binding.chartRangeSelector.check(R.id.year)
-    fun clearCheck() = binding.chartRangeSelector.clearCheck()
 
     fun checkedChipId() = binding.chartRangeSelector.checkedChipId
 
     fun listener(listener: (Int) -> Unit) {
         binding.chartRangeSelector.setOnCheckedStateChangeListener { _, checkedIds ->
-            listener.invoke(checkedIds[0])
+            if (checkedIds.isNotEmpty()) {
+                listener.invoke(checkedIds[0])
+            }
         }
     }
 

--- a/app/src/main/java/com/weatherxm/ui/devicesrewards/DeviceRewardsAdapter.kt
+++ b/app/src/main/java/com/weatherxm/ui/devicesrewards/DeviceRewardsAdapter.kt
@@ -12,6 +12,7 @@ import com.weatherxm.databinding.ListItemDeviceRewardsBinding
 import com.weatherxm.ui.common.DeviceTotalRewards
 import com.weatherxm.ui.common.DeviceTotalRewardsDetails
 import com.weatherxm.ui.common.hide
+import com.weatherxm.ui.common.invisible
 import com.weatherxm.ui.common.show
 import com.weatherxm.ui.common.visible
 import com.weatherxm.util.Rewards.formatTokens
@@ -97,7 +98,7 @@ class DeviceRewardsAdapter(
                 RewardsSummaryMode.WEEK -> binding.chartRangeSelector.checkWeek()
                 RewardsSummaryMode.MONTH -> binding.chartRangeSelector.checkMonth()
                 RewardsSummaryMode.YEAR -> binding.chartRangeSelector.checkYear()
-                else -> binding.chartRangeSelector.clearCheck()
+                else -> throw NotImplementedError("Unknown rewards mode ${details.mode}")
             }.also {
                 ignoreRangeChipListener = false
             }
@@ -156,7 +157,7 @@ class DeviceRewardsAdapter(
         private fun invokeOnRangeChip(checkedChipId: Int, deviceId: String) {
             binding.detailsStatus.animation(R.raw.anim_loading).visible(true)
             binding.chartRangeSelector.disable()
-            binding.detailsContainer.visible(false)
+            binding.detailsContainer.invisible()
             binding.retryCard.visible(false)
             onRangeChipClicked.invoke(absoluteAdapterPosition, checkedChipId, deviceId)
         }

--- a/app/src/main/res/layout/list_item_device_rewards.xml
+++ b/app/src/main/res/layout/list_item_device_rewards.xml
@@ -185,6 +185,7 @@
                     android:layout_height="wrap_content"
                     android:visibility="gone"
                     app:empty_animation="@raw/anim_loading"
+                    app:layout_constraintBottom_toBottomOf="parent"
                     app:layout_constraintTop_toBottomOf="@id/detailsHeader" />
 
                 <com.weatherxm.ui.components.RetryCardView
@@ -192,6 +193,7 @@
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
                     android:visibility="gone"
+                    app:layout_constraintBottom_toBottomOf="parent"
                     app:layout_constraintTop_toBottomOf="@id/detailsHeader" />
             </androidx.constraintlayout.widget.ConstraintLayout>
         </FrameLayout>

--- a/app/src/main/res/layout/view_range_selector.xml
+++ b/app/src/main/res/layout/view_range_selector.xml
@@ -15,6 +15,7 @@
         android:background="@drawable/background_rounded_layer_1"
         android:padding="@dimen/padding_extra_small"
         app:chipSpacingHorizontal="@dimen/margin_extra_small"
+        app:selectionRequired="true"
         app:singleSelection="true"
         tools:checkedChip="@id/week">
 


### PR DESCRIPTION
### **Why?**
Two crashes (one reported internally, one reported in Firebase which was fixed in the past and broken again).

### **How?**
Disallow unchecking range selector in charts and use a default empty string instead of null in claiming of pulse in a rare case)

### **Testing**
Ensure that double tapping in the same chip in the chart range selector in Rewards Analytics does not cause a crash or an uncheck.