### PR TITLE
Add Permissions to the job in order to be able to deploy on GitHub Pages

### DIFF
--- a/.github/workflows/on-main-firebase-distribution.yml
+++ b/.github/workflows/on-main-firebase-distribution.yml
@@ -24,6 +24,10 @@ env:
     GLOBAL_GRADLE_CACHE: gradle-cache-${GITHUB_REPOSITORY}
 jobs:
     development_dist_and_coverage_report:
+        permissions:
+            contents: read
+            pages: write
+            id-token: write
         environment: development
         env:
             # API URL for Dev Flavor


### PR DESCRIPTION
### **Why?**
Failed action: https://github.com/WeatherXM/wxm-android/actions/runs/10941798207/job/30377271777

### **How?**
Add Permissions to the job in order to be able to deploy on GitHub Pages