### PR TITLE
FE-1169 Fixed analytics event on daily card click in forecast

### DIFF
--- a/app/src/main/java/com/weatherxm/analytics/AnalyticsService.kt
+++ b/app/src/main/java/com/weatherxm/analytics/AnalyticsService.kt
@@ -254,7 +254,6 @@ interface AnalyticsService {
         NO_REWARD_SPLITTING("no_reward_splitting"),
         STAKEHOLDER_LOWERCASE("stakeholder"),
         NON_STAKEHOLDER("non_stakeholder"),
-        FORECAST_DAY("Forecast Day"),
         FORECAST_NEXT_7_DAYS("forecast_next_7_days"),
         TOKENS_EARNED_PRESSED("Tokens Earned pressed"),
         DEVICE_REWARD_ANALYTICS_CARD("Device Reward Analytics Card"),

--- a/app/src/main/java/com/weatherxm/ui/devicedetails/forecast/DailyForecastAdapter.kt
+++ b/app/src/main/java/com/weatherxm/ui/devicedetails/forecast/DailyForecastAdapter.kt
@@ -5,6 +5,7 @@ import android.view.ViewGroup
 import androidx.recyclerview.widget.DiffUtil
 import androidx.recyclerview.widget.ListAdapter
 import androidx.recyclerview.widget.RecyclerView
+import com.google.firebase.analytics.FirebaseAnalytics
 import com.weatherxm.analytics.AnalyticsService
 import com.weatherxm.analytics.AnalyticsWrapper
 import com.weatherxm.databinding.ListItemForecastBinding
@@ -76,7 +77,11 @@ class DailyForecastAdapter(private val onClickListener: (UIForecastDay) -> Unit)
         fun bind(item: UIForecastDay) {
             binding.root.setOnClickListener {
                 analytics.trackEventSelectContent(
-                    AnalyticsService.ParamValue.FORECAST_DAY.paramValue,
+                    AnalyticsService.ParamValue.DAILY_CARD.paramValue,
+                    Pair(
+                        FirebaseAnalytics.Param.ITEM_ID,
+                        AnalyticsService.ParamValue.DAILY_FORECAST.paramValue
+                    ),
                     index = absoluteAdapterPosition.toLong()
                 )
                 onClickListener(item)

--- a/app/src/main/java/com/weatherxm/ui/devicedetails/forecast/ForecastFragment.kt
+++ b/app/src/main/java/com/weatherxm/ui/devicedetails/forecast/ForecastFragment.kt
@@ -7,10 +7,10 @@ import android.view.ViewGroup
 import com.google.firebase.analytics.FirebaseAnalytics
 import com.weatherxm.R
 import com.weatherxm.analytics.AnalyticsService
-import com.weatherxm.ui.common.Status
 import com.weatherxm.databinding.FragmentDeviceDetailsForecastBinding
 import com.weatherxm.ui.common.DeviceRelation.UNFOLLOWED
 import com.weatherxm.ui.common.HourlyForecastAdapter
+import com.weatherxm.ui.common.Status
 import com.weatherxm.ui.common.blockParentViewPagerOnScroll
 import com.weatherxm.ui.common.classSimpleName
 import com.weatherxm.ui.common.invisible
@@ -51,18 +51,7 @@ class ForecastFragment : BaseFragment() {
 
         // Initialize the adapters with empty data
         val dailyForecastAdapter = DailyForecastAdapter {
-            analytics.trackEventSelectContent(
-                AnalyticsService.ParamValue.DAILY_CARD.paramValue,
-                Pair(
-                    FirebaseAnalytics.Param.ITEM_ID,
-                    AnalyticsService.ParamValue.DAILY_FORECAST.paramValue
-                )
-            )
-            navigator.showForecastDetails(
-                context,
-                model.device,
-                forecastSelectedISODate = it.date.toString()
-            )
+            navigator.showForecastDetails(context, model.device, it.date.toString())
         }
         val hourlyForecastAdapter = HourlyForecastAdapter {
             analytics.trackEventSelectContent(


### PR DESCRIPTION
### **Why?**
We have two analytics events on Daily Card click in Forecast Tab. So this PR fixes it.

### **How?**
Keep the old one: `(.selectContent, parameters: [.contentType: .dailyCard, .itemId: .dailyForecast])` and add the `index` param.

### **Testing**
Ensure that the proper event is logged.