### PR TITLE
FE-1323 Update No Data message for public (non-owned) device

### DIFF
--- a/app/src/main/java/com/weatherxm/ui/common/DevicesAdapter.kt
+++ b/app/src/main/java/com/weatherxm/ui/common/DevicesAdapter.kt
@@ -76,10 +76,7 @@ class DeviceAdapter(private val deviceListener: DeviceListener) :
             if (item.currentWeather == null || item.currentWeather.isEmpty()) {
                 binding.weatherDataLayout.visible(false)
                 binding.noDataLayout.visible(true)
-                if (!item.isOwned()) {
-                    binding.noDataMessage.text =
-                        itemView.context.getString(R.string.no_data_message_public_device)
-                }
+                item.setNoDataMessage(itemView.context, binding.noDataMessage)
             } else {
                 setWeatherData(item)
             }

--- a/app/src/main/java/com/weatherxm/ui/common/Views.kt
+++ b/app/src/main/java/com/weatherxm/ui/common/Views.kt
@@ -570,6 +570,14 @@ fun UIDevice.handleAlerts(context: Context, issueChip: Chip, analytics: Analytic
     issueChip.visible(true)
 }
 
+fun UIDevice.setNoDataMessage(context: Context, textView: MaterialTextView) {
+    textView.text = if (!isOwned()) {
+        context.getString(R.string.no_data_message_public_device)
+    } else {
+        context.getString(R.string.no_data_message)
+    }
+}
+
 private fun Context.hideKeyboard(view: View) {
     val inputMethodManager = getSystemService(Activity.INPUT_METHOD_SERVICE) as InputMethodManager
     inputMethodManager.hideSoftInputFromWindow(view.windowToken, 0)

--- a/app/src/main/java/com/weatherxm/ui/components/WeatherCardView.kt
+++ b/app/src/main/java/com/weatherxm/ui/components/WeatherCardView.kt
@@ -11,8 +11,10 @@ import com.weatherxm.data.services.CacheService.Companion.KEY_PRESSURE
 import com.weatherxm.data.services.CacheService.Companion.KEY_TEMPERATURE
 import com.weatherxm.data.services.CacheService.Companion.KEY_WIND
 import com.weatherxm.databinding.ViewWeatherCardBinding
-import com.weatherxm.ui.common.visible
+import com.weatherxm.ui.common.UIDevice
+import com.weatherxm.ui.common.setNoDataMessage
 import com.weatherxm.ui.common.setWeatherAnimation
+import com.weatherxm.ui.common.visible
 import com.weatherxm.util.DateTimeHelper.getFormattedDateAndTime
 import com.weatherxm.util.Weather
 import com.weatherxm.util.Weather.getFormattedHumidity
@@ -113,11 +115,13 @@ class WeatherCardView : LinearLayout {
         }
     }
 
-    fun setData(data: HourlyWeather?) {
+    fun setData(device: UIDevice) {
+        val data = device.currentWeather
         if (data == null || data.isEmpty()) {
             binding.weatherDataLayout.visible(false)
             binding.secondaryCard.visible(false)
             binding.noDataLayout.visible(true)
+            device.setNoDataMessage(context, binding.noDataMessage)
         } else {
             weatherData = data
             updateCurrentWeatherUI()

--- a/app/src/main/java/com/weatherxm/ui/devicealerts/DeviceAlertsAdapter.kt
+++ b/app/src/main/java/com/weatherxm/ui/devicealerts/DeviceAlertsAdapter.kt
@@ -61,7 +61,7 @@ class DeviceAlertsAdapter(
                                 deviceAlertListener.onContactSupportClicked()
                             }
                     } else {
-                        binding.alert.message(R.string.no_data_message_public_device)
+                        binding.alert.message(R.string.station_inactive_alert_message_public)
                     }
                 }
                 DeviceAlertType.LOW_BATTERY -> {

--- a/app/src/main/java/com/weatherxm/ui/devicedetails/current/CurrentFragment.kt
+++ b/app/src/main/java/com/weatherxm/ui/devicedetails/current/CurrentFragment.kt
@@ -152,7 +152,7 @@ class CurrentFragment : BaseFragment() {
         if (device.currentWeather == null || device.currentWeather.isEmpty()) {
             binding.historicalCharts.visible(false)
         }
-        binding.latestWeatherCard.setData(device.currentWeather)
+        binding.latestWeatherCard.setData(device)
         binding.followCard.visible(device.isUnfollowed())
         binding.historicalCharts.isEnabled = !device.isUnfollowed()
     }

--- a/app/src/main/java/com/weatherxm/ui/widgets/RemoteViews.kt
+++ b/app/src/main/java/com/weatherxm/ui/widgets/RemoteViews.kt
@@ -144,11 +144,7 @@ fun RemoteViews.onDevice(
     this.setStatus(context, device)
 
     if (device.currentWeather == null || device.currentWeather.isEmpty()) {
-        setViewVisibility(R.id.weatherDataLayout, View.GONE)
-        setViewVisibility(R.id.noDataLayout, View.VISIBLE)
-        setViewPadding(R.id.root, 2, 2, 2, 2)
-        val backgroundResId = R.drawable.background_rounded_surface_error_stroke
-        setInt(R.id.root, "setBackgroundResource", backgroundResId)
+        setNoData(context, device)
     } else {
         setViewVisibility(R.id.noDataLayout, View.GONE)
         setInt(R.id.root, "setBackgroundResource", R.drawable.background_rounded_surface)
@@ -158,6 +154,24 @@ fun RemoteViews.onDevice(
 
     // Instruct the widget manager to update the widget
     appWidgetManager.updateAppWidget(appWidgetId, this)
+}
+
+fun RemoteViews.setNoData(context: Context, device: UIDevice) {
+    setViewVisibility(R.id.weatherDataLayout, View.GONE)
+    setViewVisibility(R.id.noDataLayout, View.VISIBLE)
+
+    if (!device.isOwned()) {
+        setTextViewText(
+            R.id.noDataMessage,
+            context.getString(R.string.no_data_message_public_device)
+        )
+    } else {
+        setTextViewText(R.id.noDataMessage, context.getString(R.string.no_data_message))
+    }
+
+    setViewPadding(R.id.root, 2, 2, 2, 2)
+    val backgroundResId = R.drawable.background_rounded_surface_error_stroke
+    setInt(R.id.root, "setBackgroundResource", backgroundResId)
 }
 
 fun RemoteViews.setStatus(context: Context, device: UIDevice) {

--- a/app/src/main/java/com/weatherxm/ui/widgets/selectstation/SelectStationAdapter.kt
+++ b/app/src/main/java/com/weatherxm/ui/widgets/selectstation/SelectStationAdapter.kt
@@ -14,6 +14,7 @@ import com.weatherxm.ui.common.handleAlerts
 import com.weatherxm.ui.common.handleStroke
 import com.weatherxm.ui.common.setBundleChip
 import com.weatherxm.ui.common.setColor
+import com.weatherxm.ui.common.setNoDataMessage
 import com.weatherxm.ui.common.setStatusChip
 import com.weatherxm.ui.common.stationHealthViewsOnList
 import com.weatherxm.ui.common.visible
@@ -100,6 +101,7 @@ class SelectStationAdapter(private val stationListener: (UIDevice) -> Unit) :
             if (item.currentWeather == null || item.currentWeather.isEmpty()) {
                 binding.weatherDataLayout.visible(false)
                 binding.noDataLayout.visible(true)
+                item.setNoDataMessage(itemView.context, binding.noDataMessage)
             } else {
                 setWeatherData(item)
             }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -149,7 +149,7 @@
     <string name="no_data_message">We\’re unable to show updated station data. Please make sure your station is operational and connected to the internet.</string>
     <string name="observations">Observations</string>
     <string name="forecast">Forecast</string>
-    <string name="no_data_message_public_device">We\’re unable to show live station data. Please check back later for further updates.</string>
+    <string name="no_data_message_public_device">No weather data received from this station yet, likely due to connectivity or operational issues.</string>
 
     <!-- Update (Bluetooth OTA) Station -->
     <string name="updated_needed_title">Station must be updated</string>
@@ -554,6 +554,7 @@
     <string name="issues_detected">%d issues detected</string>
     <string name="alerts_detected">%d alerts detected</string>
     <string name="station_inactive_alert_message">The station is not sending weather data. Check your network connection and the outdoor unit’s batteries. If the problem persists, contact our support team.</string>
+    <string name="station_inactive_alert_message_public">We\’re unable to show live station data. Please check back later for further updates.</string>
     <string name="update_required">Update Required</string>
     <string name="low_battery">Low Battery</string>
     <string name="low_battery_desc">Your station is reporting low battery. This may lead to data gaps at night, or in low-sunlight conditions and, eventually, lose rewards. Read more on how to replace your station batteries.</string>


### PR DESCRIPTION
### **Why?**
Update No Data message for public (non-owned) device

### **How?**
1. Updated the `no_data_message_public_device` to the new text
2. Created a new `station_inactive_alert_message_public` for the alerts screen as we reused the above one before.

### **Testing**
Ensure both texts look correct on non-owned stations.
