### PR TITLE
FE-1276 Hide loading spinner in devices list at the "Total Earned" button

### DIFF
--- a/app/src/main/java/com/weatherxm/ui/home/devices/DevicesFragment.kt
+++ b/app/src/main/java/com/weatherxm/ui/home/devices/DevicesFragment.kt
@@ -24,7 +24,6 @@ import com.weatherxm.ui.common.UIDevice
 import com.weatherxm.ui.common.applyInsets
 import com.weatherxm.ui.common.classSimpleName
 import com.weatherxm.ui.common.empty
-import com.weatherxm.ui.common.invisible
 import com.weatherxm.ui.common.setCardRadius
 import com.weatherxm.ui.common.toast
 import com.weatherxm.ui.common.visible
@@ -169,7 +168,6 @@ class DevicesFragment : BaseFragment(), DeviceListener {
             }
             Status.ERROR -> {
                 binding.swiperefresh.isRefreshing = false
-                binding.loadingRewards.invisible()
                 binding.totalEarned.text = getString(R.string.wxm_amount, "?")
                 binding.empty.animation(R.raw.anim_error, false)
                     .title(getString(R.string.error_generic_message))
@@ -188,14 +186,12 @@ class DevicesFragment : BaseFragment(), DeviceListener {
                 } else {
                     binding.recycler.visible(false)
                     binding.empty.clear().animation(R.raw.anim_loading).visible(true)
-                    binding.loadingRewards.visible(true)
                 }
             }
         }
     }
 
     private fun onDevicesRewards(rewards: DevicesRewards) {
-        binding.loadingRewards.invisible()
         binding.totalEarnedCard.setOnClickListener {
             analytics.trackEventUserAction(
                 AnalyticsService.ParamValue.TOKENS_EARNED_PRESSED.paramValue

--- a/app/src/main/res/layout/fragment_devices.xml
+++ b/app/src/main/res/layout/fragment_devices.xml
@@ -80,15 +80,6 @@
                                     android:textStyle="bold"
                                     tools:text="100,99 $WXM" />
 
-                                <com.google.android.material.progressindicator.CircularProgressIndicator
-                                    android:id="@+id/loadingRewards"
-                                    style="@style/Widget.WeatherXM.ProgressBar.Circular"
-                                    android:layout_width="wrap_content"
-                                    android:layout_height="wrap_content"
-                                    android:visibility="invisible"
-                                    app:indicatorInset="0dp"
-                                    app:indicatorSize="18dp" />
-
                             </FrameLayout>
                         </LinearLayout>
 


### PR DESCRIPTION
### **Why?**
Remove Total Earned progress icon on Android

### **How?**
Removed the spinner.

### **Testing**
Ensure that everything looks OK, the total earned is not displayed until the data are loaded.