### PR TITLE
FE-1306 CountDownTimer helper class

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -370,6 +370,7 @@ tasks.register("jacocoCoverageTestReport", type = JacocoReport::class) {
         "**/ui/widgets/currentweather/*.*",
         "**/ui/Navigator.class",
         "**/util/ChartsKt*.*",
+        "**/util/CountDownTimerHelper*.*",
         "**/BuildConfig.class"
     )
     val debugTree = fileTree(

--- a/app/src/main/java/com/weatherxm/ui/deviceheliumota/DeviceHeliumOTAViewModel.kt
+++ b/app/src/main/java/com/weatherxm/ui/deviceheliumota/DeviceHeliumOTAViewModel.kt
@@ -4,6 +4,7 @@ import android.net.Uri
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.viewModelScope
 import com.weatherxm.R
+import com.weatherxm.analytics.AnalyticsWrapper
 import com.weatherxm.data.models.BluetoothError
 import com.weatherxm.data.models.BluetoothOTAState
 import com.weatherxm.data.models.Failure
@@ -14,7 +15,6 @@ import com.weatherxm.ui.components.BluetoothHeliumViewModel
 import com.weatherxm.usecases.BluetoothConnectionUseCase
 import com.weatherxm.usecases.BluetoothScannerUseCase
 import com.weatherxm.usecases.BluetoothUpdaterUseCase
-import com.weatherxm.analytics.AnalyticsWrapper
 import com.weatherxm.util.Failure.getCode
 import com.weatherxm.util.Resources
 import kotlinx.coroutines.launch

--- a/app/src/main/java/com/weatherxm/util/CountDownTimerHelper.kt
+++ b/app/src/main/java/com/weatherxm/util/CountDownTimerHelper.kt
@@ -11,6 +11,7 @@ class CountDownTimerHelper {
 
     private var timer: CountDownTimer? = null
 
+    @Suppress("MagicNumber")
     fun start(onProgress: (Int) -> Unit, onFinished: () -> Unit) {
         timer = object : CountDownTimer(COUNTDOWN_DURATION, COUNTDOWN_INTERVAL) {
             override fun onTick(msUntilDone: Long) {

--- a/app/src/main/java/com/weatherxm/util/CountDownTimerHelper.kt
+++ b/app/src/main/java/com/weatherxm/util/CountDownTimerHelper.kt
@@ -1,0 +1,31 @@
+package com.weatherxm.util
+
+import android.os.CountDownTimer
+import timber.log.Timber
+
+class CountDownTimerHelper {
+    companion object {
+        const val COUNTDOWN_DURATION = 5000L
+        const val COUNTDOWN_INTERVAL = 50L
+    }
+
+    private var timer: CountDownTimer? = null
+
+    fun start(onProgress: (Int) -> Unit, onFinished: () -> Unit) {
+        timer = object : CountDownTimer(COUNTDOWN_DURATION, COUNTDOWN_INTERVAL) {
+            override fun onTick(msUntilDone: Long) {
+                val progress =
+                    ((COUNTDOWN_DURATION - msUntilDone) * 100L / COUNTDOWN_DURATION).toInt()
+                Timber.d("Timer progress: $progress")
+                onProgress(progress)
+            }
+
+            override fun onFinish() {
+                onFinished()
+            }
+        }
+        timer?.start()
+    }
+
+    fun stop() = timer?.cancel()
+}

--- a/app/src/test/java/com/weatherxm/TestConfig.kt
+++ b/app/src/test/java/com/weatherxm/TestConfig.kt
@@ -18,6 +18,7 @@ import com.weatherxm.data.services.CacheService.Companion.KEY_WIND
 import com.weatherxm.data.services.CacheService.Companion.KEY_WIND_DIR
 import com.weatherxm.ui.common.empty
 import com.weatherxm.util.AndroidBuildInfo
+import com.weatherxm.util.CountDownTimerHelper
 import com.weatherxm.util.Resources
 import io.kotest.core.config.AbstractProjectConfig
 import io.kotest.core.listeners.AfterProjectListener
@@ -25,7 +26,9 @@ import io.kotest.core.listeners.BeforeProjectListener
 import io.kotest.core.names.DuplicateTestNameMode
 import io.kotest.core.spec.AutoScan
 import io.mockk.every
+import io.mockk.justRun
 import io.mockk.mockk
+import io.mockk.mockkConstructor
 import io.mockk.mockkObject
 import io.mockk.mockkStatic
 import java.util.Locale
@@ -49,6 +52,9 @@ object TestConfig : AbstractProjectConfig() {
     object MyProjectListener : BeforeProjectListener, AfterProjectListener {
         @Suppress("LongMethod")
         override suspend fun beforeProject() {
+            mockkConstructor(CountDownTimerHelper::class)
+            justRun { anyConstructed<CountDownTimerHelper>().start(any(), any()) }
+            justRun { anyConstructed<CountDownTimerHelper>().stop() }
             mockkStatic(Geocoder::class)
             mockkStatic(DateFormat::class)
             mockkObject(AndroidBuildInfo)

--- a/app/src/test/java/com/weatherxm/ui/devicesettings/helium/reboot/RebootViewModelTest.kt
+++ b/app/src/test/java/com/weatherxm/ui/devicesettings/helium/reboot/RebootViewModelTest.kt
@@ -1,5 +1,6 @@
 package com.weatherxm.ui.devicesettings.helium.reboot
 
+import android.bluetooth.BluetoothDevice
 import com.weatherxm.R
 import com.weatherxm.TestConfig.failure
 import com.weatherxm.TestConfig.resources
@@ -8,6 +9,7 @@ import com.weatherxm.TestUtils.coMockEitherRight
 import com.weatherxm.analytics.AnalyticsWrapper
 import com.weatherxm.data.models.BluetoothError
 import com.weatherxm.ui.InstantExecutorListener
+import com.weatherxm.ui.common.ScannedDevice
 import com.weatherxm.ui.common.Status
 import com.weatherxm.ui.common.UIDevice
 import com.weatherxm.ui.devicesettings.RebootState
@@ -16,7 +18,9 @@ import com.weatherxm.usecases.BluetoothConnectionUseCase
 import com.weatherxm.usecases.BluetoothScannerUseCase
 import io.kotest.core.spec.style.BehaviorSpec
 import io.kotest.matchers.shouldBe
+import io.mockk.coEvery
 import io.mockk.coJustRun
+import io.mockk.coVerify
 import io.mockk.every
 import io.mockk.justRun
 import io.mockk.mockk
@@ -37,13 +41,19 @@ class RebootViewModelTest : BehaviorSpec({
     val analytics = mockk<AnalyticsWrapper>()
     lateinit var viewModel: RebootViewModel
 
-    val device = mockk<UIDevice>()
 
     val bondFlow = MutableSharedFlow<Int>(
         replay = 1, onBufferOverflow = BufferOverflow.DROP_LATEST
     )
+    val scanFlow = MutableSharedFlow<ScannedDevice>(
+        replay = 1, onBufferOverflow = BufferOverflow.DROP_LATEST
+    )
     val deviceNotFoundFailure = BluetoothError.DeviceNotFound
     val stationNotInRange = "Station not in range"
+    val macAddress = "00:00:00"
+    val pairedDevice = mockk<BluetoothDevice>()
+    val device = mockk<UIDevice>()
+    val scannedDevice = ScannedDevice(macAddress, macAddress)
 
     listener(InstantExecutorListener())
     Dispatchers.setMain(StandardTestDispatcher())
@@ -51,8 +61,11 @@ class RebootViewModelTest : BehaviorSpec({
     beforeSpec {
         justRun { analytics.trackEventFailure(any()) }
         every { connectionUseCase.registerOnBondStatus() } returns bondFlow
+        coEvery { scanUseCase.scan() } returns scanFlow
         coJustRun { connectionUseCase.reboot() }
-        every { device.getLastCharsOfLabel() } returns "00:00:00"
+        every { device.getLastCharsOfLabel() } returns macAddress
+        every { connectionUseCase.getPairedDevices() } returns listOf(pairedDevice)
+        every { pairedDevice.address } returns macAddress
 
         every {
             resources.getString(R.string.station_not_in_range_subtitle)
@@ -65,6 +78,14 @@ class RebootViewModelTest : BehaviorSpec({
             resources,
             analytics
         )
+    }
+
+    context("Get device") {
+        given("the device in the view model") {
+            then("get it") {
+                viewModel.device shouldBe device
+            }
+        }
     }
 
     context("Flow when onNotPaired gets triggered") {
@@ -101,18 +122,6 @@ class RebootViewModelTest : BehaviorSpec({
         }
     }
 
-    context("Flow when onConnectionFailure gets triggered") {
-        given("the trigger") {
-            viewModel.onConnectionFailure(failure)
-            then("onStatus should post an error with the respective RebootState") {
-                viewModel.onStatus().value?.status shouldBe Status.ERROR
-                viewModel.onStatus().value?.data shouldBe RebootState(
-                    RebootStatus.CONNECT_TO_STATION
-                )
-            }
-        }
-    }
-
     context("Start the reboot process when device is connected") {
         given("a usecase returning the result of the reboot") {
             When("it's a failure") {
@@ -137,15 +146,66 @@ class RebootViewModelTest : BehaviorSpec({
         }
     }
 
-    /**
-     * TODO: startConnectionProcess is missing due to the issue on CountDownTimer,
-     * we need to move this functionality in an util class or sth so we can mock it in the tests.
-     */
-//    context("Flow when we want to start the connection process") {
-//        given("the trigger") {
-//            viewModel.startConnectionProcess()
-//        }
-//    }
+    context("Flow when we want to start the connection process") {
+        given("the device that just got scanned") {
+            and("try to set the peripheral") {
+                When("it's a failure") {
+                    coMockEitherLeft(
+                        { connectionUseCase.setPeripheral(scannedDevice.address) },
+                        failure
+                    )
+                    scanFlow.tryEmit(scannedDevice)
+                    runTest { viewModel.startConnectionProcess() }
+                    then("analytics should track the event's failure") {
+                        verify(exactly = 2) { analytics.trackEventFailure(any()) }
+                    }
+                    then("onStatus should post an error with the respective RebootState") {
+                        viewModel.onStatus().value?.status shouldBe Status.ERROR
+                        viewModel.onStatus().value?.data shouldBe RebootState(
+                            RebootStatus.CONNECT_TO_STATION
+                        )
+                    }
+                }
+                When("it's a success") {
+                    coMockEitherRight(
+                        { connectionUseCase.setPeripheral(scannedDevice.address) },
+                        Unit
+                    )
+                    and("try to connect to the peripheral") {
+                        When("it's a failure") {
+                            coMockEitherLeft(
+                                { connectionUseCase.connectToPeripheral() },
+                                failure
+                            )
+                            runTest { viewModel.startConnectionProcess() }
+                            then("analytics should track the event's failure") {
+                                verify(exactly = 3) { analytics.trackEventFailure(any()) }
+                            }
+                            then("onStatus should post an error with the respective RebootState") {
+                                viewModel.onStatus().value?.status shouldBe Status.ERROR
+                                viewModel.onStatus().value?.data shouldBe RebootState(
+                                    RebootStatus.CONNECT_TO_STATION
+                                )
+                            }
+                        }
+                        When("it's a success") {
+                            coMockEitherRight(
+                                { connectionUseCase.connectToPeripheral() },
+                                Unit
+                            )
+                            runTest { viewModel.startConnectionProcess() }
+                            then("reboot in usecase should be called again") {
+                                coVerify(exactly = 3) { connectionUseCase.reboot() }
+                            }
+                        }
+                    }
+                }
+                then("Get the scanned device") {
+                    viewModel.scannedDevice() shouldBe scannedDevice
+                }
+            }
+        }
+    }
 
     afterSpec {
         Dispatchers.resetMain()


### PR DESCRIPTION
### **Why?**
Create a Count Down helper class to encapsulate `CountDownTimer` in order to reuse this class and be able to unit test the functionality as `CountDownTimer` is an Android library.

### **How?**
- Created a `CountDownTimerHelper` class to encapsulate the `CountDownTimer` functionality and use this class in `BluetoothHeliumViewModel` and `ClaimHeliumPairViewModel`.
- Fixed the unit tests that were missing due to having this Android class directly in our ViewModels.

### **Testing**
1. Ensure that the timer works correctly (can be checked in BLE scanning in the Helium's claiming flow as the `CountDownTimer` is used to show the progress which is shown in the "Scan Again" button)
2. Just make sure the tests run successfully (can be checked through the GitHub Action below as well).