### PR TITLE
FE-1319 Friendly name, does not change in forecast 

### DIFF
--- a/app/src/main/java/com/weatherxm/ui/devicedetails/forecast/ForecastFragment.kt
+++ b/app/src/main/java/com/weatherxm/ui/devicedetails/forecast/ForecastFragment.kt
@@ -89,6 +89,10 @@ class ForecastFragment : BaseFragment() {
             }
         }
 
+        parentModel.onDevicePolling().observe(viewLifecycleOwner) {
+            model.device = it
+        }
+
         parentModel.onDeviceFirstFetch().observe(viewLifecycleOwner) {
             model.device = it
             model.fetchForecast(true)


### PR DESCRIPTION
### **Why?**
Update forecast's tab device model on device polling updates

### **How?**
```
parentModel.onDevicePolling().observe(viewLifecycleOwner) {
    model.device = it
}
```



### **Testing**
1. Open Device Details -> Forecast
2. Open Station Settings
3. Use a new friendly name
4. Go back
5. Open a daily forecast screen
6. Ensure the new friendly name shows up