### PR TITLE
FE-1312 Use Linear lines in historical and forecast charts

### DIFF
--- a/app/src/main/java/com/weatherxm/util/Charts.kt
+++ b/app/src/main/java/com/weatherxm/util/Charts.kt
@@ -117,7 +117,7 @@ private fun LineDataSet.setDefaultSettings(context: Context, resources: Resource
     setDrawCircleHole(false)
     circleRadius = POINT_SIZE
     lineWidth = LINE_WIDTH
-    mode = LineDataSet.Mode.CUBIC_BEZIER
+    mode = LineDataSet.Mode.LINEAR
     highLightColor = context.getColor(R.color.colorPrimary)
     setDrawHorizontalHighlightIndicator(false)
     enableDashedHighlightLine(10F, 4F, 0F)
@@ -596,7 +596,6 @@ fun LineChart.initTotalEarnedChart(
     // Line and highlight Settings
     dataSet.setDefaultSettings(context, resources)
     if (dataSet.values.size > 1) dataSet.setDrawCircles(false)
-    dataSet.mode = LineDataSet.Mode.LINEAR
     dataSet.highLightColor = context.getColor(R.color.darkGrey)
     dataSet.color = context.getColor(R.color.blue)
     dataSet.axisDependency = YAxis.AxisDependency.RIGHT


### PR DESCRIPTION
### **Why?**
When there is a significant change in a chart's metric, the curved lines can create a strange visual effect in the charts that may distort the data representation. The recommended solution here is to replace the curved lines with straight ones in all our data graphs (forecast and historical)

### **How?**
Replaced `CUBIC_BEZIER` with `LINEAR`.

### **Testing**
Ensure that everything looks OK in Historical & Forecast charts.