### PR TITLE
FE-1143 RewardsUseCase & Data.Extensions unit tests

### DIFF
--- a/app/src/main/java/com/weatherxm/usecases/RewardsUseCase.kt
+++ b/app/src/main/java/com/weatherxm/usecases/RewardsUseCase.kt
@@ -166,27 +166,8 @@ class RewardsUseCaseImpl(
             val datesChartTooltip = mutableListOf<String>()
 
             rewards.data?.fastForEachIndexed { i, timeseries ->
-                /**
-                 * 7D = Show 3-letter days - e.g. Mon, Tue, Wed,
-                 * 1M = DD/MM or MM/DD based on Locale - e.g. 25/01 or 01/25
-                 * 1Y = Show 3-letter months as the design - e.g. Sep, Oct, Nov
-                 */
-                when (mode) {
-                    RewardsRepositoryImpl.Companion.RewardsSummaryMode.WEEK -> {
-                        datesChartTooltip.add(context.getString(timeseries.ts.dayOfWeek.getName()))
-                        xLabels.add(context.getString(timeseries.ts.dayOfWeek.getShortName()))
-                    }
-                    RewardsRepositoryImpl.Companion.RewardsSummaryMode.MONTH -> {
-                        datesChartTooltip.add(timeseries.ts.getFormattedDate())
-                        xLabels.add(timeseries.ts.getFormattedMonthDate())
-                    }
-                    RewardsRepositoryImpl.Companion.RewardsSummaryMode.YEAR -> {
-                        datesChartTooltip.add(
-                            timeseries.ts.month.getDisplayName(TextStyle.FULL, Locale.US)
-                        )
-                        xLabels.add(timeseries.ts.month.getDisplayName(TextStyle.SHORT, Locale.US))
-                    }
-                }
+                datesChartTooltip.add(getTooltipDate(timeseries.ts, mode))
+                xLabels.add(getXAxisLabel(timeseries.ts, mode))
                 entries.add(Entry(i.toFloat(), timeseries.totalRewards ?: 0F))
             }
 
@@ -209,27 +190,8 @@ class RewardsUseCaseImpl(
             val datesChartTooltip = mutableListOf<String>()
 
             summary.data?.fastForEachIndexed { counter, timeseries ->
-                /**
-                 * 7D = Show 3-letter days - e.g. Mon, Tue, Wed,
-                 * 1M = DD/MM or MM/DD based on Locale - e.g. 25/01 or 01/25
-                 * 1Y = Show 3-letter months as the design - e.g. Sep, Oct, Nov
-                 */
-                when (mode) {
-                    RewardsRepositoryImpl.Companion.RewardsSummaryMode.WEEK -> {
-                        datesChartTooltip.add(context.getString(timeseries.ts.dayOfWeek.getName()))
-                        xLabels.add(context.getString(timeseries.ts.dayOfWeek.getShortName()))
-                    }
-                    RewardsRepositoryImpl.Companion.RewardsSummaryMode.MONTH -> {
-                        datesChartTooltip.add(timeseries.ts.getFormattedDate())
-                        xLabels.add(timeseries.ts.getFormattedMonthDate())
-                    }
-                    RewardsRepositoryImpl.Companion.RewardsSummaryMode.YEAR -> {
-                        datesChartTooltip.add(
-                            timeseries.ts.month.getDisplayName(TextStyle.FULL, Locale.US)
-                        )
-                        xLabels.add(timeseries.ts.month.getDisplayName(TextStyle.SHORT, Locale.US))
-                    }
-                }
+                datesChartTooltip.add(getTooltipDate(timeseries.ts, mode))
+                xLabels.add(getXAxisLabel(timeseries.ts, mode))
 
                 val baseCode = RewardsCode.base_reward.name
                 val betaCode = RewardsCode.beta_rewards.name
@@ -287,6 +249,50 @@ class RewardsUseCaseImpl(
                 LineChartData(xLabels, otherEntries),
                 Status.SUCCESS
             )
+        }
+    }
+
+    private fun getTooltipDate(
+        timestamp: ZonedDateTime,
+        mode: RewardsRepositoryImpl.Companion.RewardsSummaryMode
+    ): String {
+        /**
+         * 7D = Show full days - e.g. Monday, Tuesday, Wednesday,
+         * 1M = Show short month name with the month day - e.g. Jan 1, Feb 21, Mar 30,
+         * 1Y = Show months - e.g. September, October, November
+         */
+        return when (mode) {
+            RewardsRepositoryImpl.Companion.RewardsSummaryMode.WEEK -> {
+                context.getString(timestamp.dayOfWeek.getName())
+            }
+            RewardsRepositoryImpl.Companion.RewardsSummaryMode.MONTH -> {
+                timestamp.getFormattedDate()
+            }
+            RewardsRepositoryImpl.Companion.RewardsSummaryMode.YEAR -> {
+                timestamp.month.getDisplayName(TextStyle.FULL, Locale.US)
+            }
+        }
+    }
+
+    private fun getXAxisLabel(
+        timestamp: ZonedDateTime,
+        mode: RewardsRepositoryImpl.Companion.RewardsSummaryMode
+    ): String {
+        /**
+         * 7D = Show 3-letter days - e.g. Mon, Tue, Wed,
+         * 1M = DD/MM or MM/DD based on Locale - e.g. 25/01 or 01/25
+         * 1Y = Show 3-letter months as the design - e.g. Sep, Oct, Nov
+         */
+        return when (mode) {
+            RewardsRepositoryImpl.Companion.RewardsSummaryMode.WEEK -> {
+                context.getString(timestamp.dayOfWeek.getShortName())
+            }
+            RewardsRepositoryImpl.Companion.RewardsSummaryMode.MONTH -> {
+                timestamp.getFormattedMonthDate()
+            }
+            RewardsRepositoryImpl.Companion.RewardsSummaryMode.YEAR -> {
+                timestamp.month.getDisplayName(TextStyle.SHORT, Locale.US)
+            }
         }
     }
 

--- a/app/src/test/java/com/weatherxm/TestConfig.kt
+++ b/app/src/test/java/com/weatherxm/TestConfig.kt
@@ -2,6 +2,8 @@ package com.weatherxm
 
 import android.content.Context
 import android.content.SharedPreferences
+import android.text.format.DateFormat
+import com.weatherxm.data.DATE_FORMAT_MONTH_DAY
 import com.weatherxm.data.models.Failure
 import com.weatherxm.data.services.CacheService.Companion.KEY_PRECIP
 import com.weatherxm.data.services.CacheService.Companion.KEY_PRESSURE
@@ -16,6 +18,8 @@ import io.kotest.core.names.DuplicateTestNameMode
 import io.kotest.core.spec.AutoScan
 import io.mockk.every
 import io.mockk.mockk
+import io.mockk.mockkStatic
+import java.util.Locale
 
 object TestConfig : AbstractProjectConfig() {
     override val duplicateTestNameMode = DuplicateTestNameMode.Error
@@ -27,6 +31,13 @@ object TestConfig : AbstractProjectConfig() {
     @AutoScan
     object MyProjectListener : BeforeProjectListener, AfterProjectListener {
         override suspend fun beforeProject() {
+            mockkStatic(DateFormat::class)
+            every {
+                DateFormat.getBestDateTimePattern(
+                    Locale.getDefault(),
+                    DATE_FORMAT_MONTH_DAY
+                )
+            } returns "d/M"
             every { resources.getString(R.string.uv_low) } returns "Low"
             every { resources.getString(R.string.uv_moderate) } returns "Moderate"
             every { resources.getString(R.string.uv_high) } returns "High"

--- a/app/src/test/java/com/weatherxm/TestUtils.kt
+++ b/app/src/test/java/com/weatherxm/TestUtils.kt
@@ -67,7 +67,7 @@ object TestUtils {
         this.solarRadiation.isEqual(other.solarRadiation)
     }
 
-    private fun LineChartData.isEqual(other: LineChartData) {
+    fun LineChartData.isEqual(other: LineChartData) {
         this.timestamps.forEachIndexed { i, item ->
             item shouldBe other.timestamps[i]
         }

--- a/app/src/test/java/com/weatherxm/data/ExtensionsTest.kt
+++ b/app/src/test/java/com/weatherxm/data/ExtensionsTest.kt
@@ -1,0 +1,42 @@
+package com.weatherxm.data
+
+import androidx.work.Constraints
+import androidx.work.NetworkType
+import io.kotest.core.spec.style.BehaviorSpec
+import io.kotest.matchers.shouldBe
+import okhttp3.Protocol
+import okhttp3.Request
+import okhttp3.Response
+
+class ExtensionsTest : BehaviorSpec({
+    val path = "/api/v1/me/devices"
+    val request = Request.Builder().url("https://api.weatherxm.com$path").build()
+    val response =
+        Response.Builder().request(request).code(200).protocol(Protocol.HTTP_2).message("").build()
+
+    context("Get the path of an HTTP Request and Response") {
+        given("An HTTP request") {
+            then("Get its path") {
+                request.path() shouldBe path
+            }
+        }
+
+        given("An HTTP response") {
+            then("Get its path") {
+                response.path() shouldBe path
+            }
+        }
+    }
+
+    context("Create Constraints with NetworkType = CONNECTED") {
+        given("An extension helper function we have created") {
+            then("Use it to create the constraints") {
+                Constraints.Companion
+                    .requireNetwork()
+                    .requiredNetworkType shouldBe NetworkType.CONNECTED
+            }
+        }
+    }
+
+
+})

--- a/app/src/test/java/com/weatherxm/data/ExtensionsTest.kt
+++ b/app/src/test/java/com/weatherxm/data/ExtensionsTest.kt
@@ -2,17 +2,55 @@ package com.weatherxm.data
 
 import androidx.work.Constraints
 import androidx.work.NetworkType
+import arrow.core.Either
+import com.haroldadmin.cnradapter.NetworkResponse
+import com.weatherxm.data.models.ApiError
+import com.weatherxm.data.models.ApiError.GenericError.JWTError.ForbiddenError
+import com.weatherxm.data.models.ApiError.GenericError.JWTError.UnauthorizedError
+import com.weatherxm.data.models.ApiError.GenericError.JWTError.UserNotFoundError
+import com.weatherxm.data.models.ApiError.GenericError.NotFoundError
+import com.weatherxm.data.models.ApiError.GenericError.UnknownError
+import com.weatherxm.data.models.ApiError.GenericError.UnsupportedAppVersion
+import com.weatherxm.data.models.ApiError.GenericError.ValidationError
+import com.weatherxm.data.models.ApiError.UserError.WalletError.WalletAddressNotFound
+import com.weatherxm.data.models.NetworkError
+import com.weatherxm.data.network.ErrorResponse
 import io.kotest.core.spec.style.BehaviorSpec
 import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeTypeOf
 import okhttp3.Protocol
 import okhttp3.Request
 import okhttp3.Response
+import java.io.IOException
+import java.net.SocketTimeoutException
 
 class ExtensionsTest : BehaviorSpec({
     val path = "/api/v1/me/devices"
     val request = Request.Builder().url("https://api.weatherxm.com$path").build()
     val response =
         Response.Builder().request(request).code(200).protocol(Protocol.HTTP_2).message("").build()
+
+    // [NetworkResponse] Success
+    val body = "body"
+    val retrofitResponse = retrofit2.Response.success(body)
+    val successResponse = NetworkResponse.Success<String, ErrorResponse>(body, retrofitResponse)
+
+
+    // [NetworkResponse] Network Errors
+    val errorSocketTimeout =
+        NetworkResponse.NetworkError<Unit, ErrorResponse>(SocketTimeoutException())
+    val errorIOException =
+        NetworkResponse.NetworkError<Unit, ErrorResponse>(IOException())
+
+    // [NetworkResponse] Unknown Error
+    val errorUnknown =
+        NetworkResponse.UnknownError<String, ErrorResponse>(Throwable(), retrofitResponse)
+
+    // [NetworkResponse] Server Error
+    fun errorToFailure(code: String) = NetworkResponse.ServerError<Unit, ErrorResponse>(
+        ErrorResponse(code, "", "", ""),
+        retrofitResponse
+    ).mapResponse().leftOrNull()
 
     context("Get the path of an HTTP Request and Response") {
         given("An HTTP request") {
@@ -38,5 +76,184 @@ class ExtensionsTest : BehaviorSpec({
         }
     }
 
-
+    context("Parse NetworkResponse<T, ErrorResponse> to Either<Failure, T>") {
+        given("A NetworkResponse") {
+            When("It's a success") {
+                then("Parse it to Either.Right and return the body") {
+                    successResponse.mapResponse() shouldBe Either.Right(body)
+                }
+            }
+            When("It's a network error") {
+                and("It's a SocketTimeoutException") {
+                    then("Parse it to Either.Right and return ConnectionTimeoutError") {
+                        errorSocketTimeout.mapResponse().leftOrNull()
+                            .shouldBeTypeOf<NetworkError.ConnectionTimeoutError>()
+                    }
+                }
+                and("It's a different IOException") {
+                    then("Parse it to Either.Right and return NoConnectionError") {
+                        errorIOException.mapResponse().leftOrNull()
+                            .shouldBeTypeOf<NetworkError.NoConnectionError>()
+                    }
+                }
+            }
+            When("It's an Unknown Error") {
+                then("Parse it to Either.Right and return UnknownError") {
+                    errorUnknown.mapResponse().leftOrNull()
+                        .shouldBeTypeOf<UnknownError>()
+                }
+            }
+            When("It's an ErrorResponse (Server returned an error)") {
+                and("It's an INVALID_USERNAME error") {
+                    then("Parse it to Either.Left and return InvalidUsername") {
+                        errorToFailure(ErrorResponse.INVALID_USERNAME)
+                            .shouldBeTypeOf<ApiError.AuthError.InvalidUsername>()
+                    }
+                }
+                and("It's an INVALID_PASSWORD error") {
+                    then("Parse it to Either.Left and return InvalidPassword") {
+                        errorToFailure(ErrorResponse.INVALID_PASSWORD)
+                            .shouldBeTypeOf<ApiError.AuthError.LoginError.InvalidPassword>()
+                    }
+                }
+                and("It's an INVALID_CREDENTIALS error") {
+                    then("Parse it to Either.Left and return InvalidCredentials") {
+                        errorToFailure(ErrorResponse.INVALID_CREDENTIALS)
+                            .shouldBeTypeOf<ApiError.AuthError.LoginError.InvalidCredentials>()
+                    }
+                }
+                and("It's an USER_ALREADY_EXISTS error") {
+                    then("Parse it to Either.Left and return UserAlreadyExists") {
+                        errorToFailure(ErrorResponse.USER_ALREADY_EXISTS)
+                            .shouldBeTypeOf<ApiError.AuthError.SignupError.UserAlreadyExists>()
+                    }
+                }
+                and("It's an INVALID_ACCESS_TOKEN error") {
+                    then("Parse it to Either.Left and return InvalidAccessToken") {
+                        errorToFailure(ErrorResponse.INVALID_ACCESS_TOKEN)
+                            .shouldBeTypeOf<ApiError.AuthError.InvalidAccessToken>()
+                    }
+                }
+                and("It's an INVALID_ACTIVATION_TOKEN error") {
+                    then("Parse it to Either.Left and return InvalidActivationToken") {
+                        errorToFailure(ErrorResponse.INVALID_ACTIVATION_TOKEN)
+                            .shouldBeTypeOf<ApiError.AuthError.InvalidActivationToken>()
+                    }
+                }
+                and("It's an DEVICE_NOT_FOUND error") {
+                    then("Parse it to Either.Left and return DeviceNotFound") {
+                        errorToFailure(ErrorResponse.DEVICE_NOT_FOUND)
+                            .shouldBeTypeOf<ApiError.DeviceNotFound>()
+                    }
+                }
+                and("It's an MAX_FOLLOWED error") {
+                    then("Parse it to Either.Left and return MaxFollowed") {
+                        errorToFailure(ErrorResponse.MAX_FOLLOWED)
+                            .shouldBeTypeOf<ApiError.MaxFollowed>()
+                    }
+                }
+                and("It's an INVALID_WALLET_ADDRESS error") {
+                    then("Parse it to Either.Left and return InvalidWalletAddress") {
+                        errorToFailure(ErrorResponse.INVALID_WALLET_ADDRESS)
+                            .shouldBeTypeOf<ApiError.UserError.WalletError.InvalidWalletAddress>()
+                    }
+                }
+                and("It's an INVALID_FRIENDLY_NAME error") {
+                    then("Parse it to Either.Left and return InvalidFriendlyName") {
+                        errorToFailure(ErrorResponse.INVALID_FRIENDLY_NAME)
+                            .shouldBeTypeOf<ApiError.InvalidFriendlyName>()
+                    }
+                }
+                and("It's an INVALID_FROM_DATE error") {
+                    then("Parse it to Either.Left and return InvalidFromDate") {
+                        errorToFailure(ErrorResponse.INVALID_FROM_DATE)
+                            .shouldBeTypeOf<ApiError.UserError.InvalidFromDate>()
+                    }
+                }
+                and("It's an INVALID_TO_DATE error") {
+                    then("Parse it to Either.Left and return InvalidToDate") {
+                        errorToFailure(ErrorResponse.INVALID_TO_DATE)
+                            .shouldBeTypeOf<ApiError.UserError.InvalidToDate>()
+                    }
+                }
+                and("It's an INVALID_TIMEZONE error") {
+                    then("Parse it to Either.Left and return InvalidTimezone") {
+                        errorToFailure(ErrorResponse.INVALID_TIMEZONE)
+                            .shouldBeTypeOf<ApiError.UserError.InvalidTimezone>()
+                    }
+                }
+                and("It's an INVALID_CLAIM_ID error") {
+                    then("Parse it to Either.Left and return InvalidClaimId") {
+                        errorToFailure(ErrorResponse.INVALID_CLAIM_ID)
+                            .shouldBeTypeOf<ApiError.UserError.ClaimError.InvalidClaimId>()
+                    }
+                }
+                and("It's an INVALID_CLAIM_LOCATION error") {
+                    then("Parse it to Either.Left and return InvalidClaimLocation") {
+                        errorToFailure(ErrorResponse.INVALID_CLAIM_LOCATION)
+                            .shouldBeTypeOf<ApiError.UserError.ClaimError.InvalidClaimLocation>()
+                    }
+                }
+                and("It's an DEVICE_ALREADY_CLAIMED error") {
+                    then("Parse it to Either.Left and return DeviceAlreadyClaimed") {
+                        errorToFailure(ErrorResponse.DEVICE_ALREADY_CLAIMED)
+                            .shouldBeTypeOf<ApiError.UserError.ClaimError.DeviceAlreadyClaimed>()
+                    }
+                }
+                and("It's an DEVICE_CLAIMING error") {
+                    then("Parse it to Either.Left and return DeviceClaiming") {
+                        errorToFailure(ErrorResponse.DEVICE_CLAIMING)
+                            .shouldBeTypeOf<ApiError.UserError.ClaimError.DeviceClaiming>()
+                    }
+                }
+                and("It's an UNAUTHORIZED error") {
+                    then("Parse it to Either.Left and return Unauthorized") {
+                        errorToFailure(ErrorResponse.UNAUTHORIZED)
+                            .shouldBeTypeOf<UnauthorizedError>()
+                    }
+                }
+                and("It's an USER_NOT_FOUND error") {
+                    then("Parse it to Either.Left and return UserNotFoundError") {
+                        errorToFailure(ErrorResponse.USER_NOT_FOUND)
+                            .shouldBeTypeOf<UserNotFoundError>()
+                    }
+                }
+                and("It's an FORBIDDEN error") {
+                    then("Parse it to Either.Left and return ForbiddenError") {
+                        errorToFailure(ErrorResponse.FORBIDDEN)
+                            .shouldBeTypeOf<ForbiddenError>()
+                    }
+                }
+                and("It's an VALIDATION error") {
+                    then("Parse it to Either.Left and return ValidationError") {
+                        errorToFailure(ErrorResponse.VALIDATION)
+                            .shouldBeTypeOf<ValidationError>()
+                    }
+                }
+                and("It's an NOT_FOUND error") {
+                    then("Parse it to Either.Left and return NotFoundError") {
+                        errorToFailure(ErrorResponse.NOT_FOUND)
+                            .shouldBeTypeOf<NotFoundError>()
+                    }
+                }
+                and("It's an WALLET_ADDRESS_NOT_FOUND error") {
+                    then("Parse it to Either.Left and return WalletAddressNotFound") {
+                        errorToFailure(ErrorResponse.WALLET_ADDRESS_NOT_FOUND)
+                            .shouldBeTypeOf<WalletAddressNotFound>()
+                    }
+                }
+                and("It's an UNSUPPORTED_APPLICATION_VERSION error") {
+                    then("Parse it to Either.Left and return UnsupportedAppVersion") {
+                        errorToFailure(ErrorResponse.UNSUPPORTED_APPLICATION_VERSION)
+                            .shouldBeTypeOf<UnsupportedAppVersion>()
+                    }
+                }
+                and("It's an UNKNOWN error") {
+                    then("Parse it to Either.Left and return UnknownError") {
+                        errorToFailure("").shouldBeTypeOf<UnknownError>()
+                    }
+                }
+            }
+        }
+    }
 })

--- a/app/src/test/java/com/weatherxm/usecases/ChartsUseCaseTest.kt
+++ b/app/src/test/java/com/weatherxm/usecases/ChartsUseCaseTest.kt
@@ -124,7 +124,6 @@ class ChartsUseCaseTest : BehaviorSpec({
             solarRadiationEntries.add(Entry(i.toFloat(), 500F))
         }
 
-        mockkStatic(DateFormat::class)
         every { DateFormat.is24HourFormat(context) } returns true
     }
 

--- a/app/src/test/java/com/weatherxm/usecases/RewardsUseCaseTest.kt
+++ b/app/src/test/java/com/weatherxm/usecases/RewardsUseCaseTest.kt
@@ -12,11 +12,11 @@ import com.weatherxm.TestUtils.coMockEitherRight
 import com.weatherxm.TestUtils.isEqual
 import com.weatherxm.TestUtils.isError
 import com.weatherxm.TestUtils.isSuccess
+import com.weatherxm.data.DATE_FORMAT_MONTH_DAY
 import com.weatherxm.data.models.BoostReward
 import com.weatherxm.data.models.BoostRewardDetails
 import com.weatherxm.data.models.BoostRewardMetadata
 import com.weatherxm.data.models.BoostRewardResponse
-import com.weatherxm.data.DATE_FORMAT_MONTH_DAY
 import com.weatherxm.data.models.DeviceRewardsSummary
 import com.weatherxm.data.models.DeviceRewardsSummaryData
 import com.weatherxm.data.models.DeviceRewardsSummaryDataReward
@@ -24,10 +24,9 @@ import com.weatherxm.data.models.DeviceRewardsSummaryDetails
 import com.weatherxm.data.models.DevicesRewards
 import com.weatherxm.data.models.DevicesRewardsData
 import com.weatherxm.data.models.Reward
-import com.weatherxm.datamodels..RewardDetails
+import com.weatherxm.data.models.RewardDetails
 import com.weatherxm.data.models.RewardsCode
 import com.weatherxm.data.models.RewardsTimeline
-import com.weatherxm.ui.common.Status
 import com.weatherxm.data.repository.RewardsRepository
 import com.weatherxm.data.repository.RewardsRepositoryImpl.Companion.RewardsSummaryMode
 import com.weatherxm.ui.common.BoostDetailInfo
@@ -36,6 +35,7 @@ import com.weatherxm.ui.common.DeviceTotalRewardsDetails
 import com.weatherxm.ui.common.DevicesRewardsByRange
 import com.weatherxm.ui.common.LineChartData
 import com.weatherxm.ui.common.RewardTimelineType
+import com.weatherxm.ui.common.Status
 import com.weatherxm.ui.common.TimelineReward
 import com.weatherxm.ui.common.UIBoost
 import com.weatherxm.ui.common.UIRewardsTimeline
@@ -361,7 +361,8 @@ class RewardsUseCaseTest : BehaviorSpec({
                     )
                     then("return the DeviceTotalRewardsDetails for WEEK mode") {
                         usecase.getDeviceRewardsByRange(deviceId, RewardsSummaryMode.WEEK)
-                            .getOrNull().also {
+                            .getOrNull()
+                            .also {
                                 it?.total shouldBe deviceTotalRewardsDetails.total
                                 it?.mode shouldBe deviceTotalRewardsDetails.mode
                                 it?.boosts shouldBe deviceTotalRewardsDetails.boosts
@@ -370,7 +371,9 @@ class RewardsUseCaseTest : BehaviorSpec({
                                     deviceTotalRewardsDetails.datesChartTooltip
                                 it?.baseChartData?.isEqual(deviceTotalRewardsDetails.baseChartData)
                                 it?.betaChartData?.isEqual(deviceTotalRewardsDetails.betaChartData)
-                                it?.otherChartData?.isEqual(deviceTotalRewardsDetails.otherChartData)
+                                it?.otherChartData?.isEqual(
+                                    deviceTotalRewardsDetails.otherChartData
+                                )
                                 it?.status shouldBe deviceTotalRewardsDetails.status
                             }
                     }

--- a/app/src/test/java/com/weatherxm/usecases/RewardsUseCaseTest.kt
+++ b/app/src/test/java/com/weatherxm/usecases/RewardsUseCaseTest.kt
@@ -2,21 +2,39 @@ package com.weatherxm.usecases
 
 import android.icu.text.CompactDecimalFormat
 import android.icu.text.NumberFormat
+import android.text.format.DateFormat
+import com.github.mikephil.charting.data.Entry
+import com.weatherxm.R
 import com.weatherxm.TestConfig.context
 import com.weatherxm.TestConfig.failure
 import com.weatherxm.TestUtils.coMockEitherLeft
 import com.weatherxm.TestUtils.coMockEitherRight
+import com.weatherxm.TestUtils.isEqual
 import com.weatherxm.TestUtils.isError
 import com.weatherxm.TestUtils.isSuccess
 import com.weatherxm.data.models.BoostReward
 import com.weatherxm.data.models.BoostRewardDetails
 import com.weatherxm.data.models.BoostRewardMetadata
 import com.weatherxm.data.models.BoostRewardResponse
+import com.weatherxm.data.DATE_FORMAT_MONTH_DAY
+import com.weatherxm.data.models.DeviceRewardsSummary
+import com.weatherxm.data.models.DeviceRewardsSummaryData
+import com.weatherxm.data.models.DeviceRewardsSummaryDataReward
+import com.weatherxm.data.models.DeviceRewardsSummaryDetails
+import com.weatherxm.data.models.DevicesRewards
+import com.weatherxm.data.models.DevicesRewardsData
 import com.weatherxm.data.models.Reward
-import com.weatherxm.data.models.RewardDetails
+import com.weatherxm.datamodels..RewardDetails
+import com.weatherxm.data.models.RewardsCode
 import com.weatherxm.data.models.RewardsTimeline
+import com.weatherxm.ui.common.Status
 import com.weatherxm.data.repository.RewardsRepository
+import com.weatherxm.data.repository.RewardsRepositoryImpl.Companion.RewardsSummaryMode
 import com.weatherxm.ui.common.BoostDetailInfo
+import com.weatherxm.ui.common.DeviceTotalRewardsBoost
+import com.weatherxm.ui.common.DeviceTotalRewardsDetails
+import com.weatherxm.ui.common.DevicesRewardsByRange
+import com.weatherxm.ui.common.LineChartData
 import com.weatherxm.ui.common.RewardTimelineType
 import com.weatherxm.ui.common.TimelineReward
 import com.weatherxm.ui.common.UIBoost
@@ -25,12 +43,17 @@ import com.weatherxm.ui.common.empty
 import com.weatherxm.util.DateTimeHelper.getFormattedDate
 import com.weatherxm.util.NumberUtils
 import io.kotest.core.spec.style.BehaviorSpec
+import io.kotest.matchers.shouldBe
 import io.mockk.every
 import io.mockk.mockk
 import org.koin.core.context.startKoin
 import org.koin.core.context.stopKoin
+import org.koin.core.qualifier.named
 import org.koin.dsl.module
+import java.time.ZoneId
 import java.time.ZonedDateTime
+import java.time.format.DateTimeFormatter
+import java.util.Locale
 
 class RewardsUseCaseTest : BehaviorSpec({
     val repository = mockk<RewardsRepository>()
@@ -90,6 +113,73 @@ class RewardsUseCaseTest : BehaviorSpec({
             emptyList()
         )
 
+    val customTimestamp = ZonedDateTime.of(2024, 1, 1, 8, 0, 0, 0, ZoneId.of("UTC"))
+    val devicesRewards =
+        DevicesRewards(100F, mutableListOf(DevicesRewardsData(customTimestamp, 100F)))
+    val devicesRewardsByRangeWeek = DevicesRewardsByRange(
+        100F,
+        RewardsSummaryMode.WEEK,
+        listOf("Monday"),
+        LineChartData(mutableListOf("Mon"), mutableListOf(Entry(0F, 100F)))
+    )
+    val devicesRewardsByRangeMonth = DevicesRewardsByRange(
+        100F,
+        RewardsSummaryMode.MONTH,
+        listOf("Jan 1"),
+        LineChartData(mutableListOf("1/1"), mutableListOf(Entry(0F, 100F)))
+    )
+    val devicesRewardsByRangeYear = DevicesRewardsByRange(
+        100F,
+        RewardsSummaryMode.YEAR,
+        listOf("January"),
+        LineChartData(mutableListOf("Jan"), mutableListOf(Entry(0F, 100F)))
+    )
+
+    val deviceRewardsSummary = DeviceRewardsSummary(
+        100F,
+        listOf(
+            DeviceRewardsSummaryData(
+                customTimestamp,
+                listOf(
+                    DeviceRewardsSummaryDataReward("base", RewardsCode.base_reward.name, 40F),
+                    DeviceRewardsSummaryDataReward("boost", RewardsCode.beta_rewards.name, 40F),
+                    DeviceRewardsSummaryDataReward("boost", "other", 20F)
+                )
+            )
+        ),
+        listOf(
+            DeviceRewardsSummaryDetails(
+                "boost",
+                RewardsCode.beta_rewards.name,
+                40F,
+                81F,
+                customTimestamp,
+                customTimestamp,
+                49.3F
+            )
+        )
+    )
+    val deviceTotalRewardsDetails = DeviceTotalRewardsDetails(
+        100F,
+        RewardsSummaryMode.WEEK,
+        listOf(
+            DeviceTotalRewardsBoost(
+                RewardsCode.beta_rewards.name,
+                49,
+                81F,
+                40F,
+                customTimestamp,
+                customTimestamp
+            )
+        ),
+        listOf(100F),
+        listOf("Monday"),
+        LineChartData(mutableListOf("Mon"), mutableListOf(Entry(0F, 40F))),
+        LineChartData(mutableListOf("Mon"), mutableListOf(Entry(0F, 80F))),
+        LineChartData(mutableListOf("Mon"), mutableListOf(Entry(0F, 100F))),
+        Status.SUCCESS
+    )
+
     beforeSpec {
         startKoin {
             modules(
@@ -100,11 +190,21 @@ class RewardsUseCaseTest : BehaviorSpec({
                     single<NumberFormat> {
                         mockk<NumberFormat>()
                     }
+                    single<DateTimeFormatter>(named(DATE_FORMAT_MONTH_DAY)) {
+                        val usersLocaleDateFormat =
+                            DateFormat.getBestDateTimePattern(
+                                Locale.getDefault(),
+                                DATE_FORMAT_MONTH_DAY
+                            )
+                        DateTimeFormatter.ofPattern(usersLocaleDateFormat)
+                    }
                 }
             )
         }
         every { NumberUtils.compactNumber(any()) } returns "10"
         every { NumberUtils.formatNumber(any()) } returns "10"
+        every { context.getString(R.string.monday) } returns "Monday"
+        every { context.getString(R.string.mon) } returns "Mon"
     }
 
     context("Get timeline of rewards") {
@@ -184,6 +284,105 @@ class RewardsUseCaseTest : BehaviorSpec({
                 coMockEitherLeft({ repository.getBoostReward(deviceId, boostCode) }, failure)
                 then("return the failure") {
                     usecase.getBoostReward(deviceId, boostReward).isError()
+                }
+            }
+        }
+    }
+
+    context("Get rewards summary for all devices by range") {
+        given("A repository providing the rewards summary") {
+            When("it's a success") {
+                and("mode is WEEK") {
+                    coMockEitherRight(
+                        { repository.getDevicesRewardsByRange(RewardsSummaryMode.WEEK) },
+                        devicesRewards
+                    )
+                    then("return the DevicesRewardsByRange for WEEK mode") {
+                        usecase.getDevicesRewardsByRange(RewardsSummaryMode.WEEK).getOrNull().also {
+                            it?.total shouldBe devicesRewardsByRangeWeek.total
+                            it?.mode shouldBe devicesRewardsByRangeWeek.mode
+                            it?.datesChartTooltip shouldBe
+                                devicesRewardsByRangeWeek.datesChartTooltip
+                            it?.lineChartData?.isEqual(devicesRewardsByRangeWeek.lineChartData)
+                        }
+                    }
+                }
+                and("mode is MONTH") {
+                    coMockEitherRight(
+                        { repository.getDevicesRewardsByRange(RewardsSummaryMode.MONTH) },
+                        devicesRewards
+                    )
+                    then("return the DevicesRewardsByRange for MONTH mode") {
+                        usecase.getDevicesRewardsByRange(RewardsSummaryMode.MONTH).getOrNull()
+                            .also {
+                                it?.total shouldBe devicesRewardsByRangeMonth.total
+                                it?.mode shouldBe devicesRewardsByRangeMonth.mode
+                                it?.datesChartTooltip shouldBe
+                                    devicesRewardsByRangeMonth.datesChartTooltip
+                                it?.lineChartData?.isEqual(devicesRewardsByRangeMonth.lineChartData)
+                            }
+                    }
+                }
+                and("mode is YEAR") {
+                    coMockEitherRight(
+                        { repository.getDevicesRewardsByRange(RewardsSummaryMode.YEAR) },
+                        devicesRewards
+                    )
+                    then("return the DevicesRewardsByRange for YEAR mode") {
+                        usecase.getDevicesRewardsByRange(RewardsSummaryMode.YEAR).getOrNull().also {
+                            it?.total shouldBe devicesRewardsByRangeYear.total
+                            it?.mode shouldBe devicesRewardsByRangeYear.mode
+                            it?.datesChartTooltip shouldBe
+                                devicesRewardsByRangeYear.datesChartTooltip
+                            it?.lineChartData?.isEqual(devicesRewardsByRangeYear.lineChartData)
+                        }
+                    }
+                }
+            }
+            When("it's a failure") {
+                coMockEitherLeft(
+                    { repository.getDevicesRewardsByRange(RewardsSummaryMode.WEEK) },
+                    failure
+                )
+                then("return the failure") {
+                    usecase.getDevicesRewardsByRange(RewardsSummaryMode.WEEK).isError()
+                }
+            }
+        }
+    }
+
+    context("Get rewards summary for a device by range") {
+        given("A repository providing the device's rewards summary") {
+            When("it's a success") {
+                and("mode is WEEK") {
+                    coMockEitherRight(
+                        { repository.getDeviceRewardsByRange(deviceId, RewardsSummaryMode.WEEK) },
+                        deviceRewardsSummary
+                    )
+                    then("return the DeviceTotalRewardsDetails for WEEK mode") {
+                        usecase.getDeviceRewardsByRange(deviceId, RewardsSummaryMode.WEEK)
+                            .getOrNull().also {
+                                it?.total shouldBe deviceTotalRewardsDetails.total
+                                it?.mode shouldBe deviceTotalRewardsDetails.mode
+                                it?.boosts shouldBe deviceTotalRewardsDetails.boosts
+                                it?.totals shouldBe deviceTotalRewardsDetails.totals
+                                it?.datesChartTooltip shouldBe
+                                    deviceTotalRewardsDetails.datesChartTooltip
+                                it?.baseChartData?.isEqual(deviceTotalRewardsDetails.baseChartData)
+                                it?.betaChartData?.isEqual(deviceTotalRewardsDetails.betaChartData)
+                                it?.otherChartData?.isEqual(deviceTotalRewardsDetails.otherChartData)
+                                it?.status shouldBe deviceTotalRewardsDetails.status
+                            }
+                    }
+                }
+            }
+            When("it's a failure") {
+                coMockEitherLeft(
+                    { repository.getDeviceRewardsByRange(deviceId, RewardsSummaryMode.WEEK) },
+                    failure
+                )
+                then("return the failure") {
+                    usecase.getDeviceRewardsByRange(deviceId, RewardsSummaryMode.WEEK).isError()
                 }
             }
         }

--- a/app/src/test/java/com/weatherxm/usecases/StatsUseCaseTest.kt
+++ b/app/src/test/java/com/weatherxm/usecases/StatsUseCaseTest.kt
@@ -27,7 +27,6 @@ import io.kotest.core.spec.style.BehaviorSpec
 import io.kotest.matchers.shouldBe
 import io.mockk.every
 import io.mockk.mockk
-import io.mockk.mockkStatic
 import org.koin.core.context.startKoin
 import org.koin.core.context.stopKoin
 import org.koin.core.qualifier.named

--- a/app/src/test/java/com/weatherxm/usecases/StatsUseCaseTest.kt
+++ b/app/src/test/java/com/weatherxm/usecases/StatsUseCaseTest.kt
@@ -104,7 +104,6 @@ class StatsUseCaseTest : KoinTest, BehaviorSpec({
             })
         }
 
-        mockkStatic(DateFormat::class)
         every { DateFormat.is24HourFormat(context) } returns true
 
         every { NumberUtils.compactNumber(any()) } returns "1"

--- a/app/src/test/java/com/weatherxm/util/DateTimeHelperTest.kt
+++ b/app/src/test/java/com/weatherxm/util/DateTimeHelperTest.kt
@@ -46,14 +46,6 @@ class DateTimeHelperTest : BehaviorSpec({
     val timestamp = 1717077600000L
 
     beforeSpec {
-        mockkStatic(DateFormat::class)
-        every {
-            DateFormat.getBestDateTimePattern(
-                Locale.getDefault(),
-                DATE_FORMAT_MONTH_DAY
-            )
-        } returns "d/M"
-
         startKoin {
             modules(
                 module {

--- a/app/src/test/java/com/weatherxm/util/DateTimeHelperTest.kt
+++ b/app/src/test/java/com/weatherxm/util/DateTimeHelperTest.kt
@@ -22,7 +22,6 @@ import com.weatherxm.util.DateTimeHelper.timestampToLocalDate
 import io.kotest.core.spec.style.BehaviorSpec
 import io.kotest.matchers.shouldBe
 import io.mockk.every
-import io.mockk.mockkStatic
 import org.koin.core.context.startKoin
 import org.koin.core.context.stopKoin
 import org.koin.core.qualifier.named


### PR DESCRIPTION
### **Why?**
Some missing unit tests for `RewardsUseCase` and for `Data.Extensions`

### **How?**
- Created the 2 last unit tests missing from `RewardsUseCase`. 
- Created functions `getTooltipDate` and `getXAxisLabel` as we had the same code in 2 different places.
- Created unit tests for `Data.Extensions` file.

### **Testing**
Just make sure the action below that runs unit tests completes with 100% success.