### PR TITLE
FE-1318 Network Health fixes

### DIFF
--- a/app/src/main/java/com/weatherxm/ui/devicedetails/DeviceDetailsActivity.kt
+++ b/app/src/main/java/com/weatherxm/ui/devicedetails/DeviceDetailsActivity.kt
@@ -231,14 +231,6 @@ class DeviceDetailsActivity : BaseActivity() {
 
         binding.status.setStatusChip(device)
         binding.bundle.setBundleChip(device)
-        if (!model.device.isOnline()) {
-            binding.status.setOnClickListener {
-                navigator.showDeviceAlerts(this, model.device)
-            }
-        } else {
-            binding.status.setOnClickListener(null)
-            binding.status.isClickable = false
-        }
 
         setAlerts(device)
     }

--- a/app/src/main/java/com/weatherxm/ui/devicedetails/forecast/ForecastFragment.kt
+++ b/app/src/main/java/com/weatherxm/ui/devicedetails/forecast/ForecastFragment.kt
@@ -99,6 +99,7 @@ class ForecastFragment : BaseFragment() {
             dailyForecastAdapter.submitList(it.forecastDays)
             binding.dailyForecastRecycler.visible(true)
             binding.dailyForecastTitle.visible(true)
+            binding.temperatureBarsInfoButton.visible(true)
             binding.hourlyForecastRecycler.visible(true)
             binding.hourlyForecastTitle.visible(true)
         }
@@ -124,6 +125,7 @@ class ForecastFragment : BaseFragment() {
             binding.progress.invisible()
         } else if (isLoading) {
             binding.dailyForecastTitle.visible(false)
+            binding.temperatureBarsInfoButton.visible(false)
             binding.hourlyForecastTitle.visible(false)
             binding.progress.visible(true)
         } else {
@@ -137,10 +139,11 @@ class ForecastFragment : BaseFragment() {
             binding.hiddenContentContainer.visible(false)
             model.fetchForecast()
         } else if (model.device.relation == UNFOLLOWED) {
-            binding.dailyForecastRecycler.visible(false)
-            binding.dailyForecastTitle.visible(false)
             binding.hourlyForecastTitle.visible(false)
             binding.hourlyForecastRecycler.visible(false)
+            binding.dailyForecastRecycler.visible(false)
+            binding.dailyForecastTitle.visible(false)
+            binding.temperatureBarsInfoButton.visible(false)
             binding.hiddenContentContainer.visible(true)
         }
     }

--- a/app/src/main/res/layout/activity_device_details.xml
+++ b/app/src/main/res/layout/activity_device_details.xml
@@ -67,6 +67,7 @@
                             style="@style/Widget.WeatherXM.Chip.Status"
                             android:layout_width="wrap_content"
                             android:layout_height="wrap_content"
+                            android:clickable="false"
                             app:chipCornerRadius="@dimen/radius_small"
                             app:chipIcon="@drawable/dot"
                             app:chipIconSize="10dp"

--- a/app/src/main/res/layout/list_item_device.xml
+++ b/app/src/main/res/layout/list_item_device.xml
@@ -107,6 +107,7 @@
             android:layout_height="match_parent"
             android:layout_marginHorizontal="@dimen/margin_normal_to_large"
             android:layout_marginTop="@dimen/margin_large"
+            android:paddingBottom="@dimen/padding_large"
             android:visibility="gone">
 
             <ImageView


### PR DESCRIPTION
…recast when unfollowed, remove click action on status chip when offline

### **Why?**
Some fixes after product testing in Network Health.

### **How?**
1. Removed the info button of forecast when "Hidden Content" is displayed on unfollowed stations
2. Devices List --> No Data --> Added bottom padding
3. Removed the click action from the status chip showing the last active time when it's offline

### **Testing**
Ensure that the 3 issues mentioned are fixed.