### PR TITLE
FE-1331 Optimize `isLoggedIn` functionality and the architecture of some usecases

### DIFF
--- a/app/src/main/java/com/weatherxm/data/Modules.kt
+++ b/app/src/main/java/com/weatherxm/data/Modules.kt
@@ -528,7 +528,7 @@ private val usecases = module {
         UserUseCaseImpl(get(), get(), get(), get())
     }
     single<PreferencesUseCase> {
-        PreferencesUseCaseImpl(get(), get(), get())
+        PreferencesUseCaseImpl(get(), get())
     }
     single<DeleteAccountUseCase> {
         DeleteAccountUseCaseImpl(get(), get())
@@ -549,7 +549,7 @@ private val usecases = module {
         StationSettingsUseCaseImpl(get(), get(), get())
     }
     single<WidgetSelectStationUseCase> {
-        WidgetSelectStationUseCaseImpl(get(), get(), get())
+        WidgetSelectStationUseCaseImpl(get(), get())
     }
     single<WidgetCurrentWeatherUseCase> {
         WidgetCurrentWeatherUseCaseImpl(get(), get())
@@ -975,7 +975,7 @@ private val viewmodels = module {
     viewModel { LoginViewModel(get(), get(), get()) }
     viewModel { NetworkStatsViewModel(get()) }
     viewModel { PasswordPromptViewModel(get(), get(), get()) }
-    viewModel { PreferenceViewModel(get(), get()) }
+    viewModel { PreferenceViewModel(get(), get(), get()) }
     viewModel { ResetPasswordViewModel(get(), get(), get()) }
     viewModel { RewardsClaimViewModel(get(), get()) }
     viewModel { RewardsListViewModel(get(), get()) }
@@ -994,7 +994,7 @@ private val viewmodels = module {
     viewModel { SignupViewModel(get(), get(), get()) }
     viewModel { UpdatePromptViewModel(get()) }
     viewModel { DeepLinkRouterViewModel(get(), get(), get()) }
-    viewModel { SelectStationViewModel(get()) }
+    viewModel { SelectStationViewModel(get(), get()) }
     viewModel { ClaimLocationViewModel(get(), get(), get()) }
     viewModel { ClaimHeliumViewModel(get(), get(), get()) }
     viewModel { ClaimHeliumPairViewModel(get(), get(), get(), get()) }

--- a/app/src/main/java/com/weatherxm/data/Modules.kt
+++ b/app/src/main/java/com/weatherxm/data/Modules.kt
@@ -522,7 +522,7 @@ private val usecases = module {
         RewardsUseCaseImpl(get(), androidContext())
     }
     single<AuthUseCase> {
-        AuthUseCaseImpl(get(), get(), get(), get())
+        AuthUseCaseImpl(get(), get())
     }
     single<UserUseCase> {
         UserUseCaseImpl(get(), get(), get(), get())
@@ -972,7 +972,7 @@ private val viewmodels = module {
     viewModel { ExplorerViewModel(get(), get(), get()) }
     viewModel { HomeViewModel(get(), get(), get()) }
     viewModel { ProfileViewModel(get(), get()) }
-    viewModel { LoginViewModel(get(), get(), get()) }
+    viewModel { LoginViewModel(get(), get(), get(), get()) }
     viewModel { NetworkStatsViewModel(get()) }
     viewModel { PasswordPromptViewModel(get(), get(), get()) }
     viewModel { PreferenceViewModel(get(), get(), get()) }

--- a/app/src/main/java/com/weatherxm/data/datasource/AuthDataSource.kt
+++ b/app/src/main/java/com/weatherxm/data/datasource/AuthDataSource.kt
@@ -26,6 +26,6 @@ interface AuthDataSource {
     ): Either<Failure, Unit>
 
     suspend fun refresh(authToken: AuthToken): Either<Failure, AuthToken>
-    suspend fun getAuthToken(): Either<Failure, AuthToken>
-    suspend fun setAuthToken(token: AuthToken)
+    fun getAuthToken(): Either<Failure, AuthToken>
+    fun setAuthToken(token: AuthToken)
 }

--- a/app/src/main/java/com/weatherxm/data/datasource/CacheAuthDataSource.kt
+++ b/app/src/main/java/com/weatherxm/data/datasource/CacheAuthDataSource.kt
@@ -7,11 +7,11 @@ import com.weatherxm.data.services.CacheService
 
 class CacheAuthDataSource(private val cacheService: CacheService) : AuthDataSource {
 
-    override suspend fun getAuthToken(): Either<Failure, AuthToken> {
+    override fun getAuthToken(): Either<Failure, AuthToken> {
         return cacheService.getAuthToken()
     }
 
-    override suspend fun setAuthToken(token: AuthToken) {
+    override fun setAuthToken(token: AuthToken) {
         cacheService.setAuthToken(token)
     }
 

--- a/app/src/main/java/com/weatherxm/data/datasource/NetworkAuthDataSource.kt
+++ b/app/src/main/java/com/weatherxm/data/datasource/NetworkAuthDataSource.kt
@@ -40,11 +40,11 @@ class NetworkAuthDataSource(private val authService: AuthService) : AuthDataSour
         return authService.resetPassword(ResetPasswordBody(email)).mapResponse()
     }
 
-    override suspend fun getAuthToken(): Either<Failure, AuthToken> {
+    override fun getAuthToken(): Either<Failure, AuthToken> {
         throw NotImplementedError("Won't be implemented. Ignore this.")
     }
 
-    override suspend fun setAuthToken(token: AuthToken) {
+    override fun setAuthToken(token: AuthToken) {
         throw NotImplementedError("Won't be implemented. Ignore this.")
     }
 }

--- a/app/src/main/java/com/weatherxm/data/network/interceptor/ApiRequestInterceptor.kt
+++ b/app/src/main/java/com/weatherxm/data/network/interceptor/ApiRequestInterceptor.kt
@@ -5,7 +5,6 @@ import com.weatherxm.data.datasource.CacheAuthDataSource
 import com.weatherxm.data.network.interceptor.ApiRequestInterceptor.Companion.AUTH_HEADER
 import com.weatherxm.data.path
 import com.weatherxm.ui.common.empty
-import kotlinx.coroutines.runBlocking
 import okhttp3.Interceptor
 import okhttp3.Request
 import okhttp3.Response
@@ -43,9 +42,7 @@ class ApiRequestInterceptor(private val cacheAuthDataSource: CacheAuthDataSource
 private fun Request.signedRequest(cacheAuthDataSource: CacheAuthDataSource): Request {
     return runCatching {
         // Get stored auth token
-        val authToken = runBlocking {
-            cacheAuthDataSource.getAuthToken()
-        }.getOrElse {
+        val authToken = cacheAuthDataSource.getAuthToken().getOrElse {
             throw Error("Auth Token not found.")
         }
 

--- a/app/src/main/java/com/weatherxm/data/network/interceptor/AuthTokenAuthenticator.kt
+++ b/app/src/main/java/com/weatherxm/data/network/interceptor/AuthTokenAuthenticator.kt
@@ -7,9 +7,9 @@ import arrow.core.Either
 import arrow.core.flatMap
 import arrow.core.getOrElse
 import com.weatherxm.R
-import com.weatherxm.data.models.Failure
 import com.weatherxm.data.datasource.CacheAuthDataSource
 import com.weatherxm.data.mapResponse
+import com.weatherxm.data.models.Failure
 import com.weatherxm.data.network.AuthService
 import com.weatherxm.data.network.AuthToken
 import com.weatherxm.data.network.RefreshBody
@@ -66,16 +66,14 @@ class AuthTokenAuthenticator(
         }
     }
 
-    private fun getAuthToken(): Either<Failure, AuthToken> = runBlocking {
-        cacheAuthDataSource.getAuthToken()
-            .flatMap { authToken ->
-                if (!authToken.isRefreshTokenValid()) {
-                    Either.Left(Failure.InvalidRefreshTokenError)
-                } else {
-                    Either.Right(authToken)
-                }
+    private fun getAuthToken(): Either<Failure, AuthToken> =
+        cacheAuthDataSource.getAuthToken().flatMap { authToken ->
+            if (!authToken.isRefreshTokenValid()) {
+                Either.Left(Failure.InvalidRefreshTokenError)
+            } else {
+                Either.Right(authToken)
             }
-    }
+        }
 
     private fun refresh(request: Request): Either<Failure, AuthToken> {
         Timber.d("[${request.path()}] Trying refresh & retry.")

--- a/app/src/main/java/com/weatherxm/data/repository/AuthRepository.kt
+++ b/app/src/main/java/com/weatherxm/data/repository/AuthRepository.kt
@@ -7,7 +7,7 @@ import com.weatherxm.data.network.AuthToken
 interface AuthRepository {
     suspend fun login(username: String, password: String): Either<Failure, AuthToken>
     suspend fun logout()
-    suspend fun isLoggedIn(): Either<Failure, Boolean>
+    fun isLoggedIn(): Boolean
     suspend fun signup(
         username: String,
         firstName: String?,

--- a/app/src/main/java/com/weatherxm/data/repository/AuthRepositoryImpl.kt
+++ b/app/src/main/java/com/weatherxm/data/repository/AuthRepositoryImpl.kt
@@ -3,12 +3,12 @@ package com.weatherxm.data.repository
 import arrow.core.Either
 import arrow.core.flatMap
 import com.weatherxm.BuildConfig
-import com.weatherxm.data.models.Failure
 import com.weatherxm.data.datasource.AppConfigDataSource
 import com.weatherxm.data.datasource.CacheAuthDataSource
 import com.weatherxm.data.datasource.CacheUserDataSource
 import com.weatherxm.data.datasource.DatabaseExplorerDataSource
 import com.weatherxm.data.datasource.NetworkAuthDataSource
+import com.weatherxm.data.models.Failure
 import com.weatherxm.data.network.AuthToken
 import com.weatherxm.data.services.CacheService
 import timber.log.Timber
@@ -38,16 +38,17 @@ class AuthRepositoryImpl(
         cacheService.clearAll()
     }
 
-    override suspend fun isLoggedIn(): Either<Failure, Boolean> {
+    override fun isLoggedIn(): Boolean {
         /**
          * Fix: Consider the user as logged in in local mock mode because otherwise this returns
          * Either.Left and some functionalities are limited because of a not logged in user
          */
-        if (BuildConfig.FLAVOR_mode == "local") return Either.Right(true)
+        if (BuildConfig.FLAVOR_mode == "local") return true
 
-        return cacheAuthDataSource.getAuthToken().map {
-            it.isAccessTokenValid() || it.isRefreshTokenValid()
-        }
+        return cacheAuthDataSource.getAuthToken().fold(
+            ifLeft = { false },
+            ifRight = { it.isAccessTokenValid() || it.isRefreshTokenValid() }
+        )
     }
 
     override suspend fun signup(

--- a/app/src/main/java/com/weatherxm/service/workers/RefreshFcmApiWorker.kt
+++ b/app/src/main/java/com/weatherxm/service/workers/RefreshFcmApiWorker.kt
@@ -39,9 +39,11 @@ class RefreshFcmApiWorker(
     private val notificationsRepository: NotificationsRepository by inject()
 
     override suspend fun doWork(): Result {
-        return authUseCase.isLoggedIn().fold({ Result.failure() }, {
+        return if (authUseCase.isLoggedIn()) {
             notificationsRepository.setFcmToken(workerParams.inputData.getString(ARG_FCM_TOKEN))
             Result.success()
-        })
+        } else {
+            Result.failure()
+        }
     }
 }

--- a/app/src/main/java/com/weatherxm/ui/cellinfo/CellInfoViewModel.kt
+++ b/app/src/main/java/com/weatherxm/ui/cellinfo/CellInfoViewModel.kt
@@ -4,7 +4,6 @@ import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import arrow.core.getOrElse
 import com.weatherxm.R
 import com.weatherxm.analytics.AnalyticsService
 import com.weatherxm.analytics.AnalyticsWrapper
@@ -117,7 +116,7 @@ class CellInfoViewModel(
 
     init {
         viewModelScope.launch(Dispatchers.IO) {
-            isLoggedIn = authUseCase.isLoggedIn().getOrElse { false }
+            isLoggedIn = authUseCase.isLoggedIn()
         }
     }
 }

--- a/app/src/main/java/com/weatherxm/ui/devicedetails/DeviceDetailsViewModel.kt
+++ b/app/src/main/java/com/weatherxm/ui/devicedetails/DeviceDetailsViewModel.kt
@@ -4,7 +4,6 @@ import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import arrow.core.getOrElse
 import com.weatherxm.R
 import com.weatherxm.analytics.AnalyticsService
 import com.weatherxm.analytics.AnalyticsWrapper
@@ -139,7 +138,7 @@ class DeviceDetailsViewModel(
 
     init {
         viewModelScope.launch {
-            isLoggedIn = authUseCase.isLoggedIn().getOrElse { false }
+            isLoggedIn = authUseCase.isLoggedIn()
         }
     }
 }

--- a/app/src/main/java/com/weatherxm/ui/devicesettings/helium/DeviceSettingsHeliumViewModel.kt
+++ b/app/src/main/java/com/weatherxm/ui/devicesettings/helium/DeviceSettingsHeliumViewModel.kt
@@ -4,7 +4,6 @@ import android.content.Context
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.viewModelScope
-import arrow.core.getOrElse
 import com.weatherxm.R
 import com.weatherxm.analytics.AnalyticsWrapper
 import com.weatherxm.data.models.DeviceInfo
@@ -133,8 +132,7 @@ class DeviceSettingsHeliumViewModel(
         var walletAddress = String.empty()
         coroutineScope {
             val getWalletAddressJob = launch {
-                val isLoggedIn = authUseCase.isLoggedIn().getOrElse { false }
-                if (isLoggedIn) {
+                if (authUseCase.isLoggedIn()) {
                     userUseCase.getWalletAddress().onRight {
                         walletAddress = it
                     }

--- a/app/src/main/java/com/weatherxm/ui/devicesettings/wifi/DeviceSettingsWifiViewModel.kt
+++ b/app/src/main/java/com/weatherxm/ui/devicesettings/wifi/DeviceSettingsWifiViewModel.kt
@@ -4,7 +4,6 @@ import android.content.Context
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.viewModelScope
-import arrow.core.getOrElse
 import com.weatherxm.R
 import com.weatherxm.analytics.AnalyticsWrapper
 import com.weatherxm.data.models.DeviceInfo
@@ -179,8 +178,7 @@ class DeviceSettingsWifiViewModel(
         var walletAddress = String.empty()
         coroutineScope {
             val getWalletAddressJob = launch {
-                val isLoggedIn = authUseCase.isLoggedIn().getOrElse { false }
-                if (isLoggedIn) {
+                if (authUseCase.isLoggedIn()) {
                     userUseCase.getWalletAddress().onRight {
                         walletAddress = it
                     }

--- a/app/src/main/java/com/weatherxm/ui/login/LoginActivity.kt
+++ b/app/src/main/java/com/weatherxm/ui/login/LoginActivity.kt
@@ -4,22 +4,21 @@ import android.appwidget.AppWidgetManager
 import android.content.Intent
 import android.os.Bundle
 import android.view.inputmethod.EditorInfo
-import arrow.core.getOrElse
 import com.google.firebase.analytics.FirebaseAnalytics
 import com.weatherxm.R
 import com.weatherxm.analytics.AnalyticsService
-import com.weatherxm.ui.common.Resource
-import com.weatherxm.ui.common.Status
 import com.weatherxm.data.models.User
 import com.weatherxm.databinding.ActivityLoginBinding
 import com.weatherxm.ui.common.Contracts
 import com.weatherxm.ui.common.Contracts.ARG_USER_MESSAGE
+import com.weatherxm.ui.common.Resource
+import com.weatherxm.ui.common.Status
 import com.weatherxm.ui.common.classSimpleName
 import com.weatherxm.ui.common.hideKeyboard
-import com.weatherxm.ui.common.onTextChanged
 import com.weatherxm.ui.common.invisible
-import com.weatherxm.ui.common.visible
+import com.weatherxm.ui.common.onTextChanged
 import com.weatherxm.ui.common.toast
+import com.weatherxm.ui.common.visible
 import com.weatherxm.ui.components.BaseActivity
 import com.weatherxm.util.Validator
 import com.weatherxm.util.WidgetHelper
@@ -55,12 +54,10 @@ class LoginActivity : BaseActivity() {
             onUserResult(it)
         }
 
-        model.isLoggedIn().observe(this) { result ->
-            if (result.getOrElse { false }) {
-                Timber.d("Already Logged In. Finish the activity.")
-                toast(R.string.already_logged_in)
-                finish()
-            }
+        if (model.isLoggedIn()) {
+            Timber.d("Already Logged In. Finish the activity.")
+            toast(R.string.already_logged_in)
+            finish()
         }
 
         binding.username.onTextChanged {

--- a/app/src/main/java/com/weatherxm/ui/login/LoginViewModel.kt
+++ b/app/src/main/java/com/weatherxm/ui/login/LoginViewModel.kt
@@ -4,7 +4,6 @@ import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import arrow.core.Either
 import arrow.core.flatMap
 import com.weatherxm.R
 import com.weatherxm.analytics.AnalyticsWrapper
@@ -12,8 +11,8 @@ import com.weatherxm.data.models.ApiError.AuthError.InvalidUsername
 import com.weatherxm.data.models.ApiError.AuthError.LoginError.InvalidCredentials
 import com.weatherxm.data.models.ApiError.AuthError.LoginError.InvalidPassword
 import com.weatherxm.data.models.Failure
-import com.weatherxm.ui.common.Resource
 import com.weatherxm.data.models.User
+import com.weatherxm.ui.common.Resource
 import com.weatherxm.usecases.AuthUseCase
 import com.weatherxm.util.Failure.getDefaultMessage
 import com.weatherxm.util.Failure.getDefaultMessageResId
@@ -34,18 +33,11 @@ class LoginViewModel(
     private val user = MutableLiveData<Resource<User>>()
     fun user(): LiveData<Resource<User>> = user
 
-    /*
-    * Needed for checking if the user is logged in or not for a race condition where a user
-    * that has added a widget, logs in to a 2nd account and taps the "Login" button in the Widget
+    /**
+     * Needed for checking if the user is logged in or not for a race condition where a user
+     * that has added a widget, logs in to a 2nd account and taps the "Login" button in the Widget
      */
-    private val isLoggedIn = MutableLiveData<Either<Failure, Boolean>>().apply {
-        Timber.d("Checking if user is logged in in the background")
-        viewModelScope.launch(Dispatchers.IO) {
-            postValue(authUseCase.isLoggedIn())
-        }
-    }
-
-    fun isLoggedIn(): LiveData<Either<Failure, Boolean>> = isLoggedIn
+    fun isLoggedIn(): Boolean = authUseCase.isLoggedIn()
 
     fun login(username: String, password: String) {
         onLogin.postValue(Resource.loading())

--- a/app/src/main/java/com/weatherxm/ui/login/LoginViewModel.kt
+++ b/app/src/main/java/com/weatherxm/ui/login/LoginViewModel.kt
@@ -14,6 +14,7 @@ import com.weatherxm.data.models.Failure
 import com.weatherxm.data.models.User
 import com.weatherxm.ui.common.Resource
 import com.weatherxm.usecases.AuthUseCase
+import com.weatherxm.usecases.UserUseCase
 import com.weatherxm.util.Failure.getDefaultMessage
 import com.weatherxm.util.Failure.getDefaultMessageResId
 import com.weatherxm.util.Resources
@@ -23,6 +24,7 @@ import timber.log.Timber
 
 class LoginViewModel(
     private val authUseCase: AuthUseCase,
+    private val userUseCase: UserUseCase,
     private val resources: Resources,
     private val analytics: AnalyticsWrapper
 ) : ViewModel() {
@@ -50,7 +52,7 @@ class LoginViewModel(
                 }
                 .flatMap {
                     onLogin.postValue(Resource.success(Unit))
-                    authUseCase.getUser()
+                    userUseCase.getUser()
                 }
                 .mapLeft {
                     analytics.trackEventFailure(it.code)
@@ -84,6 +86,6 @@ class LoginViewModel(
     }
 
     fun shouldShowAnalyticsOptIn(): Boolean {
-        return authUseCase.shouldShowAnalyticsOptIn()
+        return userUseCase.shouldShowAnalyticsOptIn()
     }
 }

--- a/app/src/main/java/com/weatherxm/ui/preferences/PreferenceFragment.kt
+++ b/app/src/main/java/com/weatherxm/ui/preferences/PreferenceFragment.kt
@@ -93,26 +93,12 @@ class PreferenceFragment : PreferenceFragmentCompat() {
             appVersionPref?.summary = getString(R.string.app_version) + "-$it"
         }
 
-        model.isLoggedIn().observe(this) { result ->
-            result
-                .mapLeft {
-                    Timber.d("Not logged in. Hide account preferences.")
-                    onLoggedOut(
-                        logoutBtn,
-                        resetPassBtn,
-                        deleteAccountButton,
-                        analyticsPreference
-                    )
-                }
-                .map {
-                    Timber.d("Logged in. Handle button clicks")
-                    onLoggedIn(
-                        logoutBtn,
-                        resetPassBtn,
-                        deleteAccountButton,
-                        analyticsPreference
-                    )
-                }
+        if (model.isLoggedIn()) {
+            Timber.d("Logged in. Handle button clicks")
+            onLoggedIn(logoutBtn, resetPassBtn, deleteAccountButton, analyticsPreference)
+        } else {
+            Timber.d("Not logged in. Hide account preferences.")
+            onLoggedOut(logoutBtn, resetPassBtn, deleteAccountButton, analyticsPreference)
         }
     }
 

--- a/app/src/main/java/com/weatherxm/ui/preferences/PreferenceViewModel.kt
+++ b/app/src/main/java/com/weatherxm/ui/preferences/PreferenceViewModel.kt
@@ -5,13 +5,10 @@ import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import arrow.core.Either
 import com.weatherxm.analytics.AnalyticsWrapper
-import com.weatherxm.data.models.Failure
 import com.weatherxm.usecases.PreferencesUseCase
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
-import timber.log.Timber
 
 class PreferenceViewModel(
     private val preferencesUseCase: PreferencesUseCase,
@@ -24,17 +21,8 @@ class PreferenceViewModel(
     // Needed for passing info to the activity to when logging out
     private val onLogout = MutableLiveData(false)
 
-    fun onLogout() = onLogout
-
-    fun isLoggedIn(): LiveData<Either<Failure, Boolean>> = isLoggedIn
-
-    // Needed for checking if the user is logged in or not, so we can show/hide the logout button
-    private val isLoggedIn = MutableLiveData<Either<Failure, Boolean>>().apply {
-        Timber.d("Checking if user is logged in in the background")
-        viewModelScope.launch(Dispatchers.IO) {
-            postValue(preferencesUseCase.isLoggedIn())
-        }
-    }
+    fun onLogout(): LiveData<Boolean> = onLogout
+    fun isLoggedIn(): Boolean = preferencesUseCase.isLoggedIn()
 
     fun logout() {
         viewModelScope.launch(Dispatchers.IO) {

--- a/app/src/main/java/com/weatherxm/ui/preferences/PreferenceViewModel.kt
+++ b/app/src/main/java/com/weatherxm/ui/preferences/PreferenceViewModel.kt
@@ -6,12 +6,14 @@ import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.weatherxm.analytics.AnalyticsWrapper
+import com.weatherxm.usecases.AuthUseCase
 import com.weatherxm.usecases.PreferencesUseCase
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 
 class PreferenceViewModel(
     private val preferencesUseCase: PreferencesUseCase,
+    private val authUseCase: AuthUseCase,
     private val analytics: AnalyticsWrapper
 ) : ViewModel() {
     val onPreferencesChanged = SharedPreferences.OnSharedPreferenceChangeListener { _, _ ->
@@ -22,12 +24,12 @@ class PreferenceViewModel(
     private val onLogout = MutableLiveData(false)
 
     fun onLogout(): LiveData<Boolean> = onLogout
-    fun isLoggedIn(): Boolean = preferencesUseCase.isLoggedIn()
+    fun isLoggedIn(): Boolean = authUseCase.isLoggedIn()
 
     fun logout() {
         viewModelScope.launch(Dispatchers.IO) {
             analytics.onLogout()
-            preferencesUseCase.logout()
+            authUseCase.logout()
             onLogout.postValue(true)
         }
     }

--- a/app/src/main/java/com/weatherxm/ui/rewarddetails/RewardDetailsViewModel.kt
+++ b/app/src/main/java/com/weatherxm/ui/rewarddetails/RewardDetailsViewModel.kt
@@ -4,7 +4,6 @@ import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import arrow.core.getOrElse
 import com.weatherxm.R
 import com.weatherxm.analytics.AnalyticsWrapper
 import com.weatherxm.data.models.ApiError
@@ -40,10 +39,9 @@ class RewardDetailsViewModel(
 
     private var rewardSplitsData = RewardSplitsData(listOf(), String.empty())
     private var walletAddressJob: Job? = null
-    private var isLoggedIn: Boolean? = null
 
     private fun fetchWalletAddress() {
-        if (isLoggedIn == true) {
+        if (authUseCase.isLoggedIn()) {
             walletAddressJob = viewModelScope.launch {
                 userUseCase.getWalletAddress().onRight {
                     rewardSplitsData.wallet = it
@@ -101,11 +99,5 @@ class RewardDetailsViewModel(
                 }
             )
         )
-    }
-
-    init {
-        viewModelScope.launch(Dispatchers.IO) {
-            isLoggedIn = authUseCase.isLoggedIn().getOrElse { false }
-        }
     }
 }

--- a/app/src/main/java/com/weatherxm/ui/widgets/selectstation/SelectStationViewModel.kt
+++ b/app/src/main/java/com/weatherxm/ui/widgets/selectstation/SelectStationViewModel.kt
@@ -6,12 +6,16 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.weatherxm.ui.common.Resource
 import com.weatherxm.ui.common.UIDevice
+import com.weatherxm.usecases.AuthUseCase
 import com.weatherxm.usecases.WidgetSelectStationUseCase
 import com.weatherxm.util.Failure.getDefaultMessage
 import kotlinx.coroutines.launch
 import timber.log.Timber
 
-class SelectStationViewModel(private val usecase: WidgetSelectStationUseCase) : ViewModel() {
+class SelectStationViewModel(
+    private val usecase: WidgetSelectStationUseCase,
+    private val authUseCase: AuthUseCase,
+) : ViewModel() {
 
     private val onDevices = MutableLiveData<Resource<List<UIDevice>>>()
     private val isNotLoggedIn = MutableLiveData<Unit>()
@@ -29,7 +33,7 @@ class SelectStationViewModel(private val usecase: WidgetSelectStationUseCase) : 
 
     fun checkIfLoggedInAndProceed() {
         Timber.d("Checking if user is logged in in the background")
-        if (usecase.isLoggedIn()) {
+        if (authUseCase.isLoggedIn()) {
             fetch()
         } else {
             isNotLoggedIn.postValue(Unit)

--- a/app/src/main/java/com/weatherxm/ui/widgets/selectstation/SelectStationViewModel.kt
+++ b/app/src/main/java/com/weatherxm/ui/widgets/selectstation/SelectStationViewModel.kt
@@ -8,7 +8,6 @@ import com.weatherxm.ui.common.Resource
 import com.weatherxm.ui.common.UIDevice
 import com.weatherxm.usecases.WidgetSelectStationUseCase
 import com.weatherxm.util.Failure.getDefaultMessage
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import timber.log.Timber
 
@@ -30,16 +29,10 @@ class SelectStationViewModel(private val usecase: WidgetSelectStationUseCase) : 
 
     fun checkIfLoggedInAndProceed() {
         Timber.d("Checking if user is logged in in the background")
-        viewModelScope.launch(Dispatchers.IO) {
-            usecase.isLoggedIn().onRight {
-                if (it) {
-                    fetch()
-                } else {
-                    isNotLoggedIn.postValue(Unit)
-                }
-            }.onLeft {
-                isNotLoggedIn.postValue(Unit)
-            }
+        if (usecase.isLoggedIn()) {
+            fetch()
+        } else {
+            isNotLoggedIn.postValue(Unit)
         }
     }
 

--- a/app/src/main/java/com/weatherxm/usecases/AuthUseCase.kt
+++ b/app/src/main/java/com/weatherxm/usecases/AuthUseCase.kt
@@ -19,7 +19,7 @@ interface AuthUseCase {
     ): Either<Failure, String>
 
     suspend fun resetPassword(email: String): Either<Failure, Unit>
-    suspend fun isLoggedIn(): Either<Failure, Boolean>
+    fun isLoggedIn(): Boolean
     fun shouldShowAnalyticsOptIn(): Boolean
     suspend fun isPasswordCorrect(password: String): Either<Failure, Boolean>
 }
@@ -31,7 +31,7 @@ class AuthUseCaseImpl(
     private val userPreferencesRepository: UserPreferencesRepository
 ) : AuthUseCase {
 
-    override suspend fun isLoggedIn(): Either<Failure, Boolean> {
+    override fun isLoggedIn(): Boolean {
         return authRepository.isLoggedIn()
     }
 

--- a/app/src/main/java/com/weatherxm/usecases/AuthUseCase.kt
+++ b/app/src/main/java/com/weatherxm/usecases/AuthUseCase.kt
@@ -11,7 +11,6 @@ import com.weatherxm.data.repository.UserRepository
 
 interface AuthUseCase {
     suspend fun login(username: String, password: String): Either<Failure, AuthToken>
-    suspend fun getUser(): Either<Failure, User>
     suspend fun signup(
         username: String,
         firstName: String?,
@@ -20,16 +19,13 @@ interface AuthUseCase {
 
     suspend fun resetPassword(email: String): Either<Failure, Unit>
     fun isLoggedIn(): Boolean
-    fun shouldShowAnalyticsOptIn(): Boolean
     suspend fun isPasswordCorrect(password: String): Either<Failure, Boolean>
     suspend fun logout()
 }
 
 class AuthUseCaseImpl(
     private val authRepository: AuthRepository,
-    private val userRepository: UserRepository,
-    private val notificationsRepository: NotificationsRepository,
-    private val userPreferencesRepository: UserPreferencesRepository
+    private val notificationsRepository: NotificationsRepository
 ) : AuthUseCase {
 
     override fun isLoggedIn(): Boolean {
@@ -52,16 +48,8 @@ class AuthUseCaseImpl(
         }
     }
 
-    override suspend fun getUser(): Either<Failure, User> {
-        return userRepository.getUser()
-    }
-
     override suspend fun resetPassword(email: String): Either<Failure, Unit> {
         return authRepository.resetPassword(email)
-    }
-
-    override fun shouldShowAnalyticsOptIn(): Boolean {
-        return userPreferencesRepository.shouldShowAnalyticsOptIn()
     }
 
     override suspend fun isPasswordCorrect(password: String): Either<Failure, Boolean> {

--- a/app/src/main/java/com/weatherxm/usecases/AuthUseCase.kt
+++ b/app/src/main/java/com/weatherxm/usecases/AuthUseCase.kt
@@ -22,6 +22,7 @@ interface AuthUseCase {
     fun isLoggedIn(): Boolean
     fun shouldShowAnalyticsOptIn(): Boolean
     suspend fun isPasswordCorrect(password: String): Either<Failure, Boolean>
+    suspend fun logout()
 }
 
 class AuthUseCaseImpl(
@@ -65,5 +66,9 @@ class AuthUseCaseImpl(
 
     override suspend fun isPasswordCorrect(password: String): Either<Failure, Boolean> {
         return authRepository.isPasswordCorrect(password)
+    }
+
+    override suspend fun logout() {
+        authRepository.logout()
     }
 }

--- a/app/src/main/java/com/weatherxm/usecases/AuthUseCase.kt
+++ b/app/src/main/java/com/weatherxm/usecases/AuthUseCase.kt
@@ -2,12 +2,9 @@ package com.weatherxm.usecases
 
 import arrow.core.Either
 import com.weatherxm.data.models.Failure
-import com.weatherxm.data.models.User
 import com.weatherxm.data.network.AuthToken
 import com.weatherxm.data.repository.AuthRepository
 import com.weatherxm.data.repository.NotificationsRepository
-import com.weatherxm.data.repository.UserPreferencesRepository
-import com.weatherxm.data.repository.UserRepository
 
 interface AuthUseCase {
     suspend fun login(username: String, password: String): Either<Failure, AuthToken>

--- a/app/src/main/java/com/weatherxm/usecases/PreferencesUseCase.kt
+++ b/app/src/main/java/com/weatherxm/usecases/PreferencesUseCase.kt
@@ -1,29 +1,17 @@
 package com.weatherxm.usecases
 
 import com.weatherxm.data.repository.AppConfigRepository
-import com.weatherxm.data.repository.AuthRepository
 import com.weatherxm.data.repository.UserPreferencesRepository
 
 interface PreferencesUseCase {
-    fun isLoggedIn(): Boolean
-    suspend fun logout()
     fun setAnalyticsEnabled(enabled: Boolean)
     fun getInstallationId(): String?
 }
 
 class PreferencesUseCaseImpl(
-    private val authRepository: AuthRepository,
     private val appConfigRepository: AppConfigRepository,
     private val userPreferencesRepository: UserPreferencesRepository
 ) : PreferencesUseCase {
-
-    override fun isLoggedIn(): Boolean {
-        return authRepository.isLoggedIn()
-    }
-
-    override suspend fun logout() {
-        authRepository.logout()
-    }
 
     override fun setAnalyticsEnabled(enabled: Boolean) {
         userPreferencesRepository.setAnalyticsEnabled(enabled)

--- a/app/src/main/java/com/weatherxm/usecases/PreferencesUseCase.kt
+++ b/app/src/main/java/com/weatherxm/usecases/PreferencesUseCase.kt
@@ -1,13 +1,11 @@
 package com.weatherxm.usecases
 
-import arrow.core.Either
-import com.weatherxm.data.models.Failure
 import com.weatherxm.data.repository.AppConfigRepository
 import com.weatherxm.data.repository.AuthRepository
 import com.weatherxm.data.repository.UserPreferencesRepository
 
 interface PreferencesUseCase {
-    suspend fun isLoggedIn(): Either<Failure, Boolean>
+    fun isLoggedIn(): Boolean
     suspend fun logout()
     fun setAnalyticsEnabled(enabled: Boolean)
     fun getInstallationId(): String?
@@ -19,7 +17,7 @@ class PreferencesUseCaseImpl(
     private val userPreferencesRepository: UserPreferencesRepository
 ) : PreferencesUseCase {
 
-    override suspend fun isLoggedIn(): Either<Failure, Boolean> {
+    override fun isLoggedIn(): Boolean {
         return authRepository.isLoggedIn()
     }
 

--- a/app/src/main/java/com/weatherxm/usecases/UserUseCase.kt
+++ b/app/src/main/java/com/weatherxm/usecases/UserUseCase.kt
@@ -19,6 +19,7 @@ interface UserUseCase {
     fun setWalletWarningDismissTimestamp()
     suspend fun getWalletRewards(walletAddress: String?): Either<Failure, UIWalletRewards>
     fun getUserId(): String
+    fun shouldShowAnalyticsOptIn(): Boolean
 }
 
 class UserUseCaseImpl(
@@ -73,5 +74,9 @@ class UserUseCaseImpl(
 
     override fun getUserId(): String {
         return userRepository.getUserId()
+    }
+
+    override fun shouldShowAnalyticsOptIn(): Boolean {
+        return userPreferencesRepository.shouldShowAnalyticsOptIn()
     }
 }

--- a/app/src/main/java/com/weatherxm/usecases/WidgetCurrentWeatherUseCase.kt
+++ b/app/src/main/java/com/weatherxm/usecases/WidgetCurrentWeatherUseCase.kt
@@ -7,6 +7,5 @@ import com.weatherxm.ui.common.UIDevice
 interface WidgetCurrentWeatherUseCase {
     suspend fun getUserDevice(deviceId: String): Either<Failure, UIDevice>
     fun removeWidgetId(widgetId: Int)
-
     fun getWidgetDevice(widgetId: Int): String?
 }

--- a/app/src/main/java/com/weatherxm/usecases/WidgetSelectStationUseCase.kt
+++ b/app/src/main/java/com/weatherxm/usecases/WidgetSelectStationUseCase.kt
@@ -6,6 +6,5 @@ import com.weatherxm.ui.common.UIDevice
 
 interface WidgetSelectStationUseCase {
     suspend fun getUserDevices(): Either<Failure, List<UIDevice>>
-    fun isLoggedIn(): Boolean
     fun saveWidgetData(widgetId: Int, deviceId: String)
 }

--- a/app/src/main/java/com/weatherxm/usecases/WidgetSelectStationUseCase.kt
+++ b/app/src/main/java/com/weatherxm/usecases/WidgetSelectStationUseCase.kt
@@ -6,6 +6,6 @@ import com.weatherxm.ui.common.UIDevice
 
 interface WidgetSelectStationUseCase {
     suspend fun getUserDevices(): Either<Failure, List<UIDevice>>
-    suspend fun isLoggedIn(): Either<Failure, Boolean>
+    fun isLoggedIn(): Boolean
     fun saveWidgetData(widgetId: Int, deviceId: String)
 }

--- a/app/src/main/java/com/weatherxm/usecases/WidgetSelectStationUseCaseImpl.kt
+++ b/app/src/main/java/com/weatherxm/usecases/WidgetSelectStationUseCaseImpl.kt
@@ -8,14 +8,9 @@ import com.weatherxm.data.repository.WidgetRepository
 import com.weatherxm.ui.common.UIDevice
 
 class WidgetSelectStationUseCaseImpl(
-    private val authRepository: AuthRepository,
     private val deviceRepository: DeviceRepository,
     private val widgetRepository: WidgetRepository
 ) : WidgetSelectStationUseCase {
-
-    override fun isLoggedIn(): Boolean {
-        return authRepository.isLoggedIn()
-    }
 
     override suspend fun getUserDevices(): Either<Failure, List<UIDevice>> {
         return deviceRepository.getUserDevices().map {

--- a/app/src/main/java/com/weatherxm/usecases/WidgetSelectStationUseCaseImpl.kt
+++ b/app/src/main/java/com/weatherxm/usecases/WidgetSelectStationUseCaseImpl.kt
@@ -13,7 +13,7 @@ class WidgetSelectStationUseCaseImpl(
     private val widgetRepository: WidgetRepository
 ) : WidgetSelectStationUseCase {
 
-    override suspend fun isLoggedIn(): Either<Failure, Boolean> {
+    override fun isLoggedIn(): Boolean {
         return authRepository.isLoggedIn()
     }
 

--- a/app/src/main/java/com/weatherxm/usecases/WidgetSelectStationUseCaseImpl.kt
+++ b/app/src/main/java/com/weatherxm/usecases/WidgetSelectStationUseCaseImpl.kt
@@ -2,7 +2,6 @@ package com.weatherxm.usecases
 
 import arrow.core.Either
 import com.weatherxm.data.models.Failure
-import com.weatherxm.data.repository.AuthRepository
 import com.weatherxm.data.repository.DeviceRepository
 import com.weatherxm.data.repository.WidgetRepository
 import com.weatherxm.ui.common.UIDevice

--- a/app/src/test/java/com/weatherxm/data/repository/AuthRepositoryTest.kt
+++ b/app/src/test/java/com/weatherxm/data/repository/AuthRepositoryTest.kt
@@ -13,6 +13,7 @@ import com.weatherxm.data.datasource.NetworkAuthDataSource
 import com.weatherxm.data.network.AuthToken
 import com.weatherxm.data.services.CacheService
 import io.kotest.core.spec.style.BehaviorSpec
+import io.kotest.matchers.shouldBe
 import io.mockk.coJustRun
 import io.mockk.coVerify
 import io.mockk.every
@@ -114,7 +115,7 @@ class AuthRepositoryTest : BehaviorSpec({
                     every { mockedAuthToken.isAccessTokenValid() } returns true
                     every { mockedAuthToken.isRefreshTokenValid() } returns false
                     then("return true") {
-                        authRepository.isLoggedIn().isSuccess(true)
+                        authRepository.isLoggedIn() shouldBe true
                     }
                 }
                 and("refresh token is valid") {
@@ -122,21 +123,21 @@ class AuthRepositoryTest : BehaviorSpec({
                     every { mockedAuthToken.isAccessTokenValid() } returns false
                     every { mockedAuthToken.isRefreshTokenValid() } returns true
                     then("return true") {
-                        authRepository.isLoggedIn().isSuccess(true)
+                        authRepository.isLoggedIn() shouldBe true
                     }
                 }
                 and("nor access or refresh token are valid") {
                     coMockEitherRight({ cacheAuthDataSource.getAuthToken() }, mockedAuthToken)
                     every { mockedAuthToken.isRefreshTokenValid() } returns false
                     then("return false") {
-                        authRepository.isLoggedIn().isSuccess(false)
+                        authRepository.isLoggedIn() shouldBe false
                     }
                 }
             }
             When("auth token is not in cache") {
                 coMockEitherLeft({ cacheAuthDataSource.getAuthToken() }, failure)
                 then("return false") {
-                    authRepository.isLoggedIn().isError()
+                    authRepository.isLoggedIn() shouldBe false
                 }
             }
         }

--- a/app/src/test/java/com/weatherxm/ui/cellinfo/CellInfoViewModelTest.kt
+++ b/app/src/test/java/com/weatherxm/ui/cellinfo/CellInfoViewModelTest.kt
@@ -103,7 +103,7 @@ class CellInfoViewModelTest : BehaviorSpec({
         }
         justRun { analytics.trackEventFailure(any()) }
         justRun { analytics.trackEventUserAction(any(), any()) }
-        coMockEitherRight({ authUseCase.isLoggedIn() }, true)
+        every { authUseCase.isLoggedIn() } returns true
         every { resources.getString(R.string.error_cell_devices_no_data) } returns cellDevicesNoData
         every { resources.getString(R.string.error_max_followed) } returns maxFollowedMsg
 

--- a/app/src/test/java/com/weatherxm/ui/devicedetails/DeviceDetailsViewModelTest.kt
+++ b/app/src/test/java/com/weatherxm/ui/devicedetails/DeviceDetailsViewModelTest.kt
@@ -114,7 +114,7 @@ class DeviceDetailsViewModelTest : BehaviorSpec({
                 AnalyticsService.ParamValue.FOLLOW.paramValue
             )
         }
-        coMockEitherRight({ authUseCase.isLoggedIn() }, true)
+        every { authUseCase.isLoggedIn() } returns true
         every { resources.getString(R.string.error_max_followed) } returns maxFollowedMsg
 
         viewModel = DeviceDetailsViewModel(

--- a/app/src/test/java/com/weatherxm/ui/devicesettings/helium/DeviceSettingsHeliumViewModelTest.kt
+++ b/app/src/test/java/com/weatherxm/ui/devicesettings/helium/DeviceSettingsHeliumViewModelTest.kt
@@ -162,7 +162,7 @@ class DeviceSettingsHeliumViewModelTest : BehaviorSpec({
         }
         justRun { analytics.trackEventFailure(any()) }
         every { DateFormat.is24HourFormat(context) } returns true
-        coMockEitherRight({ authUseCase.isLoggedIn() }, true)
+        every { authUseCase.isLoggedIn() } returns true
         coMockEitherRight({ userUseCase.getWalletAddress() }, "walletAddress")
         every { settingsUseCase.shouldNotifyOTA(device) } returns true
 

--- a/app/src/test/java/com/weatherxm/ui/devicesettings/wifi/DeviceSettingsWifiViewModelTest.kt
+++ b/app/src/test/java/com/weatherxm/ui/devicesettings/wifi/DeviceSettingsWifiViewModelTest.kt
@@ -216,7 +216,7 @@ class DeviceSettingsWifiViewModelTest : BehaviorSpec({
         every {
             resources.getString(R.string.error_invalid_device_identifier)
         } returns "invalidIdentifier"
-        coMockEitherRight({ authUseCase.isLoggedIn() }, true)
+        every { authUseCase.isLoggedIn() } returns true
         coMockEitherRight({ userUseCase.getWalletAddress() }, "walletAddress")
 
         every { resources.getString(R.string.station_default_name) } returns "Station Name"

--- a/app/src/test/java/com/weatherxm/ui/login/LoginViewModelTest.kt
+++ b/app/src/test/java/com/weatherxm/ui/login/LoginViewModelTest.kt
@@ -66,7 +66,7 @@ class LoginViewModelTest : BehaviorSpec({
         }
         justRun { analytics.trackEventFailure(any()) }
         justRun { analytics.setUserId(user.id) }
-        coMockEitherRight({ usecase.isLoggedIn() }, true)
+        every { usecase.isLoggedIn() } returns true
         every { usecase.shouldShowAnalyticsOptIn() } returns true
         every {
             resources.getString(R.string.error_login_invalid_username)
@@ -86,7 +86,7 @@ class LoginViewModelTest : BehaviorSpec({
             When("it's a success") {
                 then("LiveData posts a success") {
                     runTest { viewModel.isLoggedIn() }
-                    viewModel.isLoggedIn().value?.isSuccess(true)
+                    viewModel.isLoggedIn() shouldBe true
                 }
             }
         }

--- a/app/src/test/java/com/weatherxm/ui/login/LoginViewModelTest.kt
+++ b/app/src/test/java/com/weatherxm/ui/login/LoginViewModelTest.kt
@@ -17,6 +17,7 @@ import com.weatherxm.data.models.User
 import com.weatherxm.data.network.AuthToken
 import com.weatherxm.ui.InstantExecutorListener
 import com.weatherxm.usecases.AuthUseCase
+import com.weatherxm.usecases.UserUseCase
 import com.weatherxm.util.Resources
 import io.kotest.core.spec.style.BehaviorSpec
 import io.kotest.matchers.shouldBe
@@ -37,6 +38,7 @@ import org.koin.dsl.module
 @OptIn(ExperimentalCoroutinesApi::class)
 class LoginViewModelTest : BehaviorSpec({
     val usecase = mockk<AuthUseCase>()
+    val userUseCase = mockk<UserUseCase>()
     val analytics = mockk<AnalyticsWrapper>()
     lateinit var viewModel: LoginViewModel
 
@@ -67,7 +69,7 @@ class LoginViewModelTest : BehaviorSpec({
         justRun { analytics.trackEventFailure(any()) }
         justRun { analytics.setUserId(user.id) }
         every { usecase.isLoggedIn() } returns true
-        every { usecase.shouldShowAnalyticsOptIn() } returns true
+        every { userUseCase.shouldShowAnalyticsOptIn() } returns true
         every {
             resources.getString(R.string.error_login_invalid_username)
         } returns invalidUsername
@@ -78,7 +80,7 @@ class LoginViewModelTest : BehaviorSpec({
             resources.getString(R.string.error_login_invalid_credentials)
         } returns invalidCredentials
 
-        viewModel = LoginViewModel(usecase, resources, analytics)
+        viewModel = LoginViewModel(usecase, userUseCase, resources, analytics)
     }
 
     context("Get if the user is logged in already or not") {
@@ -149,7 +151,7 @@ class LoginViewModelTest : BehaviorSpec({
             }
             When("login is a success and fetching the user is a failure") {
                 coMockEitherRight({ usecase.login(username, password) }, authToken)
-                coMockEitherLeft({ usecase.getUser() }, failure)
+                coMockEitherLeft({ userUseCase.getUser() }, failure)
                 runTest { viewModel.login(username, password) }
                 then("LiveData of login posts a success") {
                     viewModel.onLogin().isSuccess(Unit)
@@ -163,7 +165,7 @@ class LoginViewModelTest : BehaviorSpec({
             }
             When("login is a success and fetching the user is a success also") {
                 coMockEitherRight({ usecase.login(username, password) }, authToken)
-                coMockEitherRight({ usecase.getUser() }, user)
+                coMockEitherRight({ userUseCase.getUser() }, user)
                 runTest { viewModel.login(username, password) }
                 then("LiveData of login posts a success") {
                     viewModel.onLogin().isSuccess(Unit)

--- a/app/src/test/java/com/weatherxm/ui/preferences/PreferencesViewModelTest.kt
+++ b/app/src/test/java/com/weatherxm/ui/preferences/PreferencesViewModelTest.kt
@@ -2,6 +2,7 @@ package com.weatherxm.ui.preferences
 
 import com.weatherxm.analytics.AnalyticsWrapper
 import com.weatherxm.ui.InstantExecutorListener
+import com.weatherxm.usecases.AuthUseCase
 import com.weatherxm.usecases.PreferencesUseCase
 import io.kotest.core.spec.style.BehaviorSpec
 import io.kotest.matchers.shouldBe
@@ -21,6 +22,7 @@ import kotlinx.coroutines.test.setMain
 @OptIn(ExperimentalCoroutinesApi::class)
 class PreferencesViewModelTest : BehaviorSpec({
     val usecase = mockk<PreferencesUseCase>()
+    val authUseCase = mockk<AuthUseCase>()
     val analytics = mockk<AnalyticsWrapper>()
     lateinit var viewModel: PreferenceViewModel
 
@@ -34,11 +36,11 @@ class PreferencesViewModelTest : BehaviorSpec({
         justRun { analytics.setAnalyticsEnabled(any()) }
         justRun { analytics.onLogout() }
         justRun { usecase.setAnalyticsEnabled(any()) }
-        coJustRun { usecase.logout() }
-        every { usecase.isLoggedIn() } returns true
+        coJustRun { authUseCase.logout() }
+        every { authUseCase.isLoggedIn() } returns true
         every { usecase.getInstallationId() } returns installationId
 
-        viewModel = PreferenceViewModel(usecase, analytics)
+        viewModel = PreferenceViewModel(usecase, authUseCase, analytics)
     }
 
     context("Invoke a change in SharedPreferences and update user's properties in analytics") {
@@ -68,7 +70,7 @@ class PreferencesViewModelTest : BehaviorSpec({
                 verify(exactly = 1) { analytics.onLogout() }
             }
             then("call the logout function in the usecase") {
-                coVerify(exactly = 1) { usecase.logout() }
+                coVerify(exactly = 1) { authUseCase.logout() }
             }
             then("LiveData onLogout gets invoked with `true` param") {
                 viewModel.onLogout().value shouldBe true

--- a/app/src/test/java/com/weatherxm/ui/preferences/PreferencesViewModelTest.kt
+++ b/app/src/test/java/com/weatherxm/ui/preferences/PreferencesViewModelTest.kt
@@ -1,7 +1,5 @@
 package com.weatherxm.ui.preferences
 
-import com.weatherxm.TestUtils.coMockEitherRight
-import com.weatherxm.TestUtils.isSuccess
 import com.weatherxm.analytics.AnalyticsWrapper
 import com.weatherxm.ui.InstantExecutorListener
 import com.weatherxm.usecases.PreferencesUseCase
@@ -37,7 +35,7 @@ class PreferencesViewModelTest : BehaviorSpec({
         justRun { analytics.onLogout() }
         justRun { usecase.setAnalyticsEnabled(any()) }
         coJustRun { usecase.logout() }
-        coMockEitherRight({ usecase.isLoggedIn() }, true)
+        every { usecase.isLoggedIn() } returns true
         every { usecase.getInstallationId() } returns installationId
 
         viewModel = PreferenceViewModel(usecase, analytics)
@@ -57,7 +55,7 @@ class PreferencesViewModelTest : BehaviorSpec({
             When("it's a success") {
                 then("LiveData posts a success") {
                     runTest { viewModel.isLoggedIn() }
-                    viewModel.isLoggedIn().value?.isSuccess(true)
+                    viewModel.isLoggedIn() shouldBe true
                 }
             }
         }

--- a/app/src/test/java/com/weatherxm/ui/rewarddetails/RewardDetailsViewModelTest.kt
+++ b/app/src/test/java/com/weatherxm/ui/rewarddetails/RewardDetailsViewModelTest.kt
@@ -21,6 +21,7 @@ import com.weatherxm.usecases.UserUseCase
 import com.weatherxm.util.Resources
 import io.kotest.core.spec.style.BehaviorSpec
 import io.kotest.matchers.shouldBe
+import io.mockk.every
 import io.mockk.justRun
 import io.mockk.mockk
 import kotlinx.coroutines.Dispatchers
@@ -75,7 +76,7 @@ class RewardDetailsViewModelTest : BehaviorSpec({
         }
         analytics = mockk<AnalyticsWrapper>()
         justRun { analytics.trackEventFailure(any()) }
-        coMockEitherRight({ authUseCase.isLoggedIn() }, true)
+        every { authUseCase.isLoggedIn() } returns true
         coMockEitherRight({ userUseCase.getWalletAddress() }, walletAddress)
 
         viewModel = RewardDetailsViewModel(

--- a/app/src/test/java/com/weatherxm/ui/widgets/selectstation/SelectStationViewModelTest.kt
+++ b/app/src/test/java/com/weatherxm/ui/widgets/selectstation/SelectStationViewModelTest.kt
@@ -11,6 +11,7 @@ import com.weatherxm.ui.InstantExecutorListener
 import com.weatherxm.ui.common.DeviceRelation
 import com.weatherxm.ui.common.UIDevice
 import com.weatherxm.ui.common.empty
+import com.weatherxm.usecases.AuthUseCase
 import com.weatherxm.usecases.WidgetSelectStationUseCase
 import com.weatherxm.util.Resources
 import io.kotest.core.spec.style.BehaviorSpec
@@ -32,6 +33,7 @@ import org.koin.dsl.module
 @OptIn(ExperimentalCoroutinesApi::class)
 class SelectStationViewModelTest : BehaviorSpec({
     val usecase = mockk<WidgetSelectStationUseCase>()
+    val authUseCase = mockk<AuthUseCase>()
     lateinit var viewModel: SelectStationViewModel
 
     val deviceId = "deviceId"
@@ -85,7 +87,7 @@ class SelectStationViewModelTest : BehaviorSpec({
         }
         justRun { usecase.saveWidgetData(widgetId, deviceId) }
 
-        viewModel = SelectStationViewModel(usecase)
+        viewModel = SelectStationViewModel(usecase, authUseCase)
     }
 
     context("GET / SET the selected station") {
@@ -124,7 +126,7 @@ class SelectStationViewModelTest : BehaviorSpec({
     context("Check if the user is logged in and proceed accordingly") {
         given("a usecase returning if the user is logged in or not") {
             When("the user is logged in") {
-                every { usecase.isLoggedIn() } returns true
+                every { authUseCase.isLoggedIn() } returns true
                 coMockEitherRight({ usecase.getUserDevices() }, emptyList<UIDevice>())
 
                 runTest { viewModel.checkIfLoggedInAndProceed() }
@@ -133,7 +135,7 @@ class SelectStationViewModelTest : BehaviorSpec({
                 }
             }
             When("the user is NOT logged in") {
-                every { usecase.isLoggedIn() } returns false
+                every { authUseCase.isLoggedIn() } returns false
                 runTest { viewModel.checkIfLoggedInAndProceed() }
                 then("LiveData isNotLoggedIn should be called with value Unit") {
                     viewModel.isNotLoggedIn().value shouldBe Unit

--- a/app/src/test/java/com/weatherxm/usecases/AuthUseCaseTest.kt
+++ b/app/src/test/java/com/weatherxm/usecases/AuthUseCaseTest.kt
@@ -20,15 +20,8 @@ import io.mockk.mockk
 
 class AuthUseCaseTest : BehaviorSpec({
     val authRepository = mockk<AuthRepository>()
-    val userRepository = mockk<UserRepository>()
-    val userPreferencesRepository = mockk<UserPreferencesRepository>()
     val notificationsRepository = mockk<NotificationsRepository>()
-    val usecase = AuthUseCaseImpl(
-        authRepository,
-        userRepository,
-        notificationsRepository,
-        userPreferencesRepository
-    )
+    val usecase = AuthUseCaseImpl(authRepository, notificationsRepository)
 
     val username = "username"
     val password = "password"
@@ -39,7 +32,6 @@ class AuthUseCaseTest : BehaviorSpec({
 
     beforeSpec {
         coJustRun { notificationsRepository.setFcmToken() }
-        every { userPreferencesRepository.shouldShowAnalyticsOptIn() } returns true
     }
 
     context("Get if a user is logged in or not") {
@@ -99,23 +91,6 @@ class AuthUseCaseTest : BehaviorSpec({
         }
     }
 
-    context("Get User") {
-        given("The repository which returns the user") {
-            When("the response is a failure") {
-                coMockEitherLeft({ userRepository.getUser() }, failure)
-                then("return that failure") {
-                    usecase.getUser().isError()
-                }
-            }
-            When("the response is a success") {
-                coMockEitherRight({ userRepository.getUser() }, user)
-                then("return the user") {
-                    usecase.getUser().isSuccess(user)
-                }
-            }
-        }
-    }
-
     context("Reset Password") {
         given("The repository which accepts the reset password request") {
             When("the response is a failure") {
@@ -129,14 +104,6 @@ class AuthUseCaseTest : BehaviorSpec({
                 then("return the user") {
                     usecase.resetPassword(username).isSuccess(Unit)
                 }
-            }
-        }
-    }
-
-    context("Get if we should show the analytics opt in or not") {
-        given("The repository which returns the answer") {
-            then("return the answer") {
-                usecase.shouldShowAnalyticsOptIn() shouldBe true
             }
         }
     }

--- a/app/src/test/java/com/weatherxm/usecases/AuthUseCaseTest.kt
+++ b/app/src/test/java/com/weatherxm/usecases/AuthUseCaseTest.kt
@@ -44,16 +44,16 @@ class AuthUseCaseTest : BehaviorSpec({
 
     context("Get if a user is logged in or not") {
         given("The repository providing that information") {
-            When("the response is a failure") {
-                coMockEitherLeft({ authRepository.isLoggedIn() }, failure)
-                then("return that failure") {
-                    usecase.isLoggedIn().isError()
+            When("the user is NOT logged in") {
+                every { authRepository.isLoggedIn() } returns false
+                then("return false") {
+                    usecase.isLoggedIn() shouldBe false
                 }
             }
-            When("the response is a success") {
-                coMockEitherRight({ authRepository.isLoggedIn() }, true)
-                then("return that success") {
-                    usecase.isLoggedIn().isSuccess(true)
+            When("the user is logged in") {
+                every { authRepository.isLoggedIn() } returns true
+                then("return true") {
+                    usecase.isLoggedIn() shouldBe true
                 }
             }
         }

--- a/app/src/test/java/com/weatherxm/usecases/AuthUseCaseTest.kt
+++ b/app/src/test/java/com/weatherxm/usecases/AuthUseCaseTest.kt
@@ -28,6 +28,7 @@ class AuthUseCaseTest : BehaviorSpec({
 
     beforeSpec {
         coJustRun { notificationsRepository.setFcmToken() }
+        coJustRun { authRepository.logout() }
     }
 
     context("Get if a user is logged in or not") {

--- a/app/src/test/java/com/weatherxm/usecases/AuthUseCaseTest.kt
+++ b/app/src/test/java/com/weatherxm/usecases/AuthUseCaseTest.kt
@@ -5,12 +5,9 @@ import com.weatherxm.TestUtils.coMockEitherLeft
 import com.weatherxm.TestUtils.coMockEitherRight
 import com.weatherxm.TestUtils.isError
 import com.weatherxm.TestUtils.isSuccess
-import com.weatherxm.data.models.User
 import com.weatherxm.data.network.AuthToken
 import com.weatherxm.data.repository.AuthRepository
 import com.weatherxm.data.repository.NotificationsRepository
-import com.weatherxm.data.repository.UserPreferencesRepository
-import com.weatherxm.data.repository.UserRepository
 import io.kotest.core.spec.style.BehaviorSpec
 import io.kotest.matchers.shouldBe
 import io.mockk.coJustRun
@@ -27,7 +24,6 @@ class AuthUseCaseTest : BehaviorSpec({
     val password = "password"
     val firstName = "firstName"
     val lastName = "lastName"
-    val user = mockk<User>()
     val authToken = AuthToken("access", "refresh")
 
     beforeSpec {

--- a/app/src/test/java/com/weatherxm/usecases/AuthUseCaseTest.kt
+++ b/app/src/test/java/com/weatherxm/usecases/AuthUseCaseTest.kt
@@ -157,4 +157,14 @@ class AuthUseCaseTest : BehaviorSpec({
             }
         }
     }
+
+    context("Logout a user") {
+        given("A repository providing LOGOUT mechanism") {
+            then("logout the user") {
+                usecase.logout()
+                coVerify(exactly = 1) { authRepository.logout() }
+            }
+
+        }
+    }
 })

--- a/app/src/test/java/com/weatherxm/usecases/PreferencesUseCaseTest.kt
+++ b/app/src/test/java/com/weatherxm/usecases/PreferencesUseCaseTest.kt
@@ -1,7 +1,6 @@
 package com.weatherxm.usecases
 
 import com.weatherxm.data.repository.AppConfigRepository
-import com.weatherxm.data.repository.AuthRepository
 import com.weatherxm.data.repository.UserPreferencesRepository
 import io.kotest.core.spec.style.BehaviorSpec
 import io.kotest.matchers.shouldBe
@@ -11,45 +10,15 @@ import io.mockk.every
 import io.mockk.mockk
 
 class PreferencesUseCaseTest : BehaviorSpec({
-    val authRepository = mockk<AuthRepository>()
     val appConfigRepository = mockk<AppConfigRepository>()
     val userPreferencesRepository = mockk<UserPreferencesRepository>()
-    val usecase =
-        PreferencesUseCaseImpl(authRepository, appConfigRepository, userPreferencesRepository)
+    val usecase = PreferencesUseCaseImpl(appConfigRepository, userPreferencesRepository)
 
     val analyticsEnabled = true
     val installationId = "installationId"
 
     beforeSpec {
         coJustRun { userPreferencesRepository.setAnalyticsEnabled(analyticsEnabled) }
-        coJustRun { authRepository.logout() }
-    }
-
-    context("Get if the user is logged in") {
-        given("A repository providing the answer") {
-            When("the user is logged in") {
-                every { authRepository.isLoggedIn() } returns true
-                then("return true") {
-                    usecase.isLoggedIn() shouldBe true
-                }
-            }
-            When("the user is NOT logged in") {
-                every { authRepository.isLoggedIn() } returns false
-                then("return false") {
-                    usecase.isLoggedIn() shouldBe false
-                }
-            }
-        }
-    }
-
-    context("Logout a user") {
-        given("A repository providing LOGOUT mechanism") {
-            then("logout the user") {
-                usecase.logout()
-                coVerify(exactly = 1) { authRepository.logout() }
-            }
-
-        }
     }
 
     context("Set if analytics are enabled or not") {

--- a/app/src/test/java/com/weatherxm/usecases/PreferencesUseCaseTest.kt
+++ b/app/src/test/java/com/weatherxm/usecases/PreferencesUseCaseTest.kt
@@ -1,10 +1,5 @@
 package com.weatherxm.usecases
 
-import com.weatherxm.TestConfig.failure
-import com.weatherxm.TestUtils.coMockEitherLeft
-import com.weatherxm.TestUtils.coMockEitherRight
-import com.weatherxm.TestUtils.isError
-import com.weatherxm.TestUtils.isSuccess
 import com.weatherxm.data.repository.AppConfigRepository
 import com.weatherxm.data.repository.AuthRepository
 import com.weatherxm.data.repository.UserPreferencesRepository
@@ -32,16 +27,16 @@ class PreferencesUseCaseTest : BehaviorSpec({
 
     context("Get if the user is logged in") {
         given("A repository providing the answer") {
-            When("it's a success") {
-                coMockEitherRight({ authRepository.isLoggedIn() }, true)
-                then("return that answer") {
-                    usecase.isLoggedIn().isSuccess(true)
+            When("the user is logged in") {
+                every { authRepository.isLoggedIn() } returns true
+                then("return true") {
+                    usecase.isLoggedIn() shouldBe true
                 }
             }
-            When("it's a failure") {
-                coMockEitherLeft({ authRepository.isLoggedIn() }, failure)
-                then("return that failure") {
-                    usecase.isLoggedIn().isError()
+            When("the user is NOT logged in") {
+                every { authRepository.isLoggedIn() } returns false
+                then("return false") {
+                    usecase.isLoggedIn() shouldBe false
                 }
             }
         }

--- a/app/src/test/java/com/weatherxm/usecases/StartupUseCaseTest.kt
+++ b/app/src/test/java/com/weatherxm/usecases/StartupUseCaseTest.kt
@@ -1,9 +1,6 @@
 package com.weatherxm.usecases
 
 import com.weatherxm.TestConfig.context
-import com.weatherxm.TestConfig.failure
-import com.weatherxm.TestUtils.coMockEitherLeft
-import com.weatherxm.TestUtils.coMockEitherRight
 import com.weatherxm.data.repository.AppConfigRepository
 import com.weatherxm.data.repository.AuthRepository
 import com.weatherxm.data.repository.UserPreferencesRepository
@@ -47,7 +44,7 @@ class StartupUseCaseTest : BehaviorSpec({
             When("app should not be updated") {
                 every { appConfigRepo.shouldUpdate() } returns false
                 and("user is logged in") {
-                    coMockEitherRight({ authRepo.isLoggedIn() }, true)
+                    every { authRepo.isLoggedIn() } returns true
                     and("we should show the opt-in analytics screen") {
                         every { userPreferencesRepo.shouldShowAnalyticsOptIn() } returns true
                         then("return ShowAnalyticsOptIn") {
@@ -67,7 +64,7 @@ class StartupUseCaseTest : BehaviorSpec({
                     }
                 }
                 and("User is logged out") {
-                    coMockEitherLeft({ authRepo.isLoggedIn() }, failure)
+                    every { authRepo.isLoggedIn() } returns false
                     then("return ShowExplorer") {
                         getStartupType().shouldBeTypeOf<StartupState.ShowExplorer>()
                     }

--- a/app/src/test/java/com/weatherxm/usecases/UserUseCaseTest.kt
+++ b/app/src/test/java/com/weatherxm/usecases/UserUseCaseTest.kt
@@ -44,6 +44,7 @@ class UserUseCaseTest : BehaviorSpec({
 
     beforeSpec {
         justRun { userPreferencesRepository.setWalletWarningDismissTimestamp() }
+        every { userPreferencesRepository.shouldShowAnalyticsOptIn() } returns true
     }
 
     context("Get the Wallet Address") {
@@ -107,6 +108,14 @@ class UserUseCaseTest : BehaviorSpec({
             then("return the user's id") {
                 every { userRepository.getUserId() } returns userId
                 usecase.getUserId() shouldBe userId
+            }
+        }
+    }
+
+    context("Get if we should show the analytics opt in or not") {
+        given("The repository which returns the answer") {
+            then("return the answer") {
+                usecase.shouldShowAnalyticsOptIn() shouldBe true
             }
         }
     }

--- a/app/src/test/java/com/weatherxm/usecases/WidgetSelectStationUseCaseTest.kt
+++ b/app/src/test/java/com/weatherxm/usecases/WidgetSelectStationUseCaseTest.kt
@@ -10,8 +10,10 @@ import com.weatherxm.data.repository.AuthRepository
 import com.weatherxm.data.repository.DeviceRepository
 import com.weatherxm.data.repository.WidgetRepository
 import io.kotest.core.spec.style.BehaviorSpec
+import io.kotest.matchers.shouldBe
 import io.mockk.coJustRun
 import io.mockk.coVerify
+import io.mockk.every
 import io.mockk.mockk
 
 class WidgetSelectStationUseCaseTest : BehaviorSpec({
@@ -32,16 +34,16 @@ class WidgetSelectStationUseCaseTest : BehaviorSpec({
 
     context("Get if the user is logged in") {
         given("A repository providing the answer") {
-            When("it's a success") {
-                coMockEitherRight({ authRepository.isLoggedIn() }, true)
-                then("return that answer") {
-                    usecase.isLoggedIn().isSuccess(true)
+            When("the user is logged in") {
+                every { authRepository.isLoggedIn() } returns true
+                then("return true") {
+                    usecase.isLoggedIn() shouldBe true
                 }
             }
-            When("it's a failure") {
-                coMockEitherLeft({ authRepository.isLoggedIn() }, failure)
-                then("return that failure") {
-                    usecase.isLoggedIn().isError()
+            When("the user is NOT logged in") {
+                every { authRepository.isLoggedIn() } returns false
+                then("return false") {
+                    usecase.isLoggedIn() shouldBe false
                 }
             }
         }

--- a/app/src/test/java/com/weatherxm/usecases/WidgetSelectStationUseCaseTest.kt
+++ b/app/src/test/java/com/weatherxm/usecases/WidgetSelectStationUseCaseTest.kt
@@ -6,21 +6,17 @@ import com.weatherxm.TestUtils.coMockEitherRight
 import com.weatherxm.TestUtils.isError
 import com.weatherxm.TestUtils.isSuccess
 import com.weatherxm.data.models.Device
-import com.weatherxm.data.repository.AuthRepository
 import com.weatherxm.data.repository.DeviceRepository
 import com.weatherxm.data.repository.WidgetRepository
 import io.kotest.core.spec.style.BehaviorSpec
-import io.kotest.matchers.shouldBe
 import io.mockk.coJustRun
 import io.mockk.coVerify
-import io.mockk.every
 import io.mockk.mockk
 
 class WidgetSelectStationUseCaseTest : BehaviorSpec({
-    val authRepository = mockk<AuthRepository>()
     val deviceRepository = mockk<DeviceRepository>()
     val widgetRepository = mockk<WidgetRepository>()
-    val usecase = WidgetSelectStationUseCaseImpl(authRepository, deviceRepository, widgetRepository)
+    val usecase = WidgetSelectStationUseCaseImpl(deviceRepository, widgetRepository)
 
     val widgetId = 0
     val deviceId = "deviceId"
@@ -30,23 +26,6 @@ class WidgetSelectStationUseCaseTest : BehaviorSpec({
     beforeSpec {
         coJustRun { widgetRepository.setWidgetDevice(widgetId, deviceId) }
         coJustRun { widgetRepository.setWidgetId(widgetId) }
-    }
-
-    context("Get if the user is logged in") {
-        given("A repository providing the answer") {
-            When("the user is logged in") {
-                every { authRepository.isLoggedIn() } returns true
-                then("return true") {
-                    usecase.isLoggedIn() shouldBe true
-                }
-            }
-            When("the user is NOT logged in") {
-                every { authRepository.isLoggedIn() } returns false
-                then("return false") {
-                    usecase.isLoggedIn() shouldBe false
-                }
-            }
-        }
     }
 
     context("Get user devices") {


### PR DESCRIPTION
### **Why?**
- Optimize the `isLoggedIn` to return a `Boolean` value and 
- Some architecture fixes in some UseCases having wrong/duplicate functions

### **How?**
- Refactored the `isLoggedIn` function in `AuthRepository` to return a `Boolean` instead of an `Either<Failure, Boolean>`.
- Removed the `isLoggedIn` function from all use-cases **except** the `AuthUseCase` and inject this UseCase in all ViewModels that needed it, in order to avoid having duplicate functionality in multiple UseCases.
- Removed some user-related functions from `AuthUseCase` and moved them to `UserUseCase`
- Removed some auth-related functions from `PreferenceUseCase` and moved them to `AuthUseCase`
- The `getAuthToken` and `setAuthToken` which are functions speaking with the `CacheService` are non-suspend functions in order to simplify the code and avoid using `runBlocking` in some cases.

### **Testing**
Test that everything looks OK for the following screens **in both logged-in and logged-out cases**:
1. Login Screen
2. Preferences Screen
3. Select a station for a widget screen
4. Cell Info Screen
5. Device Details Screen
