### PR TITLE
FE-1263 My profile: Total earned & Total claimed tokens error state

### DIFF
--- a/app/src/main/java/com/weatherxm/ui/common/Contracts.kt
+++ b/app/src/main/java/com/weatherxm/ui/common/Contracts.kt
@@ -2,6 +2,7 @@ package com.weatherxm.ui.common
 
 object Contracts {
     const val EMPTY_VALUE = "?"
+    const val NOT_AVAILABLE_VALUE = "N/A"
     const val ARG_DEVICE = "device"
     const val ARG_DEVICE_TYPE = "device_type"
     const val ARG_BLE_DEVICE_CONNECTED = "ble_device_connected"

--- a/app/src/main/java/com/weatherxm/ui/home/profile/ProfileFragment.kt
+++ b/app/src/main/java/com/weatherxm/ui/home/profile/ProfileFragment.kt
@@ -13,6 +13,7 @@ import com.weatherxm.analytics.AnalyticsService
 import com.weatherxm.data.models.User
 import com.weatherxm.databinding.FragmentProfileBinding
 import com.weatherxm.ui.common.Contracts.ARG_TOKEN_CLAIMED_AMOUNT
+import com.weatherxm.ui.common.Contracts.NOT_AVAILABLE_VALUE
 import com.weatherxm.ui.common.Status
 import com.weatherxm.ui.common.UIWalletRewards
 import com.weatherxm.ui.common.applyInsets
@@ -119,6 +120,7 @@ class ProfileFragment : BaseFragment() {
                 Status.ERROR -> {
                     Timber.d("Got error: $resource.message")
                     resource.message?.let { context.toast(it) }
+                    onNotAvailableRewards()
                     toggleLoading(false)
                 }
                 Status.LOADING -> {
@@ -138,6 +140,7 @@ class ProfileFragment : BaseFragment() {
                 }
                 Status.ERROR -> {
                     Timber.d("Got error: $resource.message")
+                    onNotAvailableRewards()
                     resource.message?.let { context.toast(it) }
                     toggleLoading(false)
                 }
@@ -177,6 +180,20 @@ class ProfileFragment : BaseFragment() {
             binding.swiperefresh.isRefreshing = false
             binding.progress.invisible()
         }
+    }
+
+    private fun onNotAvailableRewards() {
+        binding.totalEarnedValue.text = NOT_AVAILABLE_VALUE
+        binding.totalClaimedValue.text = NOT_AVAILABLE_VALUE
+        binding.rewards
+            .subtitle(NOT_AVAILABLE_VALUE)
+            .action(getString(R.string.action_claim)) {
+                navigator.showRewardsClaiming(
+                    rewardsClaimLauncher,
+                    requireContext(),
+                    UIWalletRewards.empty()
+                )
+            }
     }
 
     private fun updateRewardsUI(data: UIWalletRewards) {

--- a/app/src/main/java/com/weatherxm/ui/home/profile/ProfileFragment.kt
+++ b/app/src/main/java/com/weatherxm/ui/home/profile/ProfileFragment.kt
@@ -185,15 +185,7 @@ class ProfileFragment : BaseFragment() {
     private fun onNotAvailableRewards() {
         binding.totalEarnedValue.text = NOT_AVAILABLE_VALUE
         binding.totalClaimedValue.text = NOT_AVAILABLE_VALUE
-        binding.rewards
-            .subtitle(NOT_AVAILABLE_VALUE)
-            .action(getString(R.string.action_claim)) {
-                navigator.showRewardsClaiming(
-                    rewardsClaimLauncher,
-                    requireContext(),
-                    UIWalletRewards.empty()
-                )
-            }
+        binding.rewards.subtitle(NOT_AVAILABLE_VALUE)
     }
 
     private fun updateRewardsUI(data: UIWalletRewards) {


### PR DESCRIPTION
### **Why?**
Use the error state with `N/A` when we encounter an API error in the rewards in the profile screen.

### **How?**
Show the `N/A` values respectively.

### **Testing**
Reproduce it with an error (e.g. turn internet off and go to profile screen) and ensure everything looks according to the spec.
