### PR TITLE
Increase `minSdk` to 28 (Android 9)

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -78,7 +78,7 @@ android {
 
     defaultConfig {
         applicationId = "com.weatherxm.app"
-        minSdk = 24
+        minSdk = 28
         targetSdk = 35
         versionCode = 10 + getVersionGitTags().size
         val skipTagsLogging = !project.hasProperty("SKIP_TAGS_LOGGING")

--- a/app/src/main/java/com/weatherxm/data/ClientIdentificationHelper.kt
+++ b/app/src/main/java/com/weatherxm/data/ClientIdentificationHelper.kt
@@ -3,7 +3,6 @@ package com.weatherxm.data
 import android.annotation.SuppressLint
 import android.content.Context
 import android.content.pm.PackageManager
-import android.os.Build
 import com.weatherxm.data.repository.AppConfigRepository
 import com.weatherxm.util.AndroidBuildInfo
 import timber.log.Timber
@@ -25,11 +24,7 @@ class ClientIdentificationHelper(
         return try {
             val packageInfo = context.packageManager.getPackageInfo(context.packageName, 0)
             val name = packageInfo.versionName
-            val code = if (AndroidBuildInfo.sdkInt >= Build.VERSION_CODES.P) {
-                packageInfo.longVersionCode
-            } else {
-                packageInfo.versionCode
-            }
+            val code = packageInfo.longVersionCode
             val installationId = appConfigRepository.getInstallationId() ?: "N/A"
             "wxm-android (${context.applicationInfo.packageName}); $name ($code); $installationId"
         } catch (e: PackageManager.NameNotFoundException) {

--- a/app/src/main/java/com/weatherxm/service/MessagingService.kt
+++ b/app/src/main/java/com/weatherxm/service/MessagingService.kt
@@ -75,13 +75,12 @@ class MessagingService : FirebaseMessagingService() {
             RemoteMessageType.parse(remoteMessage.data.getOrDefault(ARG_TYPE, String.empty()))
 
         val manager = getSystemService(NOTIFICATION_SERVICE) as NotificationManager
-        if (AndroidBuildInfo.sdkInt >= Build.VERSION_CODES.O) {
-            val channel = NotificationChannel(
-                type.id, type.publicName, NotificationManager.IMPORTANCE_DEFAULT
-            )
-            channel.description = type.desc
-            manager.createNotificationChannel(channel)
-        }
+        val channel = NotificationChannel(
+            type.id, type.publicName, NotificationManager.IMPORTANCE_DEFAULT
+        )
+        channel.description = type.desc
+        manager.createNotificationChannel(channel)
+
 
         val notification = NotificationCompat.Builder(context, type.id).apply {
             createPendingIntent(context, remoteMessage, type)?.let {


### PR DESCRIPTION
### **Why?**
For upgrading our code and not having to support really old devices.

### **How?**
- Updated `minSdk` to 28 ([Android 9](https://apilevels.com/))
- Removed some deprecated now `if` checks

### **Testing**
Ensure that the projects builds successfully and everything looks OK.
