### PR TITLE
FE-1198 Alerts screen design changes

### DIFF
--- a/app/src/local/assets/mock_files/get_user_device.json
+++ b/app/src/local/assets/mock_files/get_user_device.json
@@ -18,8 +18,12 @@
         "lon": 23.730503
     },
     "attributes": {
-        "isActive": true,
+        "isActive": false,
         "lastWeatherStationActivity": "2022-01-13T22:00:00+02:00",
+        "firmware": {
+            "current": "1.0.0",
+            "assigned": "1.0.1"
+        },
         "hex3": {
             "index": "833f72fffffffff",
             "polygon": [

--- a/app/src/main/java/com/weatherxm/ui/components/MessageCardView.kt
+++ b/app/src/main/java/com/weatherxm/ui/components/MessageCardView.kt
@@ -7,6 +7,7 @@ import android.view.Gravity
 import android.view.LayoutInflater
 import android.widget.LinearLayout
 import androidx.annotation.ColorRes
+import androidx.annotation.DrawableRes
 import androidx.annotation.StringRes
 import androidx.appcompat.content.res.AppCompatResources
 import com.google.android.material.button.MaterialButton.ICON_GRAVITY_END
@@ -139,6 +140,11 @@ class MessageCardView : LinearLayout {
             setOnClickListener { onTroubleshootClicked.invoke() }
             visible(true)
         }
+        return this
+    }
+
+    fun icon(@DrawableRes resId: Int): MessageCardView {
+        binding.icon.setImageDrawable(AppCompatResources.getDrawable(context, resId))
         return this
     }
 

--- a/app/src/main/java/com/weatherxm/ui/devicealerts/DeviceAlertsActivity.kt
+++ b/app/src/main/java/com/weatherxm/ui/devicealerts/DeviceAlertsActivity.kt
@@ -38,7 +38,7 @@ class DeviceAlertsActivity : BaseActivity(), DeviceAlertListener {
             setNavigationOnClickListener { onBackPressedDispatcher.onBackPressed() }
         }
         device?.getDefaultOrFriendlyName()?.let {
-            binding.header.subtitle(it)
+            binding.toolbar.subtitle = it
         }
 
         val adapter = DeviceAlertsAdapter(this, device)

--- a/app/src/main/java/com/weatherxm/ui/devicealerts/DeviceAlertsAdapter.kt
+++ b/app/src/main/java/com/weatherxm/ui/devicealerts/DeviceAlertsAdapter.kt
@@ -46,6 +46,7 @@ class DeviceAlertsAdapter(
             when (item.alert) {
                 DeviceAlertType.NEEDS_UPDATE -> {
                     binding.alert
+                        .icon(R.drawable.ic_update_alt)
                         .title(R.string.updated_needed_title)
                         .message(R.string.updated_needed_desc)
                         .action(itemView.context.getString(R.string.update_station_now)) {
@@ -67,6 +68,7 @@ class DeviceAlertsAdapter(
                 }
                 DeviceAlertType.LOW_BATTERY -> {
                     binding.alert
+                        .icon(R.drawable.ic_low_battery)
                         .title(R.string.low_battery)
                         .message(R.string.low_battery_desc)
                         .action(itemView.context.getString(R.string.read_more)) {

--- a/app/src/main/res/layout/activity_device_alerts.xml
+++ b/app/src/main/res/layout/activity_device_alerts.xml
@@ -19,40 +19,24 @@
             android:id="@+id/toolbar"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            app:navigationIcon="@drawable/ic_back" />
+            app:navigationIcon="@drawable/ic_back"
+            app:title="@string/alerts"
+            tools:subtitle="My Weather Station" />
 
     </com.google.android.material.appbar.AppBarLayout>
 
-    <androidx.constraintlayout.widget.ConstraintLayout
+    <androidx.recyclerview.widget.RecyclerView
+        android:id="@+id/recycler"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
-        app:layout_behavior="com.google.android.material.appbar.AppBarLayout$ScrollingViewBehavior">
-
-        <com.weatherxm.ui.components.HeaderView
-            android:id="@+id/header"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:layout_marginHorizontal="@dimen/margin_normal"
-            android:paddingBottom="@dimen/padding_normal"
-            app:header_title="@string/alerts"
-            app:layout_constraintTop_toTopOf="parent" />
-
-        <androidx.recyclerview.widget.RecyclerView
-            android:id="@+id/recycler"
-            android:layout_width="match_parent"
-            android:layout_height="0dp"
-            android:layout_marginHorizontal="@dimen/margin_normal"
-            android:layout_marginTop="@dimen/margin_normal"
-            android:clipChildren="false"
-            android:clipToPadding="false"
-            android:overScrollMode="never"
-            android:scrollbars="vertical"
-            app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"
-            app:layout_constraintBottom_toBottomOf="parent"
-            app:layout_constraintTop_toBottomOf="@id/header"
-            tools:listitem="@layout/list_item_alert" />
-
-
-    </androidx.constraintlayout.widget.ConstraintLayout>
+        android:layout_marginHorizontal="@dimen/margin_normal"
+        android:layout_marginTop="@dimen/margin_normal"
+        android:clipChildren="false"
+        android:clipToPadding="false"
+        android:overScrollMode="never"
+        android:scrollbars="vertical"
+        app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"
+        app:layout_behavior="com.google.android.material.appbar.AppBarLayout$ScrollingViewBehavior"
+        tools:listitem="@layout/list_item_alert" />
 
 </androidx.coordinatorlayout.widget.CoordinatorLayout>


### PR DESCRIPTION
### **Why?**
Alerts screen design changes

### **How?**
Updated alerts screen's top bar and used the new icons in low battery and update required alerts.

### **Testing**
If you don't have such a station, play with local mock in order to create a station consisting of low battery, update required and inactive alerts and view its Alerts screen.

#### TIP: The local mock is already configured in `get_user_device.json` to consist of 3 alerts.
