### PR TITLE
FE-1299 Fix the content to share in the station settings screen

### DIFF
--- a/app/src/main/java/com/weatherxm/ui/devicesettings/BaseDeviceSettingsViewModel.kt
+++ b/app/src/main/java/com/weatherxm/ui/devicesettings/BaseDeviceSettingsViewModel.kt
@@ -16,7 +16,6 @@ import com.weatherxm.ui.common.DeviceAlertType
 import com.weatherxm.ui.common.RewardSplitsData
 import com.weatherxm.ui.common.UIDevice
 import com.weatherxm.ui.common.UIError
-import com.weatherxm.ui.common.empty
 import com.weatherxm.ui.common.unmask
 import com.weatherxm.usecases.StationSettingsUseCase
 import com.weatherxm.util.Resources
@@ -132,17 +131,13 @@ abstract class BaseDeviceSettingsViewModel(
     }
 
     fun parseDeviceInfoToShare(deviceInfo: UIDeviceInfo): String {
-        var sharingText = String.empty()
-        deviceInfo.default.forEach {
-            sharingText += "${it}\n"
-        }
-        deviceInfo.gateway.forEach {
-            sharingText += "${it}\n"
-        }
-        deviceInfo.station.forEach {
-            sharingText += "${it}\n"
-        }
-        return sharingText
+        return deviceInfo.default.joinToString(separator = "\n") {
+            it.toFormattedString()
+        }.plus(deviceInfo.gateway.joinToString(separator = "\n", prefix = "\n") {
+            it.toFormattedString()
+        }).plus(deviceInfo.station.joinToString(separator = "\n", prefix = "\n") {
+            it.toFormattedString()
+        })
     }
 
     fun isStakeholder(rewardSplitsData: RewardSplitsData): Boolean {

--- a/app/src/main/java/com/weatherxm/ui/devicesettings/UIModels.kt
+++ b/app/src/main/java/com/weatherxm/ui/devicesettings/UIModels.kt
@@ -21,7 +21,9 @@ data class UIDeviceInfoItem(
     val title: String,
     val value: String,
     val deviceAlert: DeviceAlert? = null,
-)
+) {
+    fun toFormattedString(): String = "$title: $value"
+}
 
 @JsonClass(generateAdapter = true)
 data class RebootState(


### PR DESCRIPTION
### **Why?**
There is a bug currently with the content copied when clicking the "Share" button to not follow the spec we have agreed onto.

### **How?**
1. Created a function `toFormattedString` in `DeviceInfoItem` UI Model and
2. Fixed the function `parseDeviceInfoToShare` in `BaseDeviceSettingsViewModel` by using the above function.

### **Testing**
Just ensure that the text to share is correct (content-wise and format-wise) as it should be in the same format as the iOS does.
