### PR TITLE
FE-1309 Update message when an owned station has an inactive alert

### DIFF
--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -553,7 +553,7 @@
     <string name="issues">%d issues</string>
     <string name="issues_detected">%d issues detected</string>
     <string name="alerts_detected">%d alerts detected</string>
-    <string name="station_inactive_alert_message">The station is not sending weather data. Check the outdoor unit’s batteries and the internet connection. If the problem persists, contact our support team.</string>
+    <string name="station_inactive_alert_message">The station is not sending weather data. Check your network connection and the outdoor unit’s batteries. If the problem persists, contact our support team.</string>
     <string name="update_required">Update Required</string>
     <string name="low_battery">Low Battery</string>
     <string name="low_battery_desc">Your station is reporting low battery. This may lead to data gaps at night, or in low-sunlight conditions and, eventually, lose rewards. Read more on how to replace your station batteries.</string>


### PR DESCRIPTION
### **Why?**
Update message when an owned station has an inactive alert

### **How?**
Used the new message:

> The station is not sending weather data. Check your network connection and the outdoor unit’s batteries. If the problem persists, contact our support team.

### **Testing**
Just ensure the new message on an inactive owned station is correct.
