### PR TITLE
Feature/fe 1344 photo capturing and gallery screens

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -524,6 +524,7 @@ dependencies {
 
     // Image Loader
     implementation(libs.coil.base)
+    implementation(libs.coil.compose)
     implementation(libs.coil.gif)
 
     // Chucker - HTTP Inspector

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -39,7 +39,7 @@
         tools:ignore="UnusedAttribute,LockedOrientationActivity">
         <provider
             android:name="androidx.core.content.FileProvider"
-            android:authorities="com.weatherxm.app.fileprovider"
+            android:authorities="${applicationId}.fileprovider"
             android:exported="false"
             android:grantUriPermissions="true">
             <meta-data

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -37,6 +37,15 @@
         android:theme="@style/Theme.WeatherXM"
         android:usesCleartextTraffic="true"
         tools:ignore="UnusedAttribute,LockedOrientationActivity">
+        <provider
+            android:name="androidx.core.content.FileProvider"
+            android:authorities="com.weatherxm.app.fileprovider"
+            android:exported="false"
+            android:grantUriPermissions="true">
+            <meta-data
+                android:name="android.support.FILE_PROVIDER_PATHS"
+                android:resource="@xml/file_provider_paths" />
+        </provider>
 
         <meta-data
             android:name="com.google.mlkit.vision.DEPENDENCIES"

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -3,6 +3,10 @@
     xmlns:tools="http://schemas.android.com/tools"
     tools:ignore="DiscouragedApi">
 
+    <uses-feature
+        android:name="android.hardware.camera"
+        android:required="false" />
+
     <uses-permission
         android:name="android.permission.ACCESS_COARSE_LOCATION"
         tools:node="replace" />
@@ -301,6 +305,10 @@
             android:theme="@style/Theme.WeatherXM" />
         <activity
             android:name="com.weatherxm.ui.photoverification.intro.PhotoVerificationIntroActivity"
+            android:screenOrientation="portrait"
+            android:theme="@style/Theme.WeatherXM" />
+        <activity
+            android:name="com.weatherxm.ui.photoverification.gallery.PhotoGalleryActivity"
             android:screenOrientation="portrait"
             android:theme="@style/Theme.WeatherXM" />
         <activity

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -316,8 +316,12 @@
             android:name="com.weatherxm.ui.photoverification.intro.PhotoVerificationIntroActivity"
             android:screenOrientation="portrait"
             android:theme="@style/Theme.WeatherXM" />
+
+        <!-- configChanges is needed in the PhotoGalleryActivity to have the ability
+            to take photos in landscape without recreating the activity -->
         <activity
             android:name="com.weatherxm.ui.photoverification.gallery.PhotoGalleryActivity"
+            android:configChanges="screenSize|orientation"
             android:screenOrientation="portrait"
             android:theme="@style/Theme.WeatherXM" />
         <activity

--- a/app/src/main/java/com/weatherxm/data/Modules.kt
+++ b/app/src/main/java/com/weatherxm/data/Modules.kt
@@ -190,6 +190,7 @@ import com.weatherxm.ui.home.profile.ProfileViewModel
 import com.weatherxm.ui.login.LoginViewModel
 import com.weatherxm.ui.networkstats.NetworkStatsViewModel
 import com.weatherxm.ui.passwordprompt.PasswordPromptViewModel
+import com.weatherxm.ui.photoverification.gallery.PhotoGalleryViewModel
 import com.weatherxm.ui.preferences.PreferenceViewModel
 import com.weatherxm.ui.resetpassword.ResetPasswordViewModel
 import com.weatherxm.ui.rewardboosts.RewardBoostViewModel
@@ -1015,6 +1016,9 @@ private val viewmodels = module {
     }
     viewModel { ClaimPulseViewModel(get(), get(), get()) }
     viewModel { DevicesRewardsViewModel(get(), get(), get()) }
+    viewModel { params ->
+        PhotoGalleryViewModel(currentPhotosList = params.get(), fromClaiming = params.get())
+    }
 }
 
 val modules = listOf(

--- a/app/src/main/java/com/weatherxm/data/Modules.kt
+++ b/app/src/main/java/com/weatherxm/data/Modules.kt
@@ -1017,7 +1017,11 @@ private val viewmodels = module {
     viewModel { ClaimPulseViewModel(get(), get(), get()) }
     viewModel { DevicesRewardsViewModel(get(), get(), get()) }
     viewModel { params ->
-        PhotoGalleryViewModel(currentPhotosList = params.get(), fromClaiming = params.get())
+        PhotoGalleryViewModel(
+            device = params.get(),
+            photos = params.get(),
+            fromClaiming = params.get()
+        )
     }
 }
 

--- a/app/src/main/java/com/weatherxm/ui/Navigator.kt
+++ b/app/src/main/java/com/weatherxm/ui/Navigator.kt
@@ -40,9 +40,11 @@ import com.weatherxm.ui.common.Contracts.ARG_DEVICE_ID
 import com.weatherxm.ui.common.Contracts.ARG_DEVICE_TYPE
 import com.weatherxm.ui.common.Contracts.ARG_EXPLORER_CELL
 import com.weatherxm.ui.common.Contracts.ARG_FORECAST_SELECTED_DAY
+import com.weatherxm.ui.common.Contracts.ARG_FROM_CLAIMING
 import com.weatherxm.ui.common.Contracts.ARG_INSTRUCTIONS_ONLY
 import com.weatherxm.ui.common.Contracts.ARG_NEEDS_PHOTO_VERIFICATION
 import com.weatherxm.ui.common.Contracts.ARG_OPEN_EXPLORER_ON_BACK
+import com.weatherxm.ui.common.Contracts.ARG_PHOTOS
 import com.weatherxm.ui.common.Contracts.ARG_REMOTE_MESSAGE
 import com.weatherxm.ui.common.Contracts.ARG_REWARD
 import com.weatherxm.ui.common.Contracts.ARG_REWARD_DETAILS
@@ -78,6 +80,7 @@ import com.weatherxm.ui.home.HomeActivity
 import com.weatherxm.ui.login.LoginActivity
 import com.weatherxm.ui.networkstats.NetworkStatsActivity
 import com.weatherxm.ui.passwordprompt.PasswordPromptFragment
+import com.weatherxm.ui.photoverification.gallery.PhotoGalleryActivity
 import com.weatherxm.ui.photoverification.intro.PhotoVerificationIntroActivity
 import com.weatherxm.ui.preferences.PreferenceActivity
 import com.weatherxm.ui.resetpassword.ResetPasswordActivity
@@ -496,6 +499,17 @@ class Navigator(private val analytics: AnalyticsWrapper) {
                 Intent(it, PhotoVerificationIntroActivity::class.java)
                     .addFlags(Intent.FLAG_ACTIVITY_SINGLE_TOP or Intent.FLAG_ACTIVITY_CLEAR_TOP)
                     .putExtra(ARG_INSTRUCTIONS_ONLY, instructionsOnly)
+            )
+        }
+    }
+
+    fun showPhotoGallery(context: Context?, photos: ArrayList<String>, fromClaiming: Boolean) {
+        context?.let {
+            it.startActivity(
+                Intent(it, PhotoGalleryActivity::class.java)
+                    .addFlags(Intent.FLAG_ACTIVITY_SINGLE_TOP or Intent.FLAG_ACTIVITY_CLEAR_TOP)
+                    .putStringArrayListExtra(ARG_PHOTOS, photos)
+                    .putExtra(ARG_FROM_CLAIMING, fromClaiming)
             )
         }
     }

--- a/app/src/main/java/com/weatherxm/ui/Navigator.kt
+++ b/app/src/main/java/com/weatherxm/ui/Navigator.kt
@@ -8,10 +8,12 @@ import android.content.Context
 import android.content.Intent
 import android.net.Uri
 import android.os.Parcelable
+import android.provider.MediaStore
 import android.provider.Settings
 import androidx.activity.result.ActivityResultLauncher
 import androidx.annotation.StringRes
 import androidx.browser.customtabs.CustomTabsIntent
+import androidx.core.content.FileProvider
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.FragmentActivity
 import androidx.fragment.app.FragmentManager
@@ -93,6 +95,7 @@ import com.weatherxm.ui.signup.SignupActivity
 import com.weatherxm.ui.startup.StartupActivity
 import com.weatherxm.ui.updateprompt.UpdatePromptActivity
 import timber.log.Timber
+import java.io.File
 import java.time.LocalDate
 
 @Suppress("TooManyFunctions")
@@ -493,21 +496,32 @@ class Navigator(private val analytics: AnalyticsWrapper) {
         }
     }
 
-    fun showPhotoVerificationIntro(context: Context?, instructionsOnly: Boolean = false) {
+    fun showPhotoVerificationIntro(
+        context: Context?,
+        device: UIDevice,
+        instructionsOnly: Boolean = false
+    ) {
         context?.let {
             it.startActivity(
                 Intent(it, PhotoVerificationIntroActivity::class.java)
                     .addFlags(Intent.FLAG_ACTIVITY_SINGLE_TOP or Intent.FLAG_ACTIVITY_CLEAR_TOP)
+                    .putExtra(ARG_DEVICE, device)
                     .putExtra(ARG_INSTRUCTIONS_ONLY, instructionsOnly)
             )
         }
     }
 
-    fun showPhotoGallery(context: Context?, photos: ArrayList<String>, fromClaiming: Boolean) {
+    fun showPhotoGallery(
+        context: Context?,
+        device: UIDevice,
+        photos: ArrayList<String>,
+        fromClaiming: Boolean
+    ) {
         context?.let {
             it.startActivity(
                 Intent(it, PhotoGalleryActivity::class.java)
                     .addFlags(Intent.FLAG_ACTIVITY_SINGLE_TOP or Intent.FLAG_ACTIVITY_CLEAR_TOP)
+                    .putExtra(ARG_DEVICE, device)
                     .putStringArrayListExtra(ARG_PHOTOS, photos)
                     .putExtra(ARG_FROM_CLAIMING, fromClaiming)
             )
@@ -605,6 +619,16 @@ class Navigator(private val analytics: AnalyticsWrapper) {
                 Timber.d(e, "Could not open support center.")
                 it.toast(R.string.error_cannot_open_support_center)
             }
+        }
+    }
+
+    fun openCamera(launcher: ActivityResultLauncher<Intent>, context: Context, destFile: File) {
+        Intent(MediaStore.ACTION_IMAGE_CAPTURE).also { takePictureIntent ->
+            takePictureIntent.putExtra(
+                MediaStore.EXTRA_OUTPUT,
+                FileProvider.getUriForFile(context, "com.weatherxm.app.fileprovider", destFile)
+            )
+            launcher.launch(takePictureIntent)
         }
     }
 

--- a/app/src/main/java/com/weatherxm/ui/Navigator.kt
+++ b/app/src/main/java/com/weatherxm/ui/Navigator.kt
@@ -52,6 +52,7 @@ import com.weatherxm.ui.common.Contracts.ARG_REWARD
 import com.weatherxm.ui.common.Contracts.ARG_REWARD_DETAILS
 import com.weatherxm.ui.common.Contracts.ARG_USER_MESSAGE
 import com.weatherxm.ui.common.Contracts.ARG_WALLET_REWARDS
+import com.weatherxm.ui.common.Contracts.FILE_PROVIDER_AUTHORITY
 import com.weatherxm.ui.common.DeviceType
 import com.weatherxm.ui.common.DevicesRewards
 import com.weatherxm.ui.common.UIDevice
@@ -235,11 +236,21 @@ class Navigator(private val analytics: AnalyticsWrapper) {
     }
 
     fun openShare(context: Context, text: String) {
-        val intent = Intent()
-        intent.action = Intent.ACTION_SEND
-        intent.type = "text/plain"
-        intent.putExtra(Intent.EXTRA_TEXT, text)
-        context.startActivity(Intent.createChooser(intent, context.getString(R.string.share)))
+        with(Intent()) {
+            action = Intent.ACTION_SEND
+            type = "text/plain"
+            putExtra(Intent.EXTRA_TEXT, text)
+            context.startActivity(Intent.createChooser(this, context.getString(R.string.share)))
+        }
+    }
+
+    fun openShareImages(context: Context, photoUris: ArrayList<Uri>) {
+        with(Intent()) {
+            action = Intent.ACTION_SEND_MULTIPLE
+            type = "image/*"
+            putParcelableArrayListExtra(Intent.EXTRA_STREAM, photoUris)
+            context.startActivity(Intent.createChooser(this, context.getString(R.string.share)))
+        }
     }
 
     fun showDeleteAccountSurvey(
@@ -626,7 +637,7 @@ class Navigator(private val analytics: AnalyticsWrapper) {
         Intent(MediaStore.ACTION_IMAGE_CAPTURE).also { takePictureIntent ->
             takePictureIntent.putExtra(
                 MediaStore.EXTRA_OUTPUT,
-                FileProvider.getUriForFile(context, "com.weatherxm.app.fileprovider", destFile)
+                FileProvider.getUriForFile(context, FILE_PROVIDER_AUTHORITY, destFile)
             )
             launcher.launch(takePictureIntent)
         }

--- a/app/src/main/java/com/weatherxm/ui/claimdevice/helium/result/ClaimHeliumResultFragment.kt
+++ b/app/src/main/java/com/weatherxm/ui/claimdevice/helium/result/ClaimHeliumResultFragment.kt
@@ -43,12 +43,6 @@ class ClaimHeliumResultFragment : BaseFragment() {
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
 
-        binding.photoVerificationBtn.setOnClickListener {
-            navigator.showPhotoVerificationIntro(context)
-            activity?.setResult(Activity.RESULT_OK)
-            activity?.finish()
-        }
-
         binding.cancel.setOnClickListener {
             analytics.trackEventUserAction(
                 actionName = AnalyticsService.ParamValue.CLAIMING_RESULT.paramValue,
@@ -158,12 +152,14 @@ class ClaimHeliumResultFragment : BaseFragment() {
                     binding.updateBtn.setOnClickListener {
                         onUpdate(device)
                     }
+                    initPhotoVerificationBtn(device)
                     binding.skipAndGoToStationBtn.setOnClickListener {
                         showConfirmBypassOTADialog(device)
                     }
                     binding.infoMessage.setHtml(R.string.update_prompt_on_claiming_flow)
                     binding.informationCard.visible(true)
                 } else if (device != null) {
+                    initPhotoVerificationBtn(device)
                     binding.skipAndGoToStationBtn.setOnClickListener {
                         ActionDialogFragment.createSkipPhotoVerification(requireContext()) {
                             onViewDevice(device)
@@ -265,5 +261,13 @@ class ClaimHeliumResultFragment : BaseFragment() {
     private fun hideButtons() {
         binding.failureButtonsContainer.invisible()
         binding.successButtonsContainer.invisible()
+    }
+
+    private fun initPhotoVerificationBtn(device: UIDevice) {
+        binding.photoVerificationBtn.setOnClickListener {
+            navigator.showPhotoVerificationIntro(context, device)
+            activity?.setResult(Activity.RESULT_OK)
+            activity?.finish()
+        }
     }
 }

--- a/app/src/main/java/com/weatherxm/ui/claimdevice/result/ClaimResultFragment.kt
+++ b/app/src/main/java/com/weatherxm/ui/claimdevice/result/ClaimResultFragment.kt
@@ -128,7 +128,7 @@ class ClaimResultFragment : BaseFragment() {
                         }.show(this)
                     }
                     binding.photoVerificationBtn.setOnClickListener {
-                        navigator.showPhotoVerificationIntro(context)
+                        navigator.showPhotoVerificationIntro(context, device)
                         activity?.setResult(Activity.RESULT_OK)
                         activity?.finish()
                     }

--- a/app/src/main/java/com/weatherxm/ui/common/Contracts.kt
+++ b/app/src/main/java/com/weatherxm/ui/common/Contracts.kt
@@ -32,4 +32,6 @@ object Contracts {
     const val ARG_FCM_TOKEN = "fcm_token"
     const val ARG_DEVICES_REWARDS = "devices_rewards"
     const val ARG_INSTRUCTIONS_ONLY = "instructions_only"
+    const val ARG_PHOTOS = "photos"
+    const val ARG_FROM_CLAIMING = "from_claiming"
 }

--- a/app/src/main/java/com/weatherxm/ui/common/Contracts.kt
+++ b/app/src/main/java/com/weatherxm/ui/common/Contracts.kt
@@ -1,5 +1,7 @@
 package com.weatherxm.ui.common
 
+import com.weatherxm.BuildConfig
+
 object Contracts {
     const val EMPTY_VALUE = "?"
     const val DEGREES_MARK = "°"
@@ -34,4 +36,5 @@ object Contracts {
     const val ARG_INSTRUCTIONS_ONLY = "instructions_only"
     const val ARG_PHOTOS = "photos"
     const val ARG_FROM_CLAIMING = "from_claiming"
+    const val FILE_PROVIDER_AUTHORITY = "${BuildConfig.APPLICATION_ID}.fileprovider"
 }

--- a/app/src/main/java/com/weatherxm/ui/common/UIModels.kt
+++ b/app/src/main/java/com/weatherxm/ui/common/UIModels.kt
@@ -171,6 +171,14 @@ data class UIDevice(
     fun isHelium() = connectivity == "helium"
     fun isWifi() = connectivity == "wifi"
     fun isCellular() = connectivity == "cellular"
+
+    fun normalizedName(): String {
+        return if (!isEmpty()) {
+            name.replace(" ", "-").lowercase()
+        } else {
+            String.empty()
+        }
+    }
 }
 
 @Keep
@@ -612,6 +620,13 @@ data class PhotoExample(
     @DrawableRes val image: Int,
     val feedbackResId: List<Int>,
     val isGoodExample: Boolean
+)
+
+@Keep
+@JsonClass(generateAdapter = true)
+data class StationPhoto(
+    val remotePath: String?,
+    val localPath: String?
 )
 
 @Keep

--- a/app/src/main/java/com/weatherxm/ui/common/Views.kt
+++ b/app/src/main/java/com/weatherxm/ui/common/Views.kt
@@ -259,6 +259,7 @@ fun ImageButton.enable() {
     isClickable = true
 }
 
+@Suppress("MagicNumber")
 fun ImageButton.disable() {
     alpha = 0.4F
     isEnabled = false

--- a/app/src/main/java/com/weatherxm/ui/common/Views.kt
+++ b/app/src/main/java/com/weatherxm/ui/common/Views.kt
@@ -30,6 +30,7 @@ import android.view.ViewGroup
 import android.view.ViewTreeObserver
 import android.view.inputmethod.InputMethodManager
 import android.widget.EditText
+import android.widget.ImageButton
 import android.widget.ImageView
 import android.widget.LinearLayout
 import android.widget.TextView
@@ -250,6 +251,18 @@ fun ImageView.loadImage(imageLoader: ImageLoader, data: Any?) {
             .target(this)
             .build()
     )
+}
+
+fun ImageButton.enable() {
+    alpha = 1.0F
+    isEnabled = true
+    isClickable = true
+}
+
+fun ImageButton.disable() {
+    alpha = 0.4F
+    isEnabled = false
+    isClickable = false
 }
 
 @Suppress("EmptyFunctionBlock")

--- a/app/src/main/java/com/weatherxm/ui/devicedetails/DeviceDetailsActivity.kt
+++ b/app/src/main/java/com/weatherxm/ui/devicedetails/DeviceDetailsActivity.kt
@@ -172,7 +172,7 @@ class DeviceDetailsActivity : BaseActivity() {
                 )
                 navigator.openShare(
                     this,
-                    getString(R.string.share_station_url, model.createNormalizedName())
+                    getString(R.string.share_station_url, model.device.normalizedName())
                 )
                 true
             }

--- a/app/src/main/java/com/weatherxm/ui/devicedetails/DeviceDetailsViewModel.kt
+++ b/app/src/main/java/com/weatherxm/ui/devicedetails/DeviceDetailsViewModel.kt
@@ -12,7 +12,6 @@ import com.weatherxm.data.models.Failure
 import com.weatherxm.ui.common.DeviceRelation
 import com.weatherxm.ui.common.Resource
 import com.weatherxm.ui.common.UIDevice
-import com.weatherxm.ui.common.empty
 import com.weatherxm.usecases.AuthUseCase
 import com.weatherxm.usecases.DeviceDetailsUseCase
 import com.weatherxm.usecases.FollowUseCase
@@ -82,14 +81,6 @@ class DeviceDetailsViewModel(
     fun updateDevice(device: UIDevice) {
         this.device = device
         onUpdatedDevice.postValue(device)
-    }
-
-    fun createNormalizedName(): String {
-        return if (!device.isEmpty()) {
-            device.name.replace(" ", "-").lowercase()
-        } else {
-            String.empty()
-        }
     }
 
     fun followStation() {

--- a/app/src/main/java/com/weatherxm/ui/deviceheliumota/DeviceHeliumOTAActivity.kt
+++ b/app/src/main/java/com/weatherxm/ui/deviceheliumota/DeviceHeliumOTAActivity.kt
@@ -100,7 +100,7 @@ class DeviceHeliumOTAActivity : BaseActivity() {
 
     private fun setListeners() {
         binding.photoVerificationBtn.setOnClickListener {
-            navigator.showPhotoVerificationIntro(this)
+            navigator.showPhotoVerificationIntro(this, model.device)
             finish()
         }
         binding.skipAndGoToStationBtn.setOnClickListener {

--- a/app/src/main/java/com/weatherxm/ui/photoverification/gallery/PhotoGalleryActivity.kt
+++ b/app/src/main/java/com/weatherxm/ui/photoverification/gallery/PhotoGalleryActivity.kt
@@ -154,7 +154,7 @@ class PhotoGalleryActivity : BaseActivity() {
         }
 
         if (model.photos.isEmpty()) {
-            getCameraPermissions()
+            binding.addPhotoBtn.performClick()
         }
     }
 

--- a/app/src/main/java/com/weatherxm/ui/photoverification/gallery/PhotoGalleryActivity.kt
+++ b/app/src/main/java/com/weatherxm/ui/photoverification/gallery/PhotoGalleryActivity.kt
@@ -34,7 +34,7 @@ class PhotoGalleryActivity : BaseActivity() {
     private val cameraLauncher =
         registerForActivityResult(ActivityResultContracts.StartActivityForResult()) {
             if (it.resultCode == RESULT_OK) {
-                // TODO: Will be filled with the uploading mechanism
+                // TODO: Save the path of the photo taken 
             }
         }
 
@@ -76,9 +76,24 @@ class PhotoGalleryActivity : BaseActivity() {
         } else {
             binding.toolbar.setNavigationIcon(R.drawable.ic_back)
             binding.toolbar.setNavigationOnClickListener {
-                // TODO: Add a check if less than 2 photos are here
+                // TODO: Add a check if less than 2 photos are here and show the respective dialog
                 finish()
             }
+        }
+
+        binding.uploadBtn.setOnClickListener {
+            ActionDialogFragment
+                .Builder(
+                    title = getString(R.string.upload_your_photos),
+                    message = getString(R.string.upload_your_photos_dialog_message),
+                    negative = getString(R.string.action_back)
+                )
+                .onPositiveClick(getString(R.string.action_upload)) {
+                    // TODO: Will be filled with the uploading mechanism
+                    finish()
+                }
+                .build()
+                .show(this)
         }
 
         binding.instructionsBtn.setOnClickListener {

--- a/app/src/main/java/com/weatherxm/ui/photoverification/gallery/PhotoGalleryActivity.kt
+++ b/app/src/main/java/com/weatherxm/ui/photoverification/gallery/PhotoGalleryActivity.kt
@@ -47,6 +47,11 @@ import org.koin.core.parameter.parametersOf
 import java.io.File
 
 class PhotoGalleryActivity : BaseActivity() {
+    companion object {
+        const val MIN_PHOTOS = 2
+        const val MAX_PHOTOS = 6
+    }
+
     private lateinit var binding: ActivityPhotoGalleryBinding
 
     private val model: PhotoGalleryViewModel by viewModel {
@@ -159,8 +164,8 @@ class PhotoGalleryActivity : BaseActivity() {
     }
 
     private fun onPhotosNumber(photosNumber: Int) {
-        binding.addPhotoBtn.visible(photosNumber < 6)
-        binding.uploadBtn.isEnabled = photosNumber >= 2
+        binding.addPhotoBtn.visible(photosNumber < MAX_PHOTOS)
+        binding.uploadBtn.isEnabled = photosNumber >= MIN_PHOTOS
         when (photosNumber) {
             0 -> {
                 binding.toolbar.subtitle = getString(R.string.add_2_more_to_upload)
@@ -203,6 +208,7 @@ class PhotoGalleryActivity : BaseActivity() {
         }
     }
 
+    @Suppress("MagicNumber")
     private fun onCameraDenied() {
         binding.deletePhotoBtn.disable()
         binding.instructionsBtn.alpha = 0.4F
@@ -252,6 +258,7 @@ class PhotoGalleryActivity : BaseActivity() {
         }
     }
 
+    @Suppress("FunctionNaming")
     @Composable
     fun Thumbnails() {
         val photos = remember { model.onPhotos }
@@ -280,6 +287,7 @@ class PhotoGalleryActivity : BaseActivity() {
         }
     }
 
+    @Suppress("FunctionNaming")
     @Composable
     fun Thumbnail(item: StationPhoto, isSelected: Boolean, onClick: () -> Unit) {
         var width = 48.dp

--- a/app/src/main/java/com/weatherxm/ui/photoverification/gallery/PhotoGalleryActivity.kt
+++ b/app/src/main/java/com/weatherxm/ui/photoverification/gallery/PhotoGalleryActivity.kt
@@ -1,10 +1,8 @@
 package com.weatherxm.ui.photoverification.gallery
 
-import android.Manifest.permission.ACCESS_MEDIA_LOCATION
 import android.Manifest.permission.CAMERA
 import android.annotation.SuppressLint
 import android.content.Intent
-import android.os.Build
 import android.os.Bundle
 import android.provider.MediaStore
 import androidx.activity.result.contract.ActivityResultContracts
@@ -18,10 +16,8 @@ import com.weatherxm.ui.common.setHtml
 import com.weatherxm.ui.common.visible
 import com.weatherxm.ui.components.ActionDialogFragment
 import com.weatherxm.ui.components.BaseActivity
-import com.weatherxm.util.AndroidBuildInfo
 import com.weatherxm.util.checkPermissionsAndThen
 import com.weatherxm.util.hasPermission
-import com.weatherxm.util.permissionsBuilder
 import org.koin.androidx.viewmodel.ext.android.viewModel
 import org.koin.core.parameter.parametersOf
 
@@ -137,12 +133,9 @@ class PhotoGalleryActivity : BaseActivity() {
     @SuppressLint("InlinedApi")
     private fun getCameraPermissions() {
         /**
-         * The below permission check (no prompt shown to the user - Google...) is necessary
-         * in order to embed GPS information in the EXIF metadata of the image
+         * Location-related permissions are also needed to be granted beforehand in order
+         * to have them in EXIF Metadata.
          */
-        if (AndroidBuildInfo.sdkInt >= Build.VERSION_CODES.Q) {
-            permissionsBuilder(permissions = arrayOf(ACCESS_MEDIA_LOCATION)).build().send()
-        }
         checkPermissionsAndThen(
             permissions = arrayOf(CAMERA),
             rationaleTitle = getString(R.string.camera_permission_required_title),

--- a/app/src/main/java/com/weatherxm/ui/photoverification/gallery/PhotoGalleryActivity.kt
+++ b/app/src/main/java/com/weatherxm/ui/photoverification/gallery/PhotoGalleryActivity.kt
@@ -153,7 +153,9 @@ class PhotoGalleryActivity : BaseActivity() {
             Thumbnails()
         }
 
-        getCameraPermissions()
+        if (model.photos.isEmpty()) {
+            getCameraPermissions()
+        }
     }
 
     override fun onResume() {
@@ -264,10 +266,8 @@ class PhotoGalleryActivity : BaseActivity() {
         val photos = remember { model.onPhotos }
         binding.emptyPhotosText.visible(photos.isEmpty())
         binding.selectedPhoto.visible(photos.isNotEmpty())
-        if (selectedPhoto.value == null) {
-            selectedPhoto.value = photos.firstOrNull()?.apply {
-                binding.selectedPhoto.load(remotePath ?: localPath)
-            }
+        selectedPhoto.value = photos.lastOrNull()?.apply {
+            binding.selectedPhoto.load(remotePath ?: localPath)
         }
 
         LazyRow(

--- a/app/src/main/java/com/weatherxm/ui/photoverification/gallery/PhotoGalleryActivity.kt
+++ b/app/src/main/java/com/weatherxm/ui/photoverification/gallery/PhotoGalleryActivity.kt
@@ -24,6 +24,7 @@ import androidx.compose.ui.res.colorResource
 import androidx.compose.ui.res.dimensionResource
 import androidx.compose.ui.unit.dp
 import coil.compose.AsyncImage
+import coil.load
 import com.weatherxm.R
 import com.weatherxm.databinding.ActivityPhotoGalleryBinding
 import com.weatherxm.ui.common.Contracts
@@ -32,6 +33,7 @@ import com.weatherxm.ui.common.Contracts.ARG_FROM_CLAIMING
 import com.weatherxm.ui.common.StationPhoto
 import com.weatherxm.ui.common.UIDevice
 import com.weatherxm.ui.common.disable
+import com.weatherxm.ui.common.empty
 import com.weatherxm.ui.common.enable
 import com.weatherxm.ui.common.parcelable
 import com.weatherxm.ui.common.setHtml
@@ -63,7 +65,7 @@ class PhotoGalleryActivity : BaseActivity() {
         }
 
     private var wentToSettingsForPermissions = false
-    private var latestPhotoTakenPath: String = ""
+    private var latestPhotoTakenPath: String = String.empty()
     private var selectedPhoto: MutableState<StationPhoto?> = mutableStateOf(null)
 
     @SuppressLint("MissingPermission")
@@ -250,8 +252,12 @@ class PhotoGalleryActivity : BaseActivity() {
     @Composable
     fun Thumbnails() {
         val photos = remember { model.onPhotos }
+        binding.emptyPhotosText.visible(photos.isEmpty())
+        binding.selectedPhoto.visible(photos.isNotEmpty())
         if (selectedPhoto.value == null) {
-            selectedPhoto.value = photos.firstOrNull()
+            selectedPhoto.value = photos.firstOrNull()?.apply {
+                binding.selectedPhoto.load(remotePath ?: localPath)
+            }
         }
 
         LazyRow(
@@ -263,7 +269,7 @@ class PhotoGalleryActivity : BaseActivity() {
                     item = photo,
                     isSelected = photo == selectedPhoto.value,
                     onClick = {
-                        // TODO: Show image
+                        binding.selectedPhoto.load(photo.remotePath ?: photo.localPath)
                         selectedPhoto.value = photo
                     }
                 )

--- a/app/src/main/java/com/weatherxm/ui/photoverification/gallery/PhotoGalleryActivity.kt
+++ b/app/src/main/java/com/weatherxm/ui/photoverification/gallery/PhotoGalleryActivity.kt
@@ -1,0 +1,162 @@
+package com.weatherxm.ui.photoverification.gallery
+
+import android.Manifest.permission.ACCESS_MEDIA_LOCATION
+import android.Manifest.permission.CAMERA
+import android.annotation.SuppressLint
+import android.content.Intent
+import android.os.Build
+import android.os.Bundle
+import android.provider.MediaStore
+import androidx.activity.result.contract.ActivityResultContracts
+import com.weatherxm.R
+import com.weatherxm.databinding.ActivityPhotoGalleryBinding
+import com.weatherxm.ui.common.Contracts
+import com.weatherxm.ui.common.Contracts.ARG_FROM_CLAIMING
+import com.weatherxm.ui.common.disable
+import com.weatherxm.ui.common.enable
+import com.weatherxm.ui.common.setHtml
+import com.weatherxm.ui.common.visible
+import com.weatherxm.ui.components.ActionDialogFragment
+import com.weatherxm.ui.components.BaseActivity
+import com.weatherxm.util.AndroidBuildInfo
+import com.weatherxm.util.checkPermissionsAndThen
+import com.weatherxm.util.hasPermission
+import com.weatherxm.util.permissionsBuilder
+import org.koin.androidx.viewmodel.ext.android.viewModel
+import org.koin.core.parameter.parametersOf
+
+class PhotoGalleryActivity : BaseActivity() {
+    private lateinit var binding: ActivityPhotoGalleryBinding
+
+    private val model: PhotoGalleryViewModel by viewModel {
+        parametersOf(
+            intent.getStringArrayListExtra(Contracts.ARG_PHOTOS),
+            intent.getBooleanExtra(ARG_FROM_CLAIMING, false)
+        )
+    }
+
+    private val cameraLauncher =
+        registerForActivityResult(ActivityResultContracts.StartActivityForResult()) {
+            if (it.resultCode == RESULT_OK) {
+                // TODO: Will be filled with the uploading mechanism
+            }
+        }
+
+    private var wentToSettingsForPermissions = false
+
+    @SuppressLint("MissingPermission")
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        binding = ActivityPhotoGalleryBinding.inflate(layoutInflater)
+        setContentView(binding.root)
+
+        binding.emptyPhotosText.setHtml(R.string.tap_plus_icon)
+
+        if (model.currentPhotosList.isEmpty()) {
+            binding.toolbar.subtitle = getString(R.string.add_2_more_to_upload)
+            binding.emptyPhotosText.visible(true)
+            binding.deletePhotoBtn.disable()
+        } else if (model.currentPhotosList.size == 1) {
+            binding.toolbar.subtitle = getString(R.string.add_1_more_to_upload)
+        } else {
+            binding.uploadBtn.isEnabled = true
+        }
+
+        if (model.fromClaiming) {
+            binding.toolbar.setNavigationIcon(R.drawable.ic_close)
+            binding.toolbar.setNavigationOnClickListener {
+                ActionDialogFragment
+                    .Builder(
+                        title = getString(R.string.exit_photo_verification),
+                        message = getString(R.string.exit_photo_verification_message),
+                        negative = getString(R.string.action_back)
+                    )
+                    .onPositiveClick(getString(R.string.action_exit)) {
+                        finish()
+                    }
+                    .build()
+                    .show(this)
+            }
+        } else {
+            binding.toolbar.setNavigationIcon(R.drawable.ic_back)
+            binding.toolbar.setNavigationOnClickListener {
+                // TODO: Add a check if less than 2 photos are here
+                finish()
+            }
+        }
+
+        binding.instructionsBtn.setOnClickListener {
+            navigator.showPhotoVerificationIntro(this, true)
+        }
+
+        binding.openSettingsBtn.setOnClickListener {
+            navigator.openAppSettings(this)
+            wentToSettingsForPermissions = true
+        }
+
+        binding.addPhotoBtn.setOnClickListener {
+            getCameraPermissions()
+        }
+
+        getCameraPermissions()
+    }
+
+    override fun onResume() {
+        if (wentToSettingsForPermissions && hasPermission(CAMERA)) {
+            onPermissionsGivenFromSettings()
+        }
+        super.onResume()
+    }
+
+    private fun onCameraDenied() {
+        binding.deletePhotoBtn.disable()
+        binding.instructionsBtn.alpha = 0.4F
+        binding.instructionsBtn.isEnabled = false
+        binding.addPhotoBtn.disable()
+        binding.emptyPhotosText.visible(false)
+        binding.permissionsContainer.visible(true)
+    }
+
+    private fun onPermissionsGivenFromSettings() {
+        binding.instructionsBtn.alpha = 1.0F
+        binding.instructionsBtn.isEnabled = true
+        binding.addPhotoBtn.enable()
+        binding.permissionsContainer.visible(false)
+        if (model.currentPhotosList.isEmpty()) {
+            binding.emptyPhotosText.visible(true)
+            binding.deletePhotoBtn.disable()
+        }
+        wentToSettingsForPermissions = false
+    }
+
+    /**
+     * `fromOnResume` helps us identify along with the `wentToSettingsForPermissions` if the user
+     * came back from the settings screen or not, in order not to open the camera on every
+     * `onResume` invocation but only on the `onCreate` one.
+     */
+    @SuppressLint("InlinedApi")
+    private fun getCameraPermissions() {
+        /**
+         * The below permission check (no prompt shown to the user - Google...) is necessary
+         * in order to embed GPS information in the EXIF metadata of the image
+         */
+        if (AndroidBuildInfo.sdkInt >= Build.VERSION_CODES.Q) {
+            permissionsBuilder(permissions = arrayOf(ACCESS_MEDIA_LOCATION)).build().send()
+        }
+        checkPermissionsAndThen(
+            permissions = arrayOf(CAMERA),
+            rationaleTitle = getString(R.string.camera_permission_required_title),
+            rationaleMessage = getString(R.string.camera_permission_required),
+            onGranted = { openCamera() },
+            onDenied = { onCameraDenied() },
+            showOnPermanentlyDenied = false
+        )
+    }
+
+    private fun openCamera() {
+        Intent(MediaStore.ACTION_IMAGE_CAPTURE).also { takePictureIntent ->
+            // TODO: Create the image file in order to save it
+            cameraLauncher.launch(takePictureIntent)
+        }
+    }
+}

--- a/app/src/main/java/com/weatherxm/ui/photoverification/gallery/PhotoGalleryActivity.kt
+++ b/app/src/main/java/com/weatherxm/ui/photoverification/gallery/PhotoGalleryActivity.kt
@@ -194,6 +194,9 @@ class PhotoGalleryActivity : BaseActivity() {
                     .build()
                     .show(this)
             } else {
+                selectedPhoto.value?.localPath?.let { path ->
+                    File(path).delete()
+                }
                 model.deletePhoto(it)
                 selectedPhoto.value = null
             }

--- a/app/src/main/java/com/weatherxm/ui/photoverification/gallery/PhotoGalleryActivity.kt
+++ b/app/src/main/java/com/weatherxm/ui/photoverification/gallery/PhotoGalleryActivity.kt
@@ -118,18 +118,22 @@ class PhotoGalleryActivity : BaseActivity() {
         }
 
         binding.uploadBtn.setOnClickListener {
-            ActionDialogFragment
-                .Builder(
-                    title = getString(R.string.upload_your_photos),
-                    message = getString(R.string.upload_your_photos_dialog_message),
-                    negative = getString(R.string.action_back)
-                )
-                .onPositiveClick(getString(R.string.action_upload)) {
-                    // TODO: Will be filled with the uploading mechanism
-                    finish()
-                }
-                .build()
-                .show(this)
+            // STOPSHIP: Revert this before merging.
+            navigator.openShareImages(this, model.getUrisOfLocalPhotos(this))
+
+
+//            ActionDialogFragment
+//                .Builder(
+//                    title = getString(R.string.upload_your_photos),
+//                    message = getString(R.string.upload_your_photos_dialog_message),
+//                    negative = getString(R.string.action_back)
+//                )
+//                .onPositiveClick(getString(R.string.action_upload)) {
+//                    // TODO: Will be filled with the uploading mechanism
+//                    finish()
+//                }
+//                .build()
+//                .show(this)
         }
 
         binding.instructionsBtn.setOnClickListener {

--- a/app/src/main/java/com/weatherxm/ui/photoverification/gallery/PhotoGalleryViewModel.kt
+++ b/app/src/main/java/com/weatherxm/ui/photoverification/gallery/PhotoGalleryViewModel.kt
@@ -13,7 +13,9 @@ class PhotoGalleryViewModel(
     val fromClaiming: Boolean
 ) : ViewModel() {
     private val onPhotosNumber = MutableLiveData(photos.size)
-    private val _onPhotos = mutableStateListOf<StationPhoto>()
+    private val _onPhotos = mutableStateListOf<StationPhoto>().apply {
+        addAll(photos)
+    }
     val onPhotos: List<StationPhoto> = _onPhotos
 
     fun onPhotosNumber(): LiveData<Int> = onPhotosNumber

--- a/app/src/main/java/com/weatherxm/ui/photoverification/gallery/PhotoGalleryViewModel.kt
+++ b/app/src/main/java/com/weatherxm/ui/photoverification/gallery/PhotoGalleryViewModel.kt
@@ -1,11 +1,16 @@
 package com.weatherxm.ui.photoverification.gallery
 
+import android.content.Context
+import android.net.Uri
 import androidx.compose.runtime.mutableStateListOf
+import androidx.core.content.FileProvider
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
+import com.weatherxm.ui.common.Contracts.FILE_PROVIDER_AUTHORITY
 import com.weatherxm.ui.common.StationPhoto
 import com.weatherxm.ui.common.UIDevice
+import java.io.File
 
 class PhotoGalleryViewModel(
     val device: UIDevice,
@@ -40,5 +45,17 @@ class PhotoGalleryViewModel(
             _onPhotos.remove(photo)
             onPhotosNumber.postValue(photos.size)
         }
+    }
+
+    fun getUrisOfLocalPhotos(context: Context): ArrayList<Uri> {
+        val uris = arrayListOf<Uri>()
+        photos.forEach {
+            if (!it.localPath.isNullOrEmpty()) {
+                uris.add(
+                    FileProvider.getUriForFile(context, FILE_PROVIDER_AUTHORITY, File(it.localPath))
+                )
+            }
+        }
+        return uris
     }
 }

--- a/app/src/main/java/com/weatherxm/ui/photoverification/gallery/PhotoGalleryViewModel.kt
+++ b/app/src/main/java/com/weatherxm/ui/photoverification/gallery/PhotoGalleryViewModel.kt
@@ -36,7 +36,6 @@ class PhotoGalleryViewModel(
             _onPhotos.remove(photo)
             onPhotosNumber.postValue(photos.size)
         } else if (photos.firstOrNull { it.localPath == photo.localPath } != null) {
-            // TODO: Delete it actually from the storage saved 
             photos.remove(photo)
             _onPhotos.remove(photo)
             onPhotosNumber.postValue(photos.size)

--- a/app/src/main/java/com/weatherxm/ui/photoverification/gallery/PhotoGalleryViewModel.kt
+++ b/app/src/main/java/com/weatherxm/ui/photoverification/gallery/PhotoGalleryViewModel.kt
@@ -1,0 +1,10 @@
+package com.weatherxm.ui.photoverification.gallery
+
+import androidx.lifecycle.ViewModel
+
+class PhotoGalleryViewModel(
+    val currentPhotosList: List<String>,
+    val fromClaiming: Boolean
+) : ViewModel() {
+    private val newPhotosTaken = mutableListOf<String>()
+}

--- a/app/src/main/java/com/weatherxm/ui/photoverification/gallery/PhotoGalleryViewModel.kt
+++ b/app/src/main/java/com/weatherxm/ui/photoverification/gallery/PhotoGalleryViewModel.kt
@@ -1,35 +1,43 @@
 package com.weatherxm.ui.photoverification.gallery
 
+import androidx.compose.runtime.mutableStateListOf
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
+import com.weatherxm.ui.common.StationPhoto
+import com.weatherxm.ui.common.UIDevice
 
 class PhotoGalleryViewModel(
-    val currentPhotosList: List<String>,
+    val device: UIDevice,
+    val photos: MutableList<StationPhoto>,
     val fromClaiming: Boolean
 ) : ViewModel() {
-    private val newPhotosTaken = mutableListOf<String>()
+    private val onPhotosNumber = MutableLiveData(photos.size)
+    private val _onPhotos = mutableStateListOf<StationPhoto>()
+    val onPhotos: List<StationPhoto> = _onPhotos
 
-    private val onPhotoNumber = MutableLiveData(getPhotoNumber())
-
-    fun onPhotoNumber(): LiveData<Int> = onPhotoNumber
-
-    private fun getPhotoNumber() = newPhotosTaken.size + currentPhotosList.size
+    fun onPhotosNumber(): LiveData<Int> = onPhotosNumber
 
     fun addPhoto(path: String) {
-        if (path.isNotEmpty() && !newPhotosTaken.contains(path)) {
-            newPhotosTaken.add(path)
-            onPhotoNumber.postValue(getPhotoNumber())
+        if (path.isNotEmpty() && photos.firstOrNull { it.localPath == path } == null) {
+            val stationPhoto = StationPhoto(null, path)
+            photos.add(stationPhoto)
+            _onPhotos.add(stationPhoto)
+            onPhotosNumber.postValue(photos.size)
         }
     }
 
-    fun deletePhoto(path: String) {
-        if (currentPhotosList.contains(path)) {
-            // TODO: Call the delete endpoint and post the new number on success
-            onPhotoNumber.postValue(getPhotoNumber())
-        } else if (newPhotosTaken.contains(path)) {
-            newPhotosTaken.remove(path)
-            onPhotoNumber.postValue(getPhotoNumber())
+    fun deletePhoto(photo: StationPhoto) {
+        if (photos.firstOrNull { it.remotePath == photo.remotePath } != null) {
+            // TODO: Call the delete endpoint and post the new state on success
+            photos.remove(photo)
+            _onPhotos.remove(photo)
+            onPhotosNumber.postValue(photos.size)
+        } else if (photos.firstOrNull { it.localPath == photo.localPath } != null) {
+            // TODO: Delete it actually from the storage saved 
+            photos.remove(photo)
+            _onPhotos.remove(photo)
+            onPhotosNumber.postValue(photos.size)
         }
     }
 }

--- a/app/src/main/java/com/weatherxm/ui/photoverification/gallery/PhotoGalleryViewModel.kt
+++ b/app/src/main/java/com/weatherxm/ui/photoverification/gallery/PhotoGalleryViewModel.kt
@@ -1,5 +1,7 @@
 package com.weatherxm.ui.photoverification.gallery
 
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 
 class PhotoGalleryViewModel(
@@ -7,4 +9,27 @@ class PhotoGalleryViewModel(
     val fromClaiming: Boolean
 ) : ViewModel() {
     private val newPhotosTaken = mutableListOf<String>()
+
+    private val onPhotoNumber = MutableLiveData(getPhotoNumber())
+
+    fun onPhotoNumber(): LiveData<Int> = onPhotoNumber
+
+    private fun getPhotoNumber() = newPhotosTaken.size + currentPhotosList.size
+
+    fun addPhoto(path: String) {
+        if (path.isNotEmpty() && !newPhotosTaken.contains(path)) {
+            newPhotosTaken.add(path)
+            onPhotoNumber.postValue(getPhotoNumber())
+        }
+    }
+
+    fun deletePhoto(path: String) {
+        if (currentPhotosList.contains(path)) {
+            // TODO: Call the delete endpoint and post the new number on success
+            onPhotoNumber.postValue(getPhotoNumber())
+        } else if (newPhotosTaken.contains(path)) {
+            newPhotosTaken.remove(path)
+            onPhotoNumber.postValue(getPhotoNumber())
+        }
+    }
 }

--- a/app/src/main/java/com/weatherxm/ui/photoverification/intro/PhotoVerificationIntroActivity.kt
+++ b/app/src/main/java/com/weatherxm/ui/photoverification/intro/PhotoVerificationIntroActivity.kt
@@ -4,7 +4,10 @@ import android.annotation.SuppressLint
 import android.os.Bundle
 import com.weatherxm.R
 import com.weatherxm.databinding.ActivityPhotoVerificationIntroBinding
+import com.weatherxm.ui.common.Contracts.ARG_DEVICE
 import com.weatherxm.ui.common.Contracts.ARG_INSTRUCTIONS_ONLY
+import com.weatherxm.ui.common.UIDevice
+import com.weatherxm.ui.common.parcelable
 import com.weatherxm.ui.components.ActionDialogFragment
 import com.weatherxm.ui.components.BaseActivity
 import com.weatherxm.ui.photoverification.PhotoVerificationInstructionsFragment
@@ -13,6 +16,7 @@ class PhotoVerificationIntroActivity : BaseActivity() {
     private lateinit var binding: ActivityPhotoVerificationIntroBinding
 
     private var instructionsOnly = false
+    private var device = UIDevice.empty()
 
     @SuppressLint("MissingPermission")
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -21,6 +25,7 @@ class PhotoVerificationIntroActivity : BaseActivity() {
         setContentView(binding.root)
 
         instructionsOnly = intent.getBooleanExtra(ARG_INSTRUCTIONS_ONLY, false)
+        device = intent.parcelable<UIDevice>(ARG_DEVICE) ?: UIDevice.empty()
     }
 
     override fun onResume() {
@@ -47,6 +52,7 @@ class PhotoVerificationIntroActivity : BaseActivity() {
                     onTakePhoto = {
                         navigator.showPhotoGallery(
                             this@PhotoVerificationIntroActivity,
+                            device,
                             arrayListOf(),
                             true
                         )

--- a/app/src/main/java/com/weatherxm/ui/photoverification/intro/PhotoVerificationIntroActivity.kt
+++ b/app/src/main/java/com/weatherxm/ui/photoverification/intro/PhotoVerificationIntroActivity.kt
@@ -45,7 +45,11 @@ class PhotoVerificationIntroActivity : BaseActivity() {
                             .show(this)
                     },
                     onTakePhoto = {
-                        // TODO: Navigate to next screen
+                        navigator.showPhotoGallery(
+                            this@PhotoVerificationIntroActivity,
+                            arrayListOf(),
+                            true
+                        )
                         finish()
                     }
                 )

--- a/app/src/main/java/com/weatherxm/util/Permissions.kt
+++ b/app/src/main/java/com/weatherxm/util/Permissions.kt
@@ -24,7 +24,8 @@ fun FragmentActivity.checkPermissionsAndThen(
     rationaleTitle: String,
     rationaleMessage: String,
     onGranted: () -> Unit,
-    onDenied: () -> Unit
+    onDenied: () -> Unit,
+    showOnPermanentlyDenied: Boolean = true
 ) {
     // Show rationale dialog
     fun onShowRationale() {
@@ -78,7 +79,11 @@ fun FragmentActivity.checkPermissionsAndThen(
         when {
             result.anyGranted() -> onGranted()
             result.anyShouldShowRationale() -> onShowRationale()
-            result.allPermanentlyDenied() -> onPermanentlyDenied()
+            result.allPermanentlyDenied() -> {
+                if (showOnPermanentlyDenied) {
+                    onPermanentlyDenied()
+                }
+            }
         }
     }
 }

--- a/app/src/main/java/com/weatherxm/util/Permissions.kt
+++ b/app/src/main/java/com/weatherxm/util/Permissions.kt
@@ -19,6 +19,7 @@ import com.weatherxm.ui.common.toast
 import com.weatherxm.ui.components.ActionDialogFragment
 import timber.log.Timber
 
+@Suppress("LongParameterList")
 fun FragmentActivity.checkPermissionsAndThen(
     vararg permissions: String,
     rationaleTitle: String,

--- a/app/src/main/res/drawable/background_imagebutton_circular_layer1.xml
+++ b/app/src/main/res/drawable/background_imagebutton_circular_layer1.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android">
+    <solid android:color="@color/layer1" />
+    <corners android:radius="@dimen/radius_extra_extra_large" />
+</shape>

--- a/app/src/main/res/drawable/background_imagebutton_smaller_radius_layer1.xml
+++ b/app/src/main/res/drawable/background_imagebutton_smaller_radius_layer1.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android">
+    <solid android:color="@color/layer1" />
+    <corners android:radius="@dimen/radius_small" />
+</shape>

--- a/app/src/main/res/drawable/ic_delete.xml
+++ b/app/src/main/res/drawable/ic_delete.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="20dp"
+    android:height="21dp"
+    android:viewportWidth="20"
+    android:viewportHeight="21">
+  <path
+      android:pathData="M7.219,3.063C7.375,2.719 7.719,2.5 8.094,2.5H11.875C12.25,2.5 12.594,2.719 12.75,3.063L13,3.5H16C16.531,3.5 17,3.969 17,4.5C17,5.063 16.531,5.5 16,5.5H4C3.438,5.5 3,5.063 3,4.5C3,3.969 3.438,3.5 4,3.5H7L7.219,3.063ZM16,6.5L15.313,17.094C15.281,17.906 14.625,18.5 13.813,18.5H6.156C5.344,18.5 4.688,17.906 4.656,17.094L4,6.5H16Z"
+      android:fillColor="#FF1744"/>
+</vector>

--- a/app/src/main/res/layout/activity_photo_gallery.xml
+++ b/app/src/main/res/layout/activity_photo_gallery.xml
@@ -1,0 +1,123 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.coordinatorlayout.widget.CoordinatorLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/root"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:fitsSystemWindows="true">
+
+    <com.google.android.material.appbar.AppBarLayout
+        android:id="@+id/app_bar"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:background="@drawable/background_rounded_bottom">
+
+        <com.google.android.material.appbar.MaterialToolbar
+            android:id="@+id/toolbar"
+            android:layout_width="match_parent"
+            android:layout_height="?actionBarSize"
+            android:background="@color/colorSurface"
+            app:navigationIconTint="@color/colorOnSurface"
+            app:title="@string/station_photos"
+            tools:navigationIcon="@drawable/ic_close"
+            tools:subtitle="@string/add_1_more_to_upload">
+
+            <com.google.android.material.button.MaterialButton
+                android:id="@+id/uploadBtn"
+                android:layout_width="wrap_content"
+                android:layout_height="37dp"
+                android:layout_gravity="end"
+                android:enabled="false"
+                android:paddingHorizontal="@dimen/padding_normal"
+                android:paddingVertical="@dimen/padding_small"
+                android:text="@string/action_upload"
+                app:cornerRadius="@dimen/radius_large" />
+        </com.google.android.material.appbar.MaterialToolbar>
+
+    </com.google.android.material.appbar.AppBarLayout>
+
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:layout_marginHorizontal="@dimen/margin_large"
+        app:layout_behavior="com.google.android.material.appbar.AppBarLayout$ScrollingViewBehavior">
+
+        <LinearLayout
+            android:id="@+id/permissionsContainer"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginHorizontal="@dimen/margin_large"
+            android:orientation="vertical"
+            android:visibility="gone"
+            app:layout_constraintBottom_toTopOf="@id/addPhotoBtn"
+            app:layout_constraintTop_toTopOf="parent">
+
+            <com.google.android.material.textview.MaterialTextView
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:gravity="center"
+                android:text="@string/camera_permission_photo_verification"
+                android:textAppearance="@style/TextAppearance.WeatherXM.Default.BodyLarge"
+                android:textStyle="bold" />
+
+            <com.google.android.material.button.MaterialButton
+                android:id="@+id/openSettingsBtn"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="@dimen/margin_large"
+                android:text="@string/action_open_settings" />
+        </LinearLayout>
+
+        <com.google.android.material.textview.MaterialTextView
+            android:id="@+id/emptyPhotosText"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:gravity="center"
+            android:text="@string/tap_plus_icon"
+            android:textAppearance="@style/TextAppearance.WeatherXM.Default.BodyLarge"
+            android:visibility="gone"
+            app:layout_constraintBottom_toTopOf="@id/addPhotoBtn"
+            app:layout_constraintTop_toTopOf="parent"
+            tools:visibility="visible" />
+
+        <ImageButton
+            android:id="@+id/addPhotoBtn"
+            android:layout_width="48dp"
+            android:layout_height="70dp"
+            android:layout_marginBottom="40dp"
+            android:background="@drawable/background_imagebutton_smaller_radius_layer1"
+            android:contentDescription="@string/add_photo"
+            android:src="@drawable/ic_add"
+            app:layout_constraintBottom_toTopOf="@id/instructionsBtn"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_goneMarginBottom="@dimen/margin_large"
+            app:tint="@color/colorPrimary" />
+
+        <ImageButton
+            android:id="@+id/deletePhotoBtn"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginBottom="@dimen/margin_extra_large"
+            android:background="@drawable/background_imagebutton_circular_layer1"
+            android:contentDescription="@string/delete_this_photo"
+            android:padding="@dimen/padding_normal"
+            android:src="@drawable/ic_delete"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintStart_toStartOf="parent" />
+
+        <com.google.android.material.button.MaterialButton
+            android:id="@+id/instructionsBtn"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginBottom="@dimen/margin_extra_large"
+            android:text="@string/action_instructions"
+            android:textColor="@color/alternativeTextColor"
+            app:backgroundTint="@color/layer1"
+            app:cornerRadius="@dimen/radius_large"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="parent" />
+    </androidx.constraintlayout.widget.ConstraintLayout>
+
+</androidx.coordinatorlayout.widget.CoordinatorLayout>

--- a/app/src/main/res/layout/activity_photo_gallery.xml
+++ b/app/src/main/res/layout/activity_photo_gallery.xml
@@ -69,6 +69,19 @@
                 android:text="@string/action_open_settings" />
         </LinearLayout>
 
+        <ImageView
+            android:id="@+id/selectedPhoto"
+            android:layout_width="match_parent"
+            android:layout_height="0dp"
+            android:layout_marginTop="@dimen/padding_extra_large"
+            android:layout_marginBottom="@dimen/margin_large"
+            android:adjustViewBounds="true"
+            android:visibility="gone"
+            app:layout_constraintBottom_toTopOf="@id/thumbnailsContainer"
+            app:layout_constraintTop_toTopOf="parent"
+            tools:ignore="ContentDescription"
+            tools:visibility="visible" />
+
         <com.google.android.material.textview.MaterialTextView
             android:id="@+id/emptyPhotosText"
             android:layout_width="match_parent"

--- a/app/src/main/res/layout/activity_photo_gallery.xml
+++ b/app/src/main/res/layout/activity_photo_gallery.xml
@@ -50,7 +50,7 @@
             android:layout_marginHorizontal="@dimen/margin_large"
             android:orientation="vertical"
             android:visibility="gone"
-            app:layout_constraintBottom_toTopOf="@id/addPhotoBtn"
+            app:layout_constraintBottom_toTopOf="@id/thumbnailsContainer"
             app:layout_constraintTop_toTopOf="parent">
 
             <com.google.android.material.textview.MaterialTextView
@@ -77,23 +77,35 @@
             android:text="@string/tap_plus_icon"
             android:textAppearance="@style/TextAppearance.WeatherXM.Default.BodyLarge"
             android:visibility="gone"
-            app:layout_constraintBottom_toTopOf="@id/addPhotoBtn"
+            app:layout_constraintBottom_toTopOf="@id/thumbnailsContainer"
             app:layout_constraintTop_toTopOf="parent"
             tools:visibility="visible" />
 
-        <ImageButton
-            android:id="@+id/addPhotoBtn"
-            android:layout_width="48dp"
-            android:layout_height="70dp"
+        <LinearLayout
+            android:id="@+id/thumbnailsContainer"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_gravity="center"
             android:layout_marginBottom="40dp"
-            android:background="@drawable/background_imagebutton_smaller_radius_layer1"
-            android:contentDescription="@string/add_photo"
-            android:src="@drawable/ic_add"
-            app:layout_constraintBottom_toTopOf="@id/instructionsBtn"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_goneMarginBottom="@dimen/margin_large"
-            app:tint="@color/colorPrimary" />
+            android:gravity="center"
+            android:orientation="horizontal"
+            app:layout_constraintBottom_toTopOf="@id/instructionsBtn">
+
+            <androidx.compose.ui.platform.ComposeView
+                android:id="@+id/thumbnails"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginEnd="@dimen/margin_small" />
+
+            <ImageButton
+                android:id="@+id/addPhotoBtn"
+                android:layout_width="48dp"
+                android:layout_height="70dp"
+                android:background="@drawable/background_imagebutton_smaller_radius_layer1"
+                android:contentDescription="@string/add_photo"
+                android:src="@drawable/ic_add"
+                app:tint="@color/colorPrimary" />
+        </LinearLayout>
 
         <ImageButton
             android:id="@+id/deletePhotoBtn"

--- a/app/src/main/res/layout/fragment_photo_verification_instructions.xml
+++ b/app/src/main/res/layout/fragment_photo_verification_instructions.xml
@@ -155,124 +155,101 @@
             android:textSize="20sp"
             android:textStyle="bold" />
 
-        <FrameLayout
+        <androidx.constraintlayout.widget.ConstraintLayout
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:layout_marginTop="@dimen/margin_large">
+            android:layout_marginTop="@dimen/margin_large"
+            android:background="@color/successTint">
 
-            <com.google.android.material.card.MaterialCardView
+            <com.google.android.material.textview.MaterialTextView
+                android:id="@+id/goodExamplesTitle"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="@dimen/margin_large"
+                android:layout_marginTop="@dimen/margin_normal"
+                android:text="@string/photo_good_example_title"
+                android:textAppearance="@style/TextAppearance.WeatherXM.Default.BodyLarge"
+                android:textStyle="bold"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toTopOf="parent" />
+
+            <ImageView
+                android:layout_width="15dp"
+                android:layout_height="15dp"
+                android:layout_marginStart="@dimen/margin_extra_small"
+                android:importantForAccessibility="no"
+                android:src="@drawable/ic_checkmark"
+                app:layout_constraintBottom_toBottomOf="@id/goodExamplesTitle"
+                app:layout_constraintStart_toEndOf="@id/goodExamplesTitle"
+                app:layout_constraintTop_toTopOf="@id/goodExamplesTitle"
+                app:tint="@color/success" />
+
+            <androidx.recyclerview.widget.RecyclerView
+                android:id="@+id/goodExamplesRecycler"
                 android:layout_width="match_parent"
-                android:layout_height="match_parent"
-                android:layout_marginHorizontal="@dimen/margin_large"
-                app:cardBackgroundColor="@color/successTint" />
+                android:layout_height="wrap_content"
+                android:layout_marginTop="@dimen/margin_normal"
+                android:clipToPadding="false"
+                android:nestedScrollingEnabled="false"
+                android:orientation="horizontal"
+                android:overScrollMode="never"
+                android:paddingHorizontal="@dimen/padding_large"
+                android:paddingBottom="@dimen/padding_normal"
+                android:scrollbars="vertical"
+                app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"
+                app:layout_constraintTop_toBottomOf="@id/goodExamplesTitle"
+                tools:ignore="RtlSymmetry"
+                tools:listitem="@layout/list_item_photo_example" />
 
-            <androidx.constraintlayout.widget.ConstraintLayout
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content">
+        </androidx.constraintlayout.widget.ConstraintLayout>
 
-                <com.google.android.material.textview.MaterialTextView
-                    android:id="@+id/goodExamplesTitle"
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:layout_marginStart="40dp"
-                    android:layout_marginTop="@dimen/margin_normal"
-                    android:text="@string/photo_good_example_title"
-                    android:textAppearance="@style/TextAppearance.WeatherXM.Default.BodyLarge"
-                    android:textStyle="bold"
-                    app:layout_constraintStart_toStartOf="parent"
-                    app:layout_constraintTop_toTopOf="parent" />
-
-                <ImageView
-                    android:layout_width="15dp"
-                    android:layout_height="15dp"
-                    android:layout_marginStart="@dimen/margin_extra_small"
-                    android:importantForAccessibility="no"
-                    android:src="@drawable/ic_checkmark"
-                    app:layout_constraintBottom_toBottomOf="@id/goodExamplesTitle"
-                    app:layout_constraintStart_toEndOf="@id/goodExamplesTitle"
-                    app:layout_constraintTop_toTopOf="@id/goodExamplesTitle"
-                    app:tint="@color/success" />
-
-                <androidx.recyclerview.widget.RecyclerView
-                    android:id="@+id/goodExamplesRecycler"
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:layout_marginTop="@dimen/margin_normal"
-                    android:clipToPadding="false"
-                    android:nestedScrollingEnabled="false"
-                    android:orientation="horizontal"
-                    android:overScrollMode="never"
-                    android:paddingStart="40dp"
-                    android:paddingEnd="40dp"
-                    android:paddingBottom="@dimen/padding_normal"
-                    android:scrollbars="vertical"
-                    app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"
-                    app:layout_constraintTop_toBottomOf="@id/goodExamplesTitle"
-                    tools:ignore="RtlSymmetry"
-                    tools:listitem="@layout/list_item_photo_example" />
-
-            </androidx.constraintlayout.widget.ConstraintLayout>
-
-        </FrameLayout>
-
-        <FrameLayout
+        <androidx.constraintlayout.widget.ConstraintLayout
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:layout_marginTop="@dimen/margin_large">
+            android:layout_marginTop="@dimen/margin_large"
+            android:background="@color/errorTint">
 
-            <com.google.android.material.card.MaterialCardView
+            <com.google.android.material.textview.MaterialTextView
+                android:id="@+id/badExamplesTitle"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="@dimen/margin_large"
+                android:layout_marginTop="@dimen/margin_normal"
+                android:text="@string/photo_bad_example_title"
+                android:textAppearance="@style/TextAppearance.WeatherXM.Default.BodyLarge"
+                android:textStyle="bold"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toTopOf="parent" />
+
+            <ImageView
+                android:layout_width="20dp"
+                android:layout_height="20dp"
+                android:layout_marginStart="@dimen/margin_extra_small"
+                android:importantForAccessibility="no"
+                android:src="@drawable/ic_error_circular"
+                app:layout_constraintBottom_toBottomOf="@id/badExamplesTitle"
+                app:layout_constraintStart_toEndOf="@id/badExamplesTitle"
+                app:layout_constraintTop_toTopOf="@id/badExamplesTitle"
+                app:tint="@color/error" />
+
+            <androidx.recyclerview.widget.RecyclerView
+                android:id="@+id/badExamplesRecycler"
                 android:layout_width="match_parent"
-                android:layout_height="match_parent"
-                android:layout_marginHorizontal="@dimen/margin_large"
-                app:cardBackgroundColor="@color/errorTint" />
+                android:layout_height="wrap_content"
+                android:layout_marginTop="@dimen/margin_normal"
+                android:clipToPadding="false"
+                android:nestedScrollingEnabled="false"
+                android:orientation="horizontal"
+                android:overScrollMode="never"
+                android:paddingHorizontal="@dimen/padding_large"
+                android:paddingBottom="@dimen/padding_normal"
+                android:scrollbars="vertical"
+                app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"
+                app:layout_constraintTop_toBottomOf="@id/badExamplesTitle"
+                tools:ignore="RtlSymmetry"
+                tools:listitem="@layout/list_item_photo_example" />
 
-            <androidx.constraintlayout.widget.ConstraintLayout
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content">
-
-                <com.google.android.material.textview.MaterialTextView
-                    android:id="@+id/badExamplesTitle"
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:layout_marginStart="40dp"
-                    android:layout_marginTop="@dimen/margin_normal"
-                    android:text="@string/photo_bad_example_title"
-                    android:textAppearance="@style/TextAppearance.WeatherXM.Default.BodyLarge"
-                    android:textStyle="bold"
-                    app:layout_constraintStart_toStartOf="parent"
-                    app:layout_constraintTop_toTopOf="parent" />
-
-                <ImageView
-                    android:layout_width="20dp"
-                    android:layout_height="20dp"
-                    android:layout_marginStart="@dimen/margin_extra_small"
-                    android:importantForAccessibility="no"
-                    android:src="@drawable/ic_error_circular"
-                    app:layout_constraintBottom_toBottomOf="@id/badExamplesTitle"
-                    app:layout_constraintStart_toEndOf="@id/badExamplesTitle"
-                    app:layout_constraintTop_toTopOf="@id/badExamplesTitle"
-                    app:tint="@color/error" />
-
-                <androidx.recyclerview.widget.RecyclerView
-                    android:id="@+id/badExamplesRecycler"
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:layout_marginTop="@dimen/margin_normal"
-                    android:clipToPadding="false"
-                    android:nestedScrollingEnabled="false"
-                    android:orientation="horizontal"
-                    android:overScrollMode="never"
-                    android:paddingStart="40dp"
-                    android:paddingEnd="40dp"
-                    android:paddingBottom="@dimen/padding_normal"
-                    android:scrollbars="vertical"
-                    app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"
-                    app:layout_constraintTop_toBottomOf="@id/badExamplesTitle"
-                    tools:ignore="RtlSymmetry"
-                    tools:listitem="@layout/list_item_photo_example" />
-
-            </androidx.constraintlayout.widget.ConstraintLayout>
-        </FrameLayout>
+        </androidx.constraintlayout.widget.ConstraintLayout>
 
         <com.google.android.material.textview.MaterialTextView
             android:layout_width="match_parent"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -684,4 +684,5 @@
     <string name="delete_this_photo_message">This photo is already uploaded, are you sure you want to delete it?</string>
     <string name="camera_permission_photo_verification">Allow WeatherXM to access your camera to continue with Photo Verification.</string>
     <string name="tap_plus_icon"><![CDATA[<b>Tap the plus icon to take a photo</b><br><br>Your camera will open]]></string>
+    <string name="upload_your_photos_dialog_message">Are you sure that your photos follow our guidelines?\nIf you are having second thoughts you can go back and retake any of them!</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -29,6 +29,7 @@
     <string name="action_view_all">View All</string>
     <string name="action_finish">Finish</string>
     <string name="action_sign_in">Sign In</string>
+    <string name="action_delete">Delete</string>
     <string name="action_buy_station">Buy a Station</string>
     <string name="action_claim">Claim</string>
     <string name="action_dismiss">Dismiss</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -654,6 +654,7 @@
     <string name="photo_examples">Photo Examples</string>
     <string name="exit_photo_verification">Exit Photo Verification</string>
     <string name="exit_photo_verification_message">Are you sure you want to exit the Photo Verification process?\n\nYou can always do it later from the station’s settings.</string>
+    <string name="exit_photo_verification_start_over">At least 2 photos are required.\nExiting now means starting over next time.</string>
     <string name="upload_your_photos">Upload your photos</string>
     <string name="upload_your_photos_message">After taking the photos, tap ‘Upload’ to send them to us for installation evaluation. Your photos are used solely for this purpose.\n\nUploading will run in the background, so feel free to navigate the app while we handle the transfer.</string>
     <string name="lets_take_first_photo">Let’s take the first photo!</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -17,6 +17,9 @@
     <string name="action_exit">Exit</string>
     <string name="action_try_again">Try Again</string>
     <string name="action_pair_station_via_bluetooth">Pair station via Bluetooth</string>
+    <string name="action_upload">Upload</string>
+    <string name="action_instructions">Instructions</string>
+    <string name="action_open_settings">Open Settings</string>
     <string name="action_favorite">Favorite</string>
     <string name="action_pair_device">Pair Device</string>
     <string name="action_retry_updating">Retry Updating</string>
@@ -673,4 +676,12 @@
     <string name="photo_bad_example_2_2">No surface of installation</string>
     <string name="photo_bad_example_3_1">Tilted angle</string>
     <string name="photo_bad_example_3_2">Subject not in the middle</string>
+    <string name="station_photos">Station Photos</string>
+    <string name="add_1_more_to_upload">Add 1 more photo to upload</string>
+    <string name="add_2_more_to_upload">Add 2 more photos to upload</string>
+    <string name="delete_this_photo">Delete this photo?</string>
+    <string name="add_photo">Add photo</string>
+    <string name="delete_this_photo_message">This photo is already uploaded, are you sure you want to delete it?</string>
+    <string name="camera_permission_photo_verification">Allow WeatherXM to access your camera to continue with Photo Verification.</string>
+    <string name="tap_plus_icon"><![CDATA[<b>Tap the plus icon to take a photo</b><br><br>Your camera will open]]></string>
 </resources>

--- a/app/src/main/res/xml/file_provider_paths.xml
+++ b/app/src/main/res/xml/file_provider_paths.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<paths>
+    <external-files-path
+        name="station_verification"
+        path="Pictures" />
+</paths>

--- a/app/src/test/java/com/weatherxm/ui/common/UIDeviceTest.kt
+++ b/app/src/test/java/com/weatherxm/ui/common/UIDeviceTest.kt
@@ -23,6 +23,7 @@ class UIDeviceTest : BehaviorSpec({
         every { device.createDeviceAlerts(any()) } answers { callOriginal() }
         every { device.hasErrors() } answers { callOriginal() }
         every { device.getLastCharsOfLabel() } answers { callOriginal() }
+        every { device.normalizedName() } answers { callOriginal() }
     }
 
     suspend fun BehaviorSpecWhenContainerScope.testDeviceRelation(
@@ -260,7 +261,7 @@ class UIDeviceTest : BehaviorSpec({
 
     context("Get the normalized name") {
         When("the name is empty") {
-            every { device.name } returns String.empty()
+
             then("return an empty string") {
                 device.normalizedName() shouldBe String.empty()
             }

--- a/app/src/test/java/com/weatherxm/ui/common/UIDeviceTest.kt
+++ b/app/src/test/java/com/weatherxm/ui/common/UIDeviceTest.kt
@@ -252,8 +252,23 @@ class UIDeviceTest : BehaviorSpec({
         }
         When("the label is valid") {
             every { device.label } returns "00:00:00"
-            then("return an the last 6 chars") {
+            then("return the last 6 chars") {
                 device.getLastCharsOfLabel() shouldBe "000000"
+            }
+        }
+    }
+
+    context("Get the normalized name") {
+        When("the name is empty") {
+            every { device.name } returns String.empty()
+            then("return an empty string") {
+                device.normalizedName() shouldBe String.empty()
+            }
+        }
+        When("the name is not empty") {
+            every { device.name } returns "My Weather Station"
+            then("return the correct normalized name") {
+                device.normalizedName() shouldBe "my-weather-station"
             }
         }
     }

--- a/app/src/test/java/com/weatherxm/ui/devicedetails/DeviceDetailsViewModelTest.kt
+++ b/app/src/test/java/com/weatherxm/ui/devicedetails/DeviceDetailsViewModelTest.kt
@@ -152,23 +152,6 @@ class DeviceDetailsViewModelTest : BehaviorSpec({
         }
     }
 
-    context("Get the normalized station name of the weather station") {
-        given("the station") {
-            When("it's empty") {
-                viewModel.updateDevice(emptyDevice)
-                then("return an empty string") {
-                    viewModel.createNormalizedName() shouldBe String.empty()
-                }
-            }
-            When("it's not empty") {
-                viewModel.updateDevice(device)
-                then("return the normalized station name") {
-                    viewModel.createNormalizedName() shouldBe normalizedStationName
-                }
-            }
-        }
-    }
-
     context("Follow a station") {
         given("a usecase returning the response of the unfollow request") {
             When("it's failure") {

--- a/app/src/test/java/com/weatherxm/ui/devicedetails/DeviceDetailsViewModelTest.kt
+++ b/app/src/test/java/com/weatherxm/ui/devicedetails/DeviceDetailsViewModelTest.kt
@@ -46,7 +46,6 @@ class DeviceDetailsViewModelTest : BehaviorSpec({
     val analytics = mockk<AnalyticsWrapper>()
     lateinit var viewModel: DeviceDetailsViewModel
 
-    val normalizedStationName = "my-weather-station"
     val emptyDevice = UIDevice.empty()
     val device = UIDevice(
         "deviceId",

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -104,6 +104,7 @@ better-link-movement-method = { module = "me.saket:better-link-movement-method",
 chucker-no-op = { module = "com.github.chuckerteam.chucker:library-no-op", version.ref = "chucker" }
 chucker = { module = "com.github.chuckerteam.chucker:library", version.ref = "chucker" }
 coil-base = { module = "io.coil-kt:coil-base", version.ref = "coil-base" }
+coil-compose = { module = "io.coil-kt:coil-compose", version.ref = "coil-base" }
 coil-gif = { module = "io.coil-kt:coil-gif", version.ref = "coil-base" }
 desugar_jdk_libs = { module = "com.android.tools:desugar_jdk_libs", version.ref = "desugar_jdk_libs" }
 dfu = { module = "no.nordicsemi.android:dfu", version.ref = "dfu" }


### PR DESCRIPTION
### **Why?**
Implement the screens where users can capture and manage photos before uploading.

### **How?**
- Created `PhotoGalleryActivity` with its ViewModel which is the activity responsible for launching the camera app and showing the photos as the design.
- Added the `UIDevice` object in the intents starting the photo verification flow as we need it for various purposes.
- Moved function `normalizedName()` to `UIDevice`
- Created `StationPhoto` UI Model which holds 2 variables, `remotePath` and `localPath` for each case. In our ViewModel we have a list of `StationPhoto` so we can show, add or delete them.

### **Testing**
Use local mock and start a claiming flow, at the end start the photo verification flow and proceed with testing the gallery + camera.
