### PR TITLE
[Hotfix] Fix directory location of code coverage tool

### DIFF
--- a/.github/workflows/on-main-firebase-distribution.yml
+++ b/.github/workflows/on-main-firebase-distribution.yml
@@ -69,6 +69,6 @@ jobs:
             -   name: Upload JaCoCo Coverage Report (HTML) to Pages Artifact
                 uses: actions/upload-pages-artifact@v3
                 with:
-                    path: 'app/build/reports/jacoco/html/'
+                    path: 'app/build/reports/jacoco'
             -   name: Deploy JaCoCo Coverage Report (HTML) to GitHub Pages
                 uses: actions/deploy-pages@v4

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -339,7 +339,7 @@ tasks.register("jacocoCoverageTestReport", type = JacocoReport::class) {
     reports {
         xml.required = true
         csv.required = false
-        html.outputLocation = layout.buildDirectory.dir("reports/jacoco/html")
+        html.outputLocation = layout.buildDirectory.dir("reports/jacoco/coverage-report")
         xml.outputLocation = layout.buildDirectory.file("reports/jacoco/report.xml")
     }
 


### PR DESCRIPTION
### **Why?**
Fix directory location of code coverage tool

### **How?**
Use `reports/jacoco/coverage-report` as the directory which the code coverage report is stored and served afterward.s