### PR TITLE
FE-1335 FE-1336 Fix info button clickable by mistake. Fix percentage layout of hourly forecast

### DIFF
--- a/app/src/main/res/layout/fragment_device_details_current.xml
+++ b/app/src/main/res/layout/fragment_device_details_current.xml
@@ -203,9 +203,8 @@
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content">
 
-                    <ImageButton
+                    <ImageView
                         android:id="@+id/emptyStationHealthIcon"
-                        style="@style/Widget.WeatherXM.ImageButton"
                         android:layout_width="20dp"
                         android:layout_height="20dp"
                         android:src="@drawable/ic_learn_more_info"

--- a/app/src/main/res/layout/list_item_hourly_forecast.xml
+++ b/app/src/main/res/layout/list_item_hourly_forecast.xml
@@ -5,11 +5,14 @@
     android:layout_height="wrap_content"
     android:layout_marginEnd="@dimen/margin_small"
     app:cardElevation="@dimen/elevation_normal"
-    app:contentPadding="@dimen/padding_normal">
+    app:contentPadding="@dimen/padding_normal"
+    app:contentPaddingBottom="@dimen/padding_small"
+    app:contentPaddingTop="@dimen/padding_small">
 
     <LinearLayout
         android:layout_width="match_parent"
         android:layout_height="match_parent"
+        android:gravity="center_horizontal"
         android:orientation="vertical">
 
         <com.google.android.material.textview.MaterialTextView
@@ -45,7 +48,7 @@
             tools:text="15.4°C" />
 
         <LinearLayout
-            android:layout_width="match_parent"
+            android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:gravity="center"
             android:orientation="horizontal">


### PR DESCRIPTION
### **Why?**
1. Device Observations: Info icon is clickable
2. Device Forecast hourly card: Percentage symbol is missing

### **How?**
1. Replaced in the info button the `ImageButton` with `ImageView`
2. Make in the hourly forecast card in the percentage layout `layout_width="wrap_content"`

### **Testing**
Ensure both issues are fixed.