### PR TITLE
Show minutes in 12-hour format in hourly forecast

### DIFF
--- a/app/src/main/java/com/weatherxm/ui/common/HourlyForecastAdapter.kt
+++ b/app/src/main/java/com/weatherxm/ui/common/HourlyForecastAdapter.kt
@@ -40,7 +40,7 @@ class HourlyForecastAdapter(
                 }
             }
 
-            binding.timestamp.text = item.timestamp.getFormattedTime(itemView.context, false)
+            binding.timestamp.text = item.timestamp.getFormattedTime(itemView.context)
             binding.icon.setWeatherAnimation(item.icon)
             binding.temperaturePrimary.text =
                 Weather.getFormattedTemperature(itemView.context, item.temperature, 1)


### PR DESCRIPTION
### **Why?**
Show minutes in 12-hour format in hourly forecast

### **How?**
Removed the `showMinutesIn12HourFormat=false` argument

### **Testing**
Just make sure everything looks OK.