### PR TITLE
Feature/fe 1341 station settings photo verification UI component

### DIFF
--- a/app/src/local/assets/mock_files/device_photos_list.json
+++ b/app/src/local/assets/mock_files/device_photos_list.json
@@ -1,0 +1,11 @@
+[
+    {
+        "url": "https://i0.wp.com/weatherxm.com/wp-content/uploads/2023/09/5-5.png"
+    },
+    {
+        "url": "https://docs.weatherxm.com/img/wxm-devices/deployments/good-example-1.jpg"
+    },
+    {
+        "url": "https://docs.weatherxm.com/img/wxm-devices/deployments/good-example-2.jpg"
+    }
+]

--- a/app/src/main/java/com/weatherxm/data/Modules.kt
+++ b/app/src/main/java/com/weatherxm/data/Modules.kt
@@ -77,6 +77,8 @@ import com.weatherxm.data.datasource.DatabaseExplorerDataSource
 import com.weatherxm.data.datasource.DatabaseWeatherHistoryDataSource
 import com.weatherxm.data.datasource.DeviceOTADataSource
 import com.weatherxm.data.datasource.DeviceOTADataSourceImpl
+import com.weatherxm.data.datasource.DevicePhotoDataSource
+import com.weatherxm.data.datasource.DevicePhotoDataSourceImpl
 import com.weatherxm.data.datasource.LocationDataSource
 import com.weatherxm.data.datasource.LocationDataSourceImpl
 import com.weatherxm.data.datasource.NetworkAddressSearchDataSource
@@ -119,6 +121,8 @@ import com.weatherxm.data.repository.AuthRepository
 import com.weatherxm.data.repository.AuthRepositoryImpl
 import com.weatherxm.data.repository.DeviceOTARepository
 import com.weatherxm.data.repository.DeviceOTARepositoryImpl
+import com.weatherxm.data.repository.DevicePhotoRepository
+import com.weatherxm.data.repository.DevicePhotoRepositoryImpl
 import com.weatherxm.data.repository.DeviceRepository
 import com.weatherxm.data.repository.DeviceRepositoryImpl
 import com.weatherxm.data.repository.ExplorerRepository
@@ -222,6 +226,8 @@ import com.weatherxm.usecases.DeviceDetailsUseCase
 import com.weatherxm.usecases.DeviceDetailsUseCaseImpl
 import com.weatherxm.usecases.DeviceListUseCase
 import com.weatherxm.usecases.DeviceListUseCaseImpl
+import com.weatherxm.usecases.DevicePhotoUseCase
+import com.weatherxm.usecases.DevicePhotoUseCaseImpl
 import com.weatherxm.usecases.EditLocationUseCase
 import com.weatherxm.usecases.EditLocationUseCaseImpl
 import com.weatherxm.usecases.ExplorerUseCase
@@ -429,6 +435,9 @@ private val datasources = module {
     single<RemoteBannersDataSource> {
         RemoteBannersDataSourceImpl(get(), get())
     }
+    single<DevicePhotoDataSource> {
+        DevicePhotoDataSourceImpl(get())
+    }
 }
 
 private val repositories = module {
@@ -494,6 +503,9 @@ private val repositories = module {
     }
     single<RemoteBannersRepository> {
         RemoteBannersRepositoryImpl(get())
+    }
+    single<DevicePhotoRepository> {
+        DevicePhotoRepositoryImpl(get())
     }
 }
 
@@ -569,6 +581,9 @@ private val usecases = module {
     }
     single<RemoteBannersUseCase> {
         RemoteBannersUseCaseImpl(get())
+    }
+    single<DevicePhotoUseCase> {
+        DevicePhotoUseCaseImpl(get())
     }
 }
 
@@ -927,12 +942,14 @@ private val viewmodels = module {
             get(),
             get(),
             get(),
+            get(),
             get()
         )
     }
     viewModel { params ->
         DeviceSettingsHeliumViewModel(
             device = params.get(),
+            get(),
             get(),
             get(),
             get(),

--- a/app/src/main/java/com/weatherxm/data/datasource/DevicePhotoDataSource.kt
+++ b/app/src/main/java/com/weatherxm/data/datasource/DevicePhotoDataSource.kt
@@ -1,0 +1,17 @@
+package com.weatherxm.data.datasource
+
+import arrow.core.Either
+import com.weatherxm.data.mapResponse
+import com.weatherxm.data.models.DevicePhoto
+import com.weatherxm.data.models.Failure
+import com.weatherxm.data.network.ApiService
+
+interface DevicePhotoDataSource {
+    suspend fun getDevicePhotos(deviceId: String): Either<Failure, List<DevicePhoto>>
+}
+
+class DevicePhotoDataSourceImpl(private val apiService: ApiService) : DevicePhotoDataSource {
+    override suspend fun getDevicePhotos(deviceId: String): Either<Failure, List<DevicePhoto>> {
+        return apiService.getDevicePhotos(deviceId).mapResponse()
+    }
+}

--- a/app/src/main/java/com/weatherxm/data/models/ApiModels.kt
+++ b/app/src/main/java/com/weatherxm/data/models/ApiModels.kt
@@ -831,6 +831,13 @@ data class DeviceRewardsSummaryDetails(
     }
 }
 
+@Keep
+@JsonClass(generateAdapter = true)
+@Parcelize
+data class DevicePhoto(
+    val url: String
+) : Parcelable
+
 @Suppress("EnumNaming")
 enum class Connectivity {
     wifi,

--- a/app/src/main/java/com/weatherxm/data/network/ApiService.kt
+++ b/app/src/main/java/com/weatherxm/data/network/ApiService.kt
@@ -7,6 +7,7 @@ import com.haroldadmin.cnradapter.NetworkResponse
 import com.weatherxm.data.models.BoostRewardResponse
 import com.weatherxm.data.models.Device
 import com.weatherxm.data.models.DeviceInfo
+import com.weatherxm.data.models.DevicePhoto
 import com.weatherxm.data.models.DeviceRewardsSummary
 import com.weatherxm.data.models.DevicesRewards
 import com.weatherxm.data.models.NetworkSearchResults
@@ -282,4 +283,12 @@ interface ApiService {
         @Path("installationId") installationId: String,
         @Path("fcmToken") fcmToken: String
     ): NetworkResponse<Unit, ErrorResponse>
+
+    @Mock
+    @MockBehavior(durationDeviation = 500, durationMillis = 2000)
+    @MockResponse(code = 200, body = "mock_files/device_photos_list.json")
+    @POST("/api/v1/me/devices/{deviceId}/photos")
+    suspend fun getDevicePhotos(
+        @Path("deviceId") deviceId: String
+    ): NetworkResponse<List<DevicePhoto>, ErrorResponse>
 }

--- a/app/src/main/java/com/weatherxm/data/repository/DevicePhotoRepository.kt
+++ b/app/src/main/java/com/weatherxm/data/repository/DevicePhotoRepository.kt
@@ -1,0 +1,18 @@
+package com.weatherxm.data.repository
+
+import arrow.core.Either
+import com.weatherxm.data.datasource.DevicePhotoDataSource
+import com.weatherxm.data.models.DevicePhoto
+import com.weatherxm.data.models.Failure
+
+interface DevicePhotoRepository {
+    suspend fun getDevicePhotos(deviceId: String): Either<Failure, List<DevicePhoto>>
+}
+
+class DevicePhotoRepositoryImpl(
+    private val datasource: DevicePhotoDataSource
+) : DevicePhotoRepository {
+    override suspend fun getDevicePhotos(deviceId: String): Either<Failure, List<DevicePhoto>> {
+        return datasource.getDevicePhotos(deviceId)
+    }
+}

--- a/app/src/main/java/com/weatherxm/ui/Navigator.kt
+++ b/app/src/main/java/com/weatherxm/ui/Navigator.kt
@@ -522,19 +522,21 @@ class Navigator(private val analytics: AnalyticsWrapper) {
     }
 
     fun showPhotoGallery(
-        context: Context?,
+        activityResultLauncher: ActivityResultLauncher<Intent>?,
+        context: Context,
         device: UIDevice,
         photos: ArrayList<String>,
         fromClaiming: Boolean
     ) {
-        context?.let {
-            it.startActivity(
-                Intent(it, PhotoGalleryActivity::class.java)
-                    .addFlags(Intent.FLAG_ACTIVITY_SINGLE_TOP or Intent.FLAG_ACTIVITY_CLEAR_TOP)
-                    .putExtra(ARG_DEVICE, device)
-                    .putStringArrayListExtra(ARG_PHOTOS, photos)
-                    .putExtra(ARG_FROM_CLAIMING, fromClaiming)
-            )
+        val intent = Intent(context, PhotoGalleryActivity::class.java)
+            .addFlags(Intent.FLAG_ACTIVITY_SINGLE_TOP or Intent.FLAG_ACTIVITY_CLEAR_TOP)
+            .putExtra(ARG_DEVICE, device)
+            .putStringArrayListExtra(ARG_PHOTOS, photos)
+            .putExtra(ARG_FROM_CLAIMING, fromClaiming)
+        if (activityResultLauncher == null) {
+            context.startActivity(intent)
+        } else {
+            activityResultLauncher.launch(intent)
         }
     }
 

--- a/app/src/main/java/com/weatherxm/ui/common/Contracts.kt
+++ b/app/src/main/java/com/weatherxm/ui/common/Contracts.kt
@@ -37,4 +37,5 @@ object Contracts {
     const val ARG_PHOTOS = "photos"
     const val ARG_FROM_CLAIMING = "from_claiming"
     const val FILE_PROVIDER_AUTHORITY = "${BuildConfig.APPLICATION_ID}.fileprovider"
+    const val ARG_DELETE_ALL_PHOTOS = "delete_all_photos"
 }

--- a/app/src/main/java/com/weatherxm/ui/common/UIModels.kt
+++ b/app/src/main/java/com/weatherxm/ui/common/UIModels.kt
@@ -625,10 +625,11 @@ data class PhotoExample(
 
 @Keep
 @JsonClass(generateAdapter = true)
+@Parcelize
 data class StationPhoto(
     val remotePath: String?,
     val localPath: String?
-)
+) : Parcelable
 
 @Keep
 data class WeatherUnit(

--- a/app/src/main/java/com/weatherxm/ui/common/Views.kt
+++ b/app/src/main/java/com/weatherxm/ui/common/Views.kt
@@ -3,6 +3,7 @@
 package com.weatherxm.ui.common
 
 import android.animation.Animator
+import android.annotation.SuppressLint
 import android.app.Activity
 import android.content.Context
 import android.content.Intent
@@ -124,6 +125,24 @@ inline fun <reified T : Parcelable> Bundle.parcelable(key: String): T? =
         BundleCompat.getParcelable(this, key, T::class.java)
     } else {
         @Suppress("DEPRECATION") getParcelable(key) as? T
+    }
+
+inline fun <reified T : Parcelable> Intent.putParcelableList(key: String, data: List<T?>): Intent {
+    val arraylist = arrayListOf<T?>()
+    data.forEach {
+        arraylist.add(it)
+    }
+    putParcelableArrayListExtra(key, arraylist)
+    return this
+}
+
+// https://stackoverflow.com/questions/76614322/boolean-java-lang-class-isinterface-on-a-null-object-reference
+@SuppressLint("NewApi")
+inline fun <reified T : Parcelable> Intent.parcelableList(key: String): ArrayList<T>? =
+    if (AndroidBuildInfo.sdkInt >= TIRAMISU) {
+        getParcelableArrayListExtra(key, T::class.java)
+    } else {
+        @Suppress("DEPRECATION") getParcelableArrayListExtra<T>(key)
     }
 
 /**

--- a/app/src/main/java/com/weatherxm/ui/devicesettings/BaseDeviceSettingsViewModel.kt
+++ b/app/src/main/java/com/weatherxm/ui/devicesettings/BaseDeviceSettingsViewModel.kt
@@ -180,11 +180,11 @@ abstract class BaseDeviceSettingsViewModel(
         }
     }
 
-    fun onPhotosChanged(shouldDeleteAllPhotos: Boolean?, photos: ArrayList<StationPhoto>?) {
+    fun onPhotosChanged(shouldDeleteAllPhotos: Boolean?, photosToDelete: ArrayList<StationPhoto>?) {
         viewModelScope.launch(dispatcher) {
             onLoading.postValue(true)
             if (shouldDeleteAllPhotos == true) {
-                deleteAllPhotos(photos)
+                deleteAllPhotos(photosToDelete)
             } else {
                 getDevicePhotos()
             }

--- a/app/src/main/java/com/weatherxm/ui/devicesettings/BaseDeviceSettingsViewModel.kt
+++ b/app/src/main/java/com/weatherxm/ui/devicesettings/BaseDeviceSettingsViewModel.kt
@@ -11,12 +11,14 @@ import com.weatherxm.analytics.AnalyticsWrapper
 import com.weatherxm.data.models.ApiError
 import com.weatherxm.data.models.BatteryState
 import com.weatherxm.data.models.DeviceInfo
+import com.weatherxm.data.models.DevicePhoto
 import com.weatherxm.ui.common.DeviceAlert
 import com.weatherxm.ui.common.DeviceAlertType
 import com.weatherxm.ui.common.RewardSplitsData
 import com.weatherxm.ui.common.UIDevice
 import com.weatherxm.ui.common.UIError
 import com.weatherxm.ui.common.unmask
+import com.weatherxm.usecases.DevicePhotoUseCase
 import com.weatherxm.usecases.StationSettingsUseCase
 import com.weatherxm.util.Resources
 import kotlinx.coroutines.CoroutineDispatcher
@@ -26,6 +28,7 @@ import timber.log.Timber
 abstract class BaseDeviceSettingsViewModel(
     var device: UIDevice,
     private val usecase: StationSettingsUseCase,
+    private val photosUseCase: DevicePhotoUseCase,
     private val resources: Resources,
     private val analytics: AnalyticsWrapper,
     protected val dispatcher: CoroutineDispatcher
@@ -34,11 +37,13 @@ abstract class BaseDeviceSettingsViewModel(
     private val onDeviceRemoved = MutableLiveData<Boolean>()
     private val onError = MutableLiveData<UIError>()
     protected val onLoading = MutableLiveData<Boolean>()
+    private val onPhotos = MutableLiveData<List<DevicePhoto>>()
 
     fun onEditNameChange(): LiveData<String> = onEditNameChange
     fun onDeviceRemoved(): LiveData<Boolean> = onDeviceRemoved
     fun onError(): LiveData<UIError> = onError
     fun onLoading(): LiveData<Boolean> = onLoading
+    fun onPhotos(): LiveData<List<DevicePhoto>> = onPhotos
 
     fun setOrClearFriendlyName(friendlyName: String?) {
         if (friendlyName == null) {
@@ -161,6 +166,14 @@ abstract class BaseDeviceSettingsViewModel(
                     resources.getString(R.string.battery_level_ok)
                 )
             )
+        }
+    }
+
+    suspend fun getDevicePhotos() {
+        photosUseCase.getDevicePhotos(device.id).onRight {
+            onPhotos.postValue(it)
+        }.onLeft {
+            Timber.e("Error when trying to get device photos: $it")
         }
     }
 

--- a/app/src/main/java/com/weatherxm/ui/devicesettings/BaseDeviceSettingsViewModel.kt
+++ b/app/src/main/java/com/weatherxm/ui/devicesettings/BaseDeviceSettingsViewModel.kt
@@ -173,10 +173,12 @@ abstract class BaseDeviceSettingsViewModel(
     }
 
     suspend fun getDevicePhotos() {
-        photosUseCase.getDevicePhotos(device.id).onRight {
-            onPhotos.postValue(it)
-        }.onLeft {
-            Timber.e("Error when trying to get device photos: $it")
+        if(device.isOwned()) {
+            photosUseCase.getDevicePhotos(device.id).onRight {
+                onPhotos.postValue(it)
+            }.onLeft {
+                Timber.e("Error when trying to get device photos: $it")
+            }
         }
     }
 

--- a/app/src/main/java/com/weatherxm/ui/devicesettings/BaseDeviceSettingsViewModel.kt
+++ b/app/src/main/java/com/weatherxm/ui/devicesettings/BaseDeviceSettingsViewModel.kt
@@ -15,6 +15,7 @@ import com.weatherxm.data.models.DevicePhoto
 import com.weatherxm.ui.common.DeviceAlert
 import com.weatherxm.ui.common.DeviceAlertType
 import com.weatherxm.ui.common.RewardSplitsData
+import com.weatherxm.ui.common.StationPhoto
 import com.weatherxm.ui.common.UIDevice
 import com.weatherxm.ui.common.UIError
 import com.weatherxm.ui.common.unmask
@@ -24,7 +25,9 @@ import com.weatherxm.util.Resources
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.launch
 import timber.log.Timber
+import java.io.File
 
+@Suppress("TooManyFunctions")
 abstract class BaseDeviceSettingsViewModel(
     var device: UIDevice,
     private val usecase: StationSettingsUseCase,
@@ -174,6 +177,29 @@ abstract class BaseDeviceSettingsViewModel(
             onPhotos.postValue(it)
         }.onLeft {
             Timber.e("Error when trying to get device photos: $it")
+        }
+    }
+
+    fun onPhotosChanged(shouldDeleteAllPhotos: Boolean?, photos: ArrayList<StationPhoto>?) {
+        viewModelScope.launch(dispatcher) {
+            onLoading.postValue(true)
+            if (shouldDeleteAllPhotos == true) {
+                deleteAllPhotos(photos)
+            } else {
+                getDevicePhotos()
+            }
+            onLoading.postValue(false)
+        }
+    }
+
+    private fun deleteAllPhotos(photos: ArrayList<StationPhoto>?) {
+        photos?.forEach { photo ->
+            photo.localPath?.let {
+                File(it).delete()
+            }
+            photo.remotePath?.let {
+                // TODO: STOPSHIP: Call the delete endpoint for each one of them
+            }
         }
     }
 

--- a/app/src/main/java/com/weatherxm/ui/devicesettings/DevicePhotosView.kt
+++ b/app/src/main/java/com/weatherxm/ui/devicesettings/DevicePhotosView.kt
@@ -1,0 +1,67 @@
+package com.weatherxm.ui.devicesettings
+
+import android.content.Context
+import android.util.AttributeSet
+import android.view.LayoutInflater
+import android.widget.LinearLayout
+import coil.load
+import com.weatherxm.data.models.DevicePhoto
+import com.weatherxm.databinding.ViewStationSettingsDevicePhotosBinding
+import com.weatherxm.ui.common.visible
+import org.koin.core.component.KoinComponent
+
+open class DevicePhotosView : LinearLayout, KoinComponent {
+
+    private lateinit var binding: ViewStationSettingsDevicePhotosBinding
+
+    constructor(context: Context?) : super(context) {
+        init(context)
+    }
+
+    constructor(context: Context?, attrs: AttributeSet?) : super(context, attrs) {
+        init(context)
+    }
+
+    constructor(context: Context?, attrs: AttributeSet?, defStyleAttr: Int) : super(
+        context,
+        attrs,
+        defStyleAttr
+    ) {
+        init(context)
+    }
+
+    private fun init(context: Context?) {
+        binding = ViewStationSettingsDevicePhotosBinding.inflate(LayoutInflater.from(context), this)
+        orientation = VERTICAL
+    }
+
+    fun setOnClickListener(onClick: () -> Unit) {
+        binding.startPhotoVerificationBtn.setOnClickListener {
+            onClick()
+        }
+        binding.firstPhotoContainer.setOnClickListener {
+            onClick()
+        }
+        binding.secondPhotoContainer.setOnClickListener {
+            onClick()
+        }
+    }
+
+    fun onEmpty() {
+        binding.emptyText.visible(true)
+        binding.startPhotoVerificationBtn.visible(true)
+    }
+
+    fun onPhotos(devicePhotos: List<DevicePhoto>) {
+        binding.emptyText.visible(false)
+        binding.startPhotoVerificationBtn.visible(false)
+        binding.photosText.visible(true)
+
+        if (devicePhotos.size >= 2) {
+            binding.firstPhoto.load(devicePhotos[0].url)
+            binding.secondPhoto.load(devicePhotos[1].url)
+            binding.photosContainer.visible(true)
+            binding.translucentViewOnSecondPhoto.visible(devicePhotos.size > 2)
+        }
+    }
+}

--- a/app/src/main/java/com/weatherxm/ui/devicesettings/DevicePhotosView.kt
+++ b/app/src/main/java/com/weatherxm/ui/devicesettings/DevicePhotosView.kt
@@ -55,9 +55,9 @@ open class DevicePhotosView : LinearLayout, KoinComponent {
                     binding.inProgressText.visible(false)
                     binding.inProgressUploadState.visible(false)
                     onError()
-                    // TODO: Show error card here after onError is implemented
+                    binding.errorCard.visible(true)
                 } else {
-                    // TODO: Hide error card
+                    binding.errorCard.visible(false)
                 }
                 if (it.isSuccess) {
                     onSuccess()
@@ -67,7 +67,7 @@ open class DevicePhotosView : LinearLayout, KoinComponent {
         }
     }
 
-    fun setOnClickListener(onClick: () -> Unit, onCancelUpload: () -> Unit) {
+    fun setOnClickListener(onClick: () -> Unit, onCancelUpload: () -> Unit, onRetry: () -> Unit) {
         binding.startPhotoVerificationBtn.setOnClickListener {
             onClick()
         }
@@ -79,6 +79,9 @@ open class DevicePhotosView : LinearLayout, KoinComponent {
         }
         binding.cancelUploadBtn.setOnClickListener {
             onCancelUpload()
+        }
+        binding.retryBtn.setOnClickListener {
+            onRetry()
         }
     }
 

--- a/app/src/main/java/com/weatherxm/ui/devicesettings/DevicePhotosView.kt
+++ b/app/src/main/java/com/weatherxm/ui/devicesettings/DevicePhotosView.kt
@@ -4,15 +4,20 @@ import android.content.Context
 import android.util.AttributeSet
 import android.view.LayoutInflater
 import android.widget.LinearLayout
+import androidx.compose.runtime.collectAsState
 import coil.load
 import com.weatherxm.data.models.DevicePhoto
 import com.weatherxm.databinding.ViewStationSettingsDevicePhotosBinding
+import com.weatherxm.service.GlobalUploadObserverService
 import com.weatherxm.ui.common.visible
+import com.weatherxm.ui.components.PhotoUploadState
 import org.koin.core.component.KoinComponent
+import org.koin.core.component.inject
 
 open class DevicePhotosView : LinearLayout, KoinComponent {
 
     private lateinit var binding: ViewStationSettingsDevicePhotosBinding
+    private val uploadObserverService: GlobalUploadObserverService by inject()
 
     constructor(context: Context?) : super(context) {
         init(context)
@@ -35,7 +40,34 @@ open class DevicePhotosView : LinearLayout, KoinComponent {
         orientation = VERTICAL
     }
 
-    fun setOnClickListener(onClick: () -> Unit) {
+    fun initProgressView(onError: () -> Unit, onSuccess: () -> Unit) {
+        binding.inProgressUploadState.setContent {
+            uploadObserverService.getUploadPhotosState().collectAsState(null).value?.let {
+                binding.photosText.visible(false)
+                binding.photosContainer.visible(false)
+                binding.emptyText.visible(false)
+                binding.startPhotoVerificationBtn.visible(false)
+                binding.cancelUploadBtn.visible(!it.isSuccess && it.error == null)
+                binding.inProgressText.visible(true)
+                binding.inProgressUploadState.visible(true)
+
+                if (it.error != null) {
+                    binding.inProgressText.visible(false)
+                    binding.inProgressUploadState.visible(false)
+                    onError()
+                    // TODO: Show error card here after onError is implemented
+                } else {
+                    // TODO: Hide error card
+                }
+                if (it.isSuccess) {
+                    onSuccess()
+                }
+                PhotoUploadState(it, false)
+            }
+        }
+    }
+
+    fun setOnClickListener(onClick: () -> Unit, onCancelUpload: () -> Unit) {
         binding.startPhotoVerificationBtn.setOnClickListener {
             onClick()
         }
@@ -45,16 +77,31 @@ open class DevicePhotosView : LinearLayout, KoinComponent {
         binding.secondPhotoContainer.setOnClickListener {
             onClick()
         }
+        binding.cancelUploadBtn.setOnClickListener {
+            onCancelUpload()
+        }
     }
 
-    fun onEmpty() {
+    fun updateUI(devicePhotos: List<DevicePhoto>) {
+        if (devicePhotos.isEmpty()) {
+            onEmpty()
+        } else {
+            onPhotos(devicePhotos)
+        }
+    }
+
+    private fun onEmpty() {
+        binding.inProgressText.visible(false)
+        binding.inProgressUploadState.visible(false)
         binding.emptyText.visible(true)
         binding.startPhotoVerificationBtn.visible(true)
     }
 
-    fun onPhotos(devicePhotos: List<DevicePhoto>) {
+    private fun onPhotos(devicePhotos: List<DevicePhoto>) {
         binding.emptyText.visible(false)
         binding.startPhotoVerificationBtn.visible(false)
+        binding.inProgressText.visible(false)
+        binding.inProgressUploadState.visible(false)
         binding.photosText.visible(true)
 
         if (devicePhotos.size >= 2) {

--- a/app/src/main/java/com/weatherxm/ui/devicesettings/helium/DeviceSettingsHeliumActivity.kt
+++ b/app/src/main/java/com/weatherxm/ui/devicesettings/helium/DeviceSettingsHeliumActivity.kt
@@ -144,7 +144,7 @@ class DeviceSettingsHeliumActivity : BaseActivity() {
             onError = {
                 // Trigger a refresh on the photos through the API
                 model.onPhotosChanged(false, null)
-                // TODO: Trigger retry mechanism
+                // TODO: STOPSHIP:  Trigger retry mechanism
             },
             onSuccess = {
                 // Trigger a refresh on the photos through the API
@@ -175,10 +175,13 @@ class DeviceSettingsHeliumActivity : BaseActivity() {
                     .onPositiveClick(getString(R.string.yes_cancel)) {
                         // Trigger a refresh on the photos through the API
                         model.onPhotosChanged(false, null)
-                        // TODO: Cancel the current upload
+                        // TODO: STOPSHIP:  Cancel the current upload
                     }
                     .build()
                     .show(this)
+            },
+            onRetry = {
+                // TODO: STOPSHIP:  Trigger retry mechanism
             }
         )
 

--- a/app/src/main/java/com/weatherxm/ui/devicesettings/helium/DeviceSettingsHeliumActivity.kt
+++ b/app/src/main/java/com/weatherxm/ui/devicesettings/helium/DeviceSettingsHeliumActivity.kt
@@ -9,11 +9,13 @@ import com.weatherxm.R
 import com.weatherxm.analytics.AnalyticsService
 import com.weatherxm.data.models.DevicePhoto
 import com.weatherxm.databinding.ActivityDeviceSettingsHeliumBinding
+import com.weatherxm.ui.common.Contracts
 import com.weatherxm.ui.common.Contracts.ARG_DEVICE
 import com.weatherxm.ui.common.DeviceAlertType
 import com.weatherxm.ui.common.DeviceRelation
 import com.weatherxm.ui.common.RewardSplitStakeholderAdapter
 import com.weatherxm.ui.common.RewardSplitsData
+import com.weatherxm.ui.common.StationPhoto
 import com.weatherxm.ui.common.UIDevice
 import com.weatherxm.ui.common.applyOnGlobalLayout
 import com.weatherxm.ui.common.classSimpleName
@@ -21,6 +23,7 @@ import com.weatherxm.ui.common.empty
 import com.weatherxm.ui.common.invisible
 import com.weatherxm.ui.common.loadImage
 import com.weatherxm.ui.common.parcelable
+import com.weatherxm.ui.common.parcelableList
 import com.weatherxm.ui.common.setHtml
 import com.weatherxm.ui.common.toast
 import com.weatherxm.ui.common.visible
@@ -48,6 +51,21 @@ class DeviceSettingsHeliumActivity : BaseActivity() {
             if (it.resultCode == Activity.RESULT_OK && device != null) {
                 model.device = device
                 setupStationLocation(true)
+            }
+        }
+
+    // Register the launcher for the photo gallery activity and wait for a possible result
+    private val photoGalleryLauncher =
+        registerForActivityResult(ActivityResultContracts.StartActivityForResult()) {
+            /**
+             * Some changes happened in the photos so we need to fetch them again or delete all of
+             * them if the user left the screen with <2 photos left.
+             */
+            val shouldDeleteAllPhotos =
+                it.data?.getBooleanExtra(Contracts.ARG_DELETE_ALL_PHOTOS, false)
+            val photos = it.data?.parcelableList<StationPhoto>(Contracts.ARG_PHOTOS)
+            if (it.resultCode == Activity.RESULT_OK) {
+                model.onPhotosChanged(shouldDeleteAllPhotos, photos)
             }
         }
 
@@ -135,7 +153,7 @@ class DeviceSettingsHeliumActivity : BaseActivity() {
             devicePhotos.forEach {
                 photos.add(it.url)
             }
-            navigator.showPhotoGallery(this, model.device, photos, false)
+            navigator.showPhotoGallery(photoGalleryLauncher, this, model.device, photos, false)
         }
         binding.devicePhotosCard.visible(true)
     }

--- a/app/src/main/java/com/weatherxm/ui/devicesettings/helium/DeviceSettingsHeliumActivity.kt
+++ b/app/src/main/java/com/weatherxm/ui/devicesettings/helium/DeviceSettingsHeliumActivity.kt
@@ -7,6 +7,7 @@ import coil.ImageLoader
 import com.google.firebase.analytics.FirebaseAnalytics
 import com.weatherxm.R
 import com.weatherxm.analytics.AnalyticsService
+import com.weatherxm.data.models.DevicePhoto
 import com.weatherxm.databinding.ActivityDeviceSettingsHeliumBinding
 import com.weatherxm.ui.common.Contracts.ARG_DEVICE
 import com.weatherxm.ui.common.DeviceAlertType
@@ -92,6 +93,10 @@ class DeviceSettingsHeliumActivity : BaseActivity() {
             finish()
         }
 
+        model.onPhotos().observe(this) {
+            onPhotos(it)
+        }
+
         binding.changeStationNameBtn.setOnClickListener {
             onChangeStationName()
         }
@@ -117,6 +122,22 @@ class DeviceSettingsHeliumActivity : BaseActivity() {
         }
 
         setupStationLocation()
+    }
+
+    private fun onPhotos(devicePhotos: List<DevicePhoto>) {
+        if (devicePhotos.isEmpty()) {
+            binding.devicePhotosCard.onEmpty()
+        } else {
+            binding.devicePhotosCard.onPhotos(devicePhotos)
+        }
+        binding.devicePhotosCard.setOnClickListener {
+            val photos = arrayListOf<String>()
+            devicePhotos.forEach {
+                photos.add(it.url)
+            }
+            navigator.showPhotoGallery(this, model.device, photos, false)
+        }
+        binding.devicePhotosCard.visible(true)
     }
 
     private fun setupRecyclers() {

--- a/app/src/main/java/com/weatherxm/ui/devicesettings/helium/DeviceSettingsHeliumActivity.kt
+++ b/app/src/main/java/com/weatherxm/ui/devicesettings/helium/DeviceSettingsHeliumActivity.kt
@@ -27,6 +27,7 @@ import com.weatherxm.ui.common.parcelableList
 import com.weatherxm.ui.common.setHtml
 import com.weatherxm.ui.common.toast
 import com.weatherxm.ui.common.visible
+import com.weatherxm.ui.components.ActionDialogFragment
 import com.weatherxm.ui.components.BaseActivity
 import com.weatherxm.ui.devicesettings.DeviceInfoItemAdapter
 import com.weatherxm.ui.devicesettings.FriendlyNameDialogFragment
@@ -139,22 +140,48 @@ class DeviceSettingsHeliumActivity : BaseActivity() {
             binding.contactSupportBtn.text = getString(R.string.see_something_wrong_contact_support)
         }
 
+        binding.devicePhotosCard.initProgressView(
+            onError = {
+                // Trigger a refresh on the photos through the API
+                model.onPhotosChanged(false, null)
+                // TODO: Trigger retry mechanism
+            },
+            onSuccess = {
+                // Trigger a refresh on the photos through the API
+                model.onPhotosChanged(false, null)
+            }
+        )
+
         setupStationLocation()
     }
 
     private fun onPhotos(devicePhotos: List<DevicePhoto>) {
-        if (devicePhotos.isEmpty()) {
-            binding.devicePhotosCard.onEmpty()
-        } else {
-            binding.devicePhotosCard.onPhotos(devicePhotos)
-        }
-        binding.devicePhotosCard.setOnClickListener {
-            val photos = arrayListOf<String>()
-            devicePhotos.forEach {
-                photos.add(it.url)
+        binding.devicePhotosCard.updateUI(devicePhotos)
+        binding.devicePhotosCard.setOnClickListener(
+            onClick = {
+                val photos = arrayListOf<String>()
+                devicePhotos.forEach {
+                    photos.add(it.url)
+                }
+                navigator.showPhotoGallery(photoGalleryLauncher, this, model.device, photos, false)
+            },
+            onCancelUpload = {
+                ActionDialogFragment
+                    .Builder(
+                        title = getString(R.string.cancel_upload),
+                        message = getString(R.string.cancel_upload_message),
+                        negative = getString(R.string.action_back)
+                    )
+                    .onPositiveClick(getString(R.string.yes_cancel)) {
+                        // Trigger a refresh on the photos through the API
+                        model.onPhotosChanged(false, null)
+                        // TODO: Cancel the current upload
+                    }
+                    .build()
+                    .show(this)
             }
-            navigator.showPhotoGallery(photoGalleryLauncher, this, model.device, photos, false)
-        }
+        )
+
         binding.devicePhotosCard.visible(true)
     }
 

--- a/app/src/main/java/com/weatherxm/ui/devicesettings/helium/DeviceSettingsHeliumViewModel.kt
+++ b/app/src/main/java/com/weatherxm/ui/devicesettings/helium/DeviceSettingsHeliumViewModel.kt
@@ -18,6 +18,7 @@ import com.weatherxm.ui.devicesettings.BaseDeviceSettingsViewModel
 import com.weatherxm.ui.devicesettings.UIDeviceInfo
 import com.weatherxm.ui.devicesettings.UIDeviceInfoItem
 import com.weatherxm.usecases.AuthUseCase
+import com.weatherxm.usecases.DevicePhotoUseCase
 import com.weatherxm.usecases.StationSettingsUseCase
 import com.weatherxm.usecases.UserUseCase
 import com.weatherxm.util.DateTimeHelper.getFormattedDateAndTime
@@ -32,12 +33,13 @@ import timber.log.Timber
 class DeviceSettingsHeliumViewModel(
     device: UIDevice,
     private val usecase: StationSettingsUseCase,
+    private val photosUseCase: DevicePhotoUseCase,
     private val userUseCase: UserUseCase,
     private val authUseCase: AuthUseCase,
     private val resources: Resources,
     private val analytics: AnalyticsWrapper,
     dispatcher: CoroutineDispatcher = Dispatchers.IO
-) : BaseDeviceSettingsViewModel(device, usecase, resources, analytics, dispatcher) {
+) : BaseDeviceSettingsViewModel(device, usecase, photosUseCase, resources, analytics, dispatcher) {
     private val onDeviceInfo = MutableLiveData<UIDeviceInfo>()
 
     private lateinit var data: UIDeviceInfo
@@ -75,6 +77,7 @@ class DeviceSettingsHeliumViewModel(
                 handleInfo(context, info)
                 onDeviceInfo.postValue(data)
             }
+            super.getDevicePhotos()
             onLoading.postValue(false)
         }
     }

--- a/app/src/main/java/com/weatherxm/ui/devicesettings/wifi/DeviceSettingsWifiActivity.kt
+++ b/app/src/main/java/com/weatherxm/ui/devicesettings/wifi/DeviceSettingsWifiActivity.kt
@@ -139,7 +139,7 @@ class DeviceSettingsWifiActivity : BaseActivity() {
             onError = {
                 // Trigger a refresh on the photos through the API
                 model.onPhotosChanged(false, null)
-                // TODO: Trigger retry mechanism
+                // TODO: STOPSHIP:  Trigger retry mechanism
             },
             onSuccess = {
                 // Trigger a refresh on the photos through the API
@@ -170,10 +170,13 @@ class DeviceSettingsWifiActivity : BaseActivity() {
                     .onPositiveClick(getString(R.string.yes_cancel)) {
                         // Trigger a refresh on the photos through the API
                         model.onPhotosChanged(false, null)
-                        // TODO: Cancel the current upload
+                        // TODO: STOPSHIP: Cancel the current upload
                     }
                     .build()
                     .show(this)
+            },
+            onRetry = {
+                // TODO: STOPSHIP:  Trigger retry mechanism
             }
         )
         binding.devicePhotosCard.visible(true)

--- a/app/src/main/java/com/weatherxm/ui/devicesettings/wifi/DeviceSettingsWifiActivity.kt
+++ b/app/src/main/java/com/weatherxm/ui/devicesettings/wifi/DeviceSettingsWifiActivity.kt
@@ -11,17 +11,20 @@ import com.weatherxm.analytics.AnalyticsService
 import com.weatherxm.data.models.DevicePhoto
 import com.weatherxm.databinding.ActivityDeviceSettingsWifiBinding
 import com.weatherxm.ui.common.BundleName
+import com.weatherxm.ui.common.Contracts
 import com.weatherxm.ui.common.Contracts.ARG_DEVICE
 import com.weatherxm.ui.common.DeviceAlertType
 import com.weatherxm.ui.common.DeviceRelation
 import com.weatherxm.ui.common.RewardSplitStakeholderAdapter
 import com.weatherxm.ui.common.RewardSplitsData
+import com.weatherxm.ui.common.StationPhoto
 import com.weatherxm.ui.common.UIDevice
 import com.weatherxm.ui.common.applyOnGlobalLayout
 import com.weatherxm.ui.common.classSimpleName
 import com.weatherxm.ui.common.empty
 import com.weatherxm.ui.common.loadImage
 import com.weatherxm.ui.common.parcelable
+import com.weatherxm.ui.common.parcelableList
 import com.weatherxm.ui.common.setHtml
 import com.weatherxm.ui.common.toast
 import com.weatherxm.ui.common.visible
@@ -51,6 +54,21 @@ class DeviceSettingsWifiActivity : BaseActivity() {
             if (it.resultCode == Activity.RESULT_OK && device != null) {
                 model.device = device
                 setupStationLocation(true)
+            }
+        }
+
+    // Register the launcher for the photo gallery activity and wait for a possible result
+    private val photoGalleryLauncher =
+        registerForActivityResult(ActivityResultContracts.StartActivityForResult()) {
+            /**
+             * Some changes happened in the photos so we need to fetch them again or delete all of
+             * them if the user left the screen with <2 photos left.
+             */
+            val shouldDeleteAllPhotos =
+                it.data?.getBooleanExtra(Contracts.ARG_DELETE_ALL_PHOTOS, false)
+            val photos = it.data?.parcelableList<StationPhoto>(Contracts.ARG_PHOTOS)
+            if (it.resultCode == Activity.RESULT_OK) {
+                model.onPhotosChanged(shouldDeleteAllPhotos, photos)
             }
         }
 
@@ -130,7 +148,7 @@ class DeviceSettingsWifiActivity : BaseActivity() {
             devicePhotos.forEach {
                 photos.add(it.url)
             }
-            navigator.showPhotoGallery(this, model.device, photos, false)
+            navigator.showPhotoGallery(photoGalleryLauncher, this, model.device, photos, false)
         }
         binding.devicePhotosCard.visible(true)
     }

--- a/app/src/main/java/com/weatherxm/ui/devicesettings/wifi/DeviceSettingsWifiActivity.kt
+++ b/app/src/main/java/com/weatherxm/ui/devicesettings/wifi/DeviceSettingsWifiActivity.kt
@@ -8,6 +8,7 @@ import coil.ImageLoader
 import com.google.firebase.analytics.FirebaseAnalytics
 import com.weatherxm.R
 import com.weatherxm.analytics.AnalyticsService
+import com.weatherxm.data.models.DevicePhoto
 import com.weatherxm.databinding.ActivityDeviceSettingsWifiBinding
 import com.weatherxm.ui.common.BundleName
 import com.weatherxm.ui.common.Contracts.ARG_DEVICE
@@ -95,6 +96,10 @@ class DeviceSettingsWifiActivity : BaseActivity() {
             finish()
         }
 
+        model.onPhotos().observe(this) {
+            onPhotos(it)
+        }
+
         binding.changeStationNameBtn.setOnClickListener {
             onChangeStationName()
         }
@@ -112,6 +117,22 @@ class DeviceSettingsWifiActivity : BaseActivity() {
         }
 
         setupStationLocation()
+    }
+
+    private fun onPhotos(devicePhotos: List<DevicePhoto>) {
+        if (devicePhotos.isEmpty()) {
+            binding.devicePhotosCard.onEmpty()
+        } else {
+            binding.devicePhotosCard.onPhotos(devicePhotos)
+        }
+        binding.devicePhotosCard.setOnClickListener {
+            val photos = arrayListOf<String>()
+            devicePhotos.forEach {
+                photos.add(it.url)
+            }
+            navigator.showPhotoGallery(this, model.device, photos, false)
+        }
+        binding.devicePhotosCard.visible(true)
     }
 
     private fun setupRecyclers() {

--- a/app/src/main/java/com/weatherxm/ui/devicesettings/wifi/DeviceSettingsWifiViewModel.kt
+++ b/app/src/main/java/com/weatherxm/ui/devicesettings/wifi/DeviceSettingsWifiViewModel.kt
@@ -19,6 +19,7 @@ import com.weatherxm.ui.devicesettings.BaseDeviceSettingsViewModel
 import com.weatherxm.ui.devicesettings.UIDeviceInfo
 import com.weatherxm.ui.devicesettings.UIDeviceInfoItem
 import com.weatherxm.usecases.AuthUseCase
+import com.weatherxm.usecases.DevicePhotoUseCase
 import com.weatherxm.usecases.StationSettingsUseCase
 import com.weatherxm.usecases.UserUseCase
 import com.weatherxm.util.DateTimeHelper.getFormattedDateAndTime
@@ -33,12 +34,13 @@ import timber.log.Timber
 class DeviceSettingsWifiViewModel(
     device: UIDevice,
     private val usecase: StationSettingsUseCase,
+    private val photosUseCase: DevicePhotoUseCase,
     private val userUseCase: UserUseCase,
     private val authUseCase: AuthUseCase,
     private val resources: Resources,
     private val analytics: AnalyticsWrapper,
     dispatcher: CoroutineDispatcher = Dispatchers.IO
-) : BaseDeviceSettingsViewModel(device, usecase, resources, analytics, dispatcher) {
+) : BaseDeviceSettingsViewModel(device, usecase, photosUseCase, resources, analytics, dispatcher) {
     private val onDeviceInfo = MutableLiveData<UIDeviceInfo>()
 
     private lateinit var data: UIDeviceInfo
@@ -74,6 +76,7 @@ class DeviceSettingsWifiViewModel(
                 handleInfo(context, info)
                 onDeviceInfo.postValue(data)
             }
+            super.getDevicePhotos()
             onLoading.postValue(false)
         }
     }

--- a/app/src/main/java/com/weatherxm/ui/home/devices/DevicesFragment.kt
+++ b/app/src/main/java/com/weatherxm/ui/home/devices/DevicesFragment.kt
@@ -146,39 +146,38 @@ class DevicesFragment : BaseFragment(), DeviceListener {
 
     private fun initAndObserveUploadState() {
         binding.uploadStateView.setContent {
-            val uploadState = uploadObserverService.getUploadPhotosState().collectAsState(null)
-            binding.uploadStateContainer.visible(uploadState.value != null)
+            val uploadState =
+                uploadObserverService.getUploadPhotosState().collectAsState(null).value
+            binding.uploadStateContainer.visible(uploadState != null)
 
-            binding.uploadAnimation.visible(uploadState.value?.error == null)
-            binding.uploadRetryIcon.visible(uploadState.value?.error != null)
+            binding.uploadAnimation.visible(uploadState?.error == null)
+            binding.uploadRetryIcon.visible(uploadState?.error != null)
 
-            if (uploadState.value?.error != null) {
+            if (uploadState?.error != null) {
                 binding.uploadStateCard.swipeToDismiss {
                     binding.uploadStateContainer.visible(false)
-                    deleteAllStationPhotos(context, uploadState.value?.device)
+                    deleteAllStationPhotos(context, uploadState?.device)
                 }
                 binding.uploadStateCard.setOnClickListener {
                     // TODO: STOPSHIP: Invoke retry mechanism
                 }
-            } else if (uploadState.value?.isSuccess == true) {
+            } else if (uploadState?.isSuccess == true) {
                 removeUploadStateOnPause = true
                 binding.uploadStateCard.swipeToDismiss {
                     binding.uploadStateContainer.visible(false)
                 }
-                uploadState.value?.device?.let { device ->
-                    binding.uploadStateCard.setOnClickListener {
-                        navigator.showStationSettings(context, device)
-                        binding.uploadStateContainer.visible(false)
-                    }
+                binding.uploadStateCard.setOnClickListener {
+                    navigator.showStationSettings(context, uploadState.device)
+                    binding.uploadStateContainer.visible(false)
                 }
                 binding.uploadAnimation.setAnimation(R.raw.anim_upload_success)
                 binding.uploadAnimation.repeatCount = 0
-            } else if (uploadState.value?.progress == 0) {
+            } else if (uploadState?.progress == 0) {
                 binding.uploadAnimation.setAnimation(R.raw.anim_uploading)
                 binding.uploadAnimation.repeatCount = INFINITE
             }
 
-            uploadState.value?.let {
+            uploadState?.let {
                 PhotoUploadState(it, true)
             }
         }

--- a/app/src/main/java/com/weatherxm/ui/home/devices/DevicesFragment.kt
+++ b/app/src/main/java/com/weatherxm/ui/home/devices/DevicesFragment.kt
@@ -158,7 +158,7 @@ class DevicesFragment : BaseFragment(), DeviceListener {
                     deleteAllStationPhotos(context, uploadState.value?.device)
                 }
                 binding.uploadStateCard.setOnClickListener {
-                    // TODO: Invoke retry mechanism
+                    // TODO: STOPSHIP: Invoke retry mechanism
                 }
             } else if (uploadState.value?.isSuccess == true) {
                 removeUploadStateOnPause = true

--- a/app/src/main/java/com/weatherxm/ui/photoverification/gallery/PhotoGalleryActivity.kt
+++ b/app/src/main/java/com/weatherxm/ui/photoverification/gallery/PhotoGalleryActivity.kt
@@ -64,9 +64,10 @@ class PhotoGalleryActivity : BaseActivity() {
     private lateinit var binding: ActivityPhotoGalleryBinding
 
     private val model: PhotoGalleryViewModel by viewModel {
+        val stationPhotoUrls = intent.getStringArrayListExtra(Contracts.ARG_PHOTOS) ?: arrayListOf()
         parametersOf(
             intent.parcelable<UIDevice>(ARG_DEVICE) ?: UIDevice.empty(),
-            intent.getStringArrayListExtra(Contracts.ARG_PHOTOS),
+            stationPhotoUrls.map { StationPhoto(it, null) },
             intent.getBooleanExtra(ARG_FROM_CLAIMING, false)
         )
     }
@@ -112,6 +113,7 @@ class PhotoGalleryActivity : BaseActivity() {
         } else {
             binding.toolbar.setNavigationIcon(R.drawable.ic_back)
             binding.toolbar.setNavigationOnClickListener {
+                // TODO: Handle when to show this. And delete all if <2.
                 ActionDialogFragment
                     .Builder(
                         title = getString(R.string.exit_photo_verification),

--- a/app/src/main/java/com/weatherxm/ui/photoverification/gallery/PhotoGalleryActivity.kt
+++ b/app/src/main/java/com/weatherxm/ui/photoverification/gallery/PhotoGalleryActivity.kt
@@ -2,9 +2,11 @@ package com.weatherxm.ui.photoverification.gallery
 
 import android.Manifest.permission.CAMERA
 import android.annotation.SuppressLint
+import android.content.Intent
 import android.graphics.BitmapFactory
 import android.os.Bundle
 import android.os.Environment
+import androidx.activity.addCallback
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.clickable
@@ -38,6 +40,7 @@ import com.weatherxm.ui.common.disable
 import com.weatherxm.ui.common.empty
 import com.weatherxm.ui.common.enable
 import com.weatherxm.ui.common.parcelable
+import com.weatherxm.ui.common.putParcelableList
 import com.weatherxm.ui.common.setHtml
 import com.weatherxm.ui.common.visible
 import com.weatherxm.ui.components.ActionDialogFragment
@@ -97,35 +100,16 @@ class PhotoGalleryActivity : BaseActivity() {
 
         if (model.fromClaiming) {
             binding.toolbar.setNavigationIcon(R.drawable.ic_close)
-            binding.toolbar.setNavigationOnClickListener {
-                ActionDialogFragment
-                    .Builder(
-                        title = getString(R.string.exit_photo_verification),
-                        message = getString(R.string.exit_photo_verification_message),
-                        negative = getString(R.string.action_back)
-                    )
-                    .onPositiveClick(getString(R.string.action_exit)) {
-                        finish()
-                    }
-                    .build()
-                    .show(this)
-            }
         } else {
             binding.toolbar.setNavigationIcon(R.drawable.ic_back)
-            binding.toolbar.setNavigationOnClickListener {
-                // TODO: Handle when to show this. And delete all if <2.
-                ActionDialogFragment
-                    .Builder(
-                        title = getString(R.string.exit_photo_verification),
-                        message = getString(R.string.exit_photo_verification_start_over),
-                        negative = getString(R.string.action_back)
-                    )
-                    .onPositiveClick(getString(R.string.action_exit)) {
-                        finish()
-                    }
-                    .build()
-                    .show(this)
-            }
+        }
+
+        binding.toolbar.setNavigationOnClickListener {
+            onBackPressedDispatcher.onBackPressed()
+        }
+
+        onBackPressedDispatcher.addCallback {
+            onExit()
         }
 
         binding.uploadBtn.setOnClickListener {
@@ -166,6 +150,7 @@ class PhotoGalleryActivity : BaseActivity() {
                     }
                     uploadObserverService.setDevice(model.device)
                     uploadRequest.startUpload()
+                    setResult(false)
                     finish()
                 }
                 .build()
@@ -205,6 +190,46 @@ class PhotoGalleryActivity : BaseActivity() {
         super.onResume()
     }
 
+    private fun onExit() {
+        if (model.fromClaiming) {
+            ActionDialogFragment
+                .Builder(
+                    title = getString(R.string.exit_photo_verification),
+                    message = getString(R.string.exit_photo_verification_message),
+                    negative = getString(R.string.action_back)
+                )
+                .onPositiveClick(getString(R.string.action_exit)) {
+                    finish()
+                }
+                .build()
+                .show(this)
+        } else {
+            if (model.photos.size < 2) {
+                ActionDialogFragment
+                    .Builder(
+                        title = getString(R.string.exit_photo_verification),
+                        message = getString(R.string.exit_photo_verification_start_over),
+                        negative = getString(R.string.action_back)
+                    )
+                    .onPositiveClick(getString(R.string.action_exit)) {
+                        setResult(true)
+                        finish()
+                    }
+                    .build()
+                    .show(this)
+            } else {
+                finish()
+            }
+        }
+    }
+
+    private fun setResult(shouldDeleteAll: Boolean) {
+        val intent = Intent()
+            .putExtra(Contracts.ARG_DELETE_ALL_PHOTOS, shouldDeleteAll)
+            .putParcelableList(Contracts.ARG_PHOTOS, model.photos)
+        setResult(RESULT_OK, intent)
+    }
+
     private fun onPhotosNumber(photosNumber: Int) {
         binding.addPhotoBtn.visible(photosNumber < MAX_PHOTOS)
         binding.uploadBtn.isEnabled = photosNumber >= MIN_PHOTOS
@@ -235,6 +260,7 @@ class PhotoGalleryActivity : BaseActivity() {
                         negative = getString(R.string.action_back)
                     )
                     .onPositiveClick(getString(R.string.action_delete)) {
+                        setResult(false)
                         model.deletePhoto(it)
                         selectedPhoto.value = null
                     }

--- a/app/src/main/java/com/weatherxm/ui/photoverification/gallery/PhotoGalleryActivity.kt
+++ b/app/src/main/java/com/weatherxm/ui/photoverification/gallery/PhotoGalleryActivity.kt
@@ -275,12 +275,14 @@ class PhotoGalleryActivity : BaseActivity() {
 
     @Suppress("MagicNumber")
     private fun onCameraDenied() {
-        binding.deletePhotoBtn.disable()
-        binding.instructionsBtn.alpha = 0.4F
-        binding.instructionsBtn.isEnabled = false
-        binding.addPhotoBtn.disable()
-        binding.emptyPhotosText.visible(false)
-        binding.permissionsContainer.visible(true)
+        if(model.photos.isEmpty()) {
+            binding.deletePhotoBtn.disable()
+            binding.instructionsBtn.alpha = 0.4F
+            binding.instructionsBtn.isEnabled = false
+            binding.addPhotoBtn.disable()
+            binding.emptyPhotosText.visible(false)
+            binding.permissionsContainer.visible(true)
+        }
     }
 
     private fun onPermissionsGivenFromSettings() {

--- a/app/src/main/java/com/weatherxm/ui/photoverification/gallery/PhotoGalleryViewModel.kt
+++ b/app/src/main/java/com/weatherxm/ui/photoverification/gallery/PhotoGalleryViewModel.kt
@@ -9,12 +9,15 @@ import androidx.lifecycle.ViewModel
 import com.weatherxm.ui.common.StationPhoto
 import com.weatherxm.ui.common.UIDevice
 import com.weatherxm.util.ImageFileHelper.getUriForFile
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.Dispatchers
 import java.io.File
 
 class PhotoGalleryViewModel(
     val device: UIDevice,
     val photos: MutableList<StationPhoto>,
-    val fromClaiming: Boolean
+    val fromClaiming: Boolean,
+    val dispatcher: CoroutineDispatcher = Dispatchers.IO
 ) : ViewModel() {
     private val onPhotosNumber = MutableLiveData(photos.size)
     private val _onPhotos = mutableStateListOf<StationPhoto>().apply {
@@ -35,7 +38,7 @@ class PhotoGalleryViewModel(
 
     fun deletePhoto(photo: StationPhoto) {
         if (photos.firstOrNull { it.remotePath == photo.remotePath } != null) {
-            // TODO: Call the delete endpoint and post the new state on success
+            // TODO: STOPSHIP: Call the delete endpoint and post the new state on success
             photos.remove(photo)
             _onPhotos.remove(photo)
             onPhotosNumber.postValue(photos.size)

--- a/app/src/main/java/com/weatherxm/ui/photoverification/intro/PhotoVerificationIntroActivity.kt
+++ b/app/src/main/java/com/weatherxm/ui/photoverification/intro/PhotoVerificationIntroActivity.kt
@@ -51,6 +51,7 @@ class PhotoVerificationIntroActivity : BaseActivity() {
                     },
                     onTakePhoto = {
                         navigator.showPhotoGallery(
+                            null,
                             this@PhotoVerificationIntroActivity,
                             device,
                             arrayListOf(),

--- a/app/src/main/java/com/weatherxm/usecases/DevicePhotoUseCase.kt
+++ b/app/src/main/java/com/weatherxm/usecases/DevicePhotoUseCase.kt
@@ -1,0 +1,18 @@
+package com.weatherxm.usecases
+
+import arrow.core.Either
+import com.weatherxm.data.models.DevicePhoto
+import com.weatherxm.data.models.Failure
+import com.weatherxm.data.repository.DevicePhotoRepository
+
+interface DevicePhotoUseCase {
+    suspend fun getDevicePhotos(deviceId: String): Either<Failure, List<DevicePhoto>>
+}
+
+class DevicePhotoUseCaseImpl(
+    private val repository: DevicePhotoRepository
+) : DevicePhotoUseCase {
+    override suspend fun getDevicePhotos(deviceId: String): Either<Failure, List<DevicePhoto>> {
+        return repository.getDevicePhotos(deviceId)
+    }
+}

--- a/app/src/main/java/com/weatherxm/usecases/StationSettingsUseCaseImpl.kt
+++ b/app/src/main/java/com/weatherxm/usecases/StationSettingsUseCaseImpl.kt
@@ -13,7 +13,7 @@ import com.weatherxm.ui.common.UIDevice
 class StationSettingsUseCaseImpl(
     private val deviceRepository: DeviceRepository,
     private val deviceOTARepository: DeviceOTARepository,
-    private val addressRepository: AddressRepository
+    private val addressRepository: AddressRepository,
 ) : StationSettingsUseCase {
 
     override suspend fun setFriendlyName(

--- a/app/src/main/res/drawable/ic_new.xml
+++ b/app/src/main/res/drawable/ic_new.xml
@@ -1,0 +1,15 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="21dp"
+    android:height="7dp"
+    android:viewportWidth="21"
+    android:viewportHeight="7">
+  <path
+      android:pathData="M5.887,0V7H4.397L1.49,2.308V7H0V0H1.49L4.402,4.697V0H5.887Z"
+      android:fillColor="#B8C6FF"/>
+  <path
+      android:pathData="M12.038,5.875V7H8.187V5.875H12.038ZM8.674,0V7H7.184V0H8.674ZM11.536,2.851V3.947H8.187V2.851H11.536ZM12.033,0V1.13H8.187V0H12.033Z"
+      android:fillColor="#B8C6FF"/>
+  <path
+      android:pathData="M14.651,5.889L16.092,0H16.896L17.08,0.981L15.545,7H14.681L14.651,5.889ZM13.911,0L15.103,5.889L15.003,7H14.04L12.435,0H13.911ZM18.347,5.865L19.524,0H21L19.4,7H18.437L18.347,5.865ZM17.348,0L18.799,5.913L18.759,7H17.895L16.35,0.976L16.549,0H17.348Z"
+      android:fillColor="#B8C6FF"/>
+</vector>

--- a/app/src/main/res/layout/activity_device_settings_helium.xml
+++ b/app/src/main/res/layout/activity_device_settings_helium.xml
@@ -164,13 +164,22 @@
 
             </com.google.android.material.card.MaterialCardView>
 
+            <com.weatherxm.ui.devicesettings.DevicePhotosView
+                android:id="@+id/devicePhotosCard"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_margin="@dimen/margin_normal"
+                android:visibility="gone"
+                app:layout_constraintTop_toBottomOf="@id/basicActionsCard"
+                tools:visibility="visible" />
+
             <com.google.android.material.card.MaterialCardView
                 android:id="@+id/locationCard"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:layout_margin="@dimen/margin_normal"
                 app:cardElevation="@dimen/elevation_small"
-                app:layout_constraintTop_toBottomOf="@id/basicActionsCard">
+                app:layout_constraintTop_toBottomOf="@id/devicePhotosCard">
 
                 <androidx.constraintlayout.widget.ConstraintLayout
                     android:id="@+id/locationLayout"

--- a/app/src/main/res/layout/activity_device_settings_wifi.xml
+++ b/app/src/main/res/layout/activity_device_settings_wifi.xml
@@ -40,6 +40,7 @@
         <androidx.constraintlayout.widget.ConstraintLayout
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
+            android:clipChildren="false"
             android:clipToPadding="false"
             android:paddingBottom="@dimen/padding_normal">
 
@@ -86,13 +87,22 @@
 
             </com.google.android.material.card.MaterialCardView>
 
+            <com.weatherxm.ui.devicesettings.DevicePhotosView
+                android:id="@+id/devicePhotosCard"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_margin="@dimen/margin_normal"
+                android:visibility="gone"
+                app:layout_constraintTop_toBottomOf="@id/basicActionsCard"
+                tools:visibility="visible" />
+
             <com.google.android.material.card.MaterialCardView
                 android:id="@+id/locationCard"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:layout_margin="@dimen/margin_normal"
                 app:cardElevation="@dimen/elevation_small"
-                app:layout_constraintTop_toBottomOf="@id/basicActionsCard">
+                app:layout_constraintTop_toBottomOf="@id/devicePhotosCard">
 
                 <androidx.constraintlayout.widget.ConstraintLayout
                     android:id="@+id/locationLayout"

--- a/app/src/main/res/layout/list_item_reward_boost.xml
+++ b/app/src/main/res/layout/list_item_reward_boost.xml
@@ -22,7 +22,6 @@
             app:layout_constraintBottom_toBottomOf="@id/dataContainer"
             app:layout_constraintTop_toTopOf="@id/dataContainer"
             tools:ignore="contentDescription"
-            tools:src="@drawable/weatherxm_gradient_background"
             tools:visibility="visible" />
 
         <androidx.constraintlayout.widget.ConstraintLayout

--- a/app/src/main/res/layout/view_station_settings_device_photos.xml
+++ b/app/src/main/res/layout/view_station_settings_device_photos.xml
@@ -1,0 +1,148 @@
+<?xml version="1.0" encoding="utf-8"?>
+<merge xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:animateLayoutChanges="true"
+    tools:orientation="vertical"
+    tools:parentTag="LinearLayout">
+
+    <com.google.android.material.card.MaterialCardView
+        android:id="@+id/parentCard"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        app:cardElevation="@dimen/elevation_small"
+        app:contentPaddingTop="0dp">
+
+        <androidx.constraintlayout.widget.ConstraintLayout
+            android:layout_width="match_parent"
+            android:layout_height="match_parent">
+
+            <com.google.android.material.textview.MaterialTextView
+                android:id="@+id/title"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="@dimen/margin_normal_to_large"
+                android:text="@string/photo_verification"
+                android:textAppearance="@style/TextAppearance.WeatherXM.TitleSmall"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toTopOf="parent" />
+
+            <com.google.android.material.card.MaterialCardView
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                app:cardBackgroundColor="@color/layer2"
+                app:cardCornerRadius="8dp"
+                app:contentPadding="@dimen/padding_small"
+                app:layout_constraintBottom_toBottomOf="@id/title"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintTop_toTopOf="@id/title">
+
+                <ImageView
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:importantForAccessibility="no"
+                    android:src="@drawable/ic_new"
+                    app:tint="@color/colorPrimary" />
+
+            </com.google.android.material.card.MaterialCardView>
+
+            <com.google.android.material.textview.MaterialTextView
+                android:id="@+id/emptyText"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="@dimen/margin_small"
+                android:text="@string/photo_verification_empty_station_settings"
+                android:textAppearance="@style/TextAppearance.WeatherXM.Default.BodyMedium"
+                android:textColor="@color/colorPrimaryVariant"
+                android:visibility="gone"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@id/title" />
+
+            <com.google.android.material.textview.MaterialTextView
+                android:id="@+id/photosText"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="@dimen/margin_small"
+                android:text="@string/thanks_helping_see_photos"
+                android:textAppearance="@style/TextAppearance.WeatherXM.Default.BodyMedium"
+                android:textColor="@color/colorPrimaryVariant"
+                android:visibility="gone"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@id/title"
+                tools:visibility="visible" />
+
+            <LinearLayout
+                android:id="@+id/photosContainer"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="@dimen/margin_small"
+                android:gravity="center"
+                android:orientation="horizontal"
+                android:visibility="gone"
+                app:layout_constraintTop_toBottomOf="@id/photosText"
+                tools:visibility="visible">
+
+                <com.google.android.material.card.MaterialCardView
+                    android:id="@+id/firstPhotoContainer"
+                    android:layout_width="160dp"
+                    android:layout_height="160dp"
+                    android:layout_marginEnd="@dimen/margin_extra_small"
+                    app:cardCornerRadius="@dimen/radius_medium"
+                    app:contentPadding="0dp">
+
+                    <ImageView
+                        android:id="@+id/firstPhoto"
+                        android:layout_width="160dp"
+                        android:layout_height="160dp"
+                        android:importantForAccessibility="no"
+                        android:scaleType="fitXY"
+                        tools:src="@drawable/photo_good_example_1" />
+                </com.google.android.material.card.MaterialCardView>
+
+                <com.google.android.material.card.MaterialCardView
+                    android:id="@+id/secondPhotoContainer"
+                    android:layout_width="160dp"
+                    android:layout_height="160dp"
+                    android:layout_marginStart="@dimen/margin_extra_small"
+                    app:cardCornerRadius="@dimen/radius_medium"
+                    app:contentPadding="0dp">
+
+                    <FrameLayout
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content">
+
+                        <ImageView
+                            android:id="@+id/secondPhoto"
+                            android:layout_width="160dp"
+                            android:layout_height="160dp"
+                            android:importantForAccessibility="no"
+                            android:scaleType="fitXY"
+                            tools:src="@drawable/photo_bad_example_1" />
+
+                        <View
+                            android:id="@+id/translucentViewOnSecondPhoto"
+                            android:layout_width="match_parent"
+                            android:layout_height="match_parent"
+                            android:background="@color/translucent_black_darker"
+                            android:visibility="gone"
+                            tools:visibility="visible" />
+                    </FrameLayout>
+                </com.google.android.material.card.MaterialCardView>
+
+            </LinearLayout>
+
+            <com.google.android.material.button.MaterialButton
+                android:id="@+id/startPhotoVerificationBtn"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="@dimen/margin_small"
+                android:text="@string/start_photo_verification"
+                android:visibility="gone"
+                app:layout_constraintTop_toBottomOf="@id/emptyText" />
+        </androidx.constraintlayout.widget.ConstraintLayout>
+
+    </com.google.android.material.card.MaterialCardView>
+
+</merge>

--- a/app/src/main/res/layout/view_station_settings_device_photos.xml
+++ b/app/src/main/res/layout/view_station_settings_device_photos.xml
@@ -73,6 +73,18 @@
                 app:layout_constraintTop_toBottomOf="@id/title"
                 tools:visibility="visible" />
 
+            <com.google.android.material.textview.MaterialTextView
+                android:id="@+id/inProgressText"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="@dimen/margin_small"
+                android:text="@string/once_completed_photos_will_appear_here"
+                android:textAppearance="@style/TextAppearance.WeatherXM.Default.BodyMedium"
+                android:textColor="@color/colorPrimaryVariant"
+                android:visibility="gone"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@id/title" />
+
             <LinearLayout
                 android:id="@+id/photosContainer"
                 android:layout_width="match_parent"
@@ -132,6 +144,24 @@
                 </com.google.android.material.card.MaterialCardView>
 
             </LinearLayout>
+
+            <androidx.compose.ui.platform.ComposeView
+                android:id="@+id/inProgressUploadState"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="@dimen/margin_small"
+                android:visibility="gone"
+                app:layout_constraintTop_toBottomOf="@id/inProgressText" />
+
+            <com.google.android.material.button.MaterialButton
+                android:id="@+id/cancelUploadBtn"
+                style="@style/Widget.WeatherXM.Button.Subtle.Borders"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="@dimen/margin_small"
+                android:text="@string/cancel_upload"
+                android:visibility="gone"
+                app:layout_constraintTop_toBottomOf="@id/inProgressUploadState" />
 
             <com.google.android.material.button.MaterialButton
                 android:id="@+id/startPhotoVerificationBtn"

--- a/app/src/main/res/layout/view_station_settings_device_photos.xml
+++ b/app/src/main/res/layout/view_station_settings_device_photos.xml
@@ -15,38 +15,44 @@
         app:cardElevation="@dimen/elevation_small"
         app:contentPaddingTop="0dp">
 
-        <androidx.constraintlayout.widget.ConstraintLayout
+        <LinearLayout
             android:layout_width="match_parent"
-            android:layout_height="match_parent">
+            android:layout_height="match_parent"
+            android:orientation="vertical">
 
-            <com.google.android.material.textview.MaterialTextView
-                android:id="@+id/title"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_marginTop="@dimen/margin_normal_to_large"
-                android:text="@string/photo_verification"
-                android:textAppearance="@style/TextAppearance.WeatherXM.TitleSmall"
-                app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toTopOf="parent" />
+            <androidx.constraintlayout.widget.ConstraintLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content">
 
-            <com.google.android.material.card.MaterialCardView
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                app:cardBackgroundColor="@color/layer2"
-                app:cardCornerRadius="8dp"
-                app:contentPadding="@dimen/padding_small"
-                app:layout_constraintBottom_toBottomOf="@id/title"
-                app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintTop_toTopOf="@id/title">
-
-                <ImageView
+                <com.google.android.material.textview.MaterialTextView
+                    android:id="@+id/title"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
-                    android:importantForAccessibility="no"
-                    android:src="@drawable/ic_new"
-                    app:tint="@color/colorPrimary" />
+                    android:layout_marginTop="@dimen/margin_normal_to_large"
+                    android:text="@string/photo_verification"
+                    android:textAppearance="@style/TextAppearance.WeatherXM.TitleSmall"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintTop_toTopOf="parent" />
 
-            </com.google.android.material.card.MaterialCardView>
+                <com.google.android.material.card.MaterialCardView
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    app:cardBackgroundColor="@color/layer2"
+                    app:cardCornerRadius="8dp"
+                    app:contentPadding="@dimen/padding_small"
+                    app:layout_constraintBottom_toBottomOf="@id/title"
+                    app:layout_constraintEnd_toEndOf="parent"
+                    app:layout_constraintTop_toTopOf="@id/title">
+
+                    <ImageView
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:importantForAccessibility="no"
+                        android:src="@drawable/ic_new"
+                        app:tint="@color/colorPrimary" />
+
+                </com.google.android.material.card.MaterialCardView>
+            </androidx.constraintlayout.widget.ConstraintLayout>
 
             <com.google.android.material.textview.MaterialTextView
                 android:id="@+id/emptyText"
@@ -56,9 +62,7 @@
                 android:text="@string/photo_verification_empty_station_settings"
                 android:textAppearance="@style/TextAppearance.WeatherXM.Default.BodyMedium"
                 android:textColor="@color/colorPrimaryVariant"
-                android:visibility="gone"
-                app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toBottomOf="@id/title" />
+                android:visibility="gone" />
 
             <com.google.android.material.textview.MaterialTextView
                 android:id="@+id/photosText"
@@ -69,8 +73,6 @@
                 android:textAppearance="@style/TextAppearance.WeatherXM.Default.BodyMedium"
                 android:textColor="@color/colorPrimaryVariant"
                 android:visibility="gone"
-                app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toBottomOf="@id/title"
                 tools:visibility="visible" />
 
             <com.google.android.material.textview.MaterialTextView
@@ -81,9 +83,7 @@
                 android:text="@string/once_completed_photos_will_appear_here"
                 android:textAppearance="@style/TextAppearance.WeatherXM.Default.BodyMedium"
                 android:textColor="@color/colorPrimaryVariant"
-                android:visibility="gone"
-                app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toBottomOf="@id/title" />
+                android:visibility="gone" />
 
             <LinearLayout
                 android:id="@+id/photosContainer"
@@ -93,7 +93,6 @@
                 android:gravity="center"
                 android:orientation="horizontal"
                 android:visibility="gone"
-                app:layout_constraintTop_toBottomOf="@id/photosText"
                 tools:visibility="visible">
 
                 <com.google.android.material.card.MaterialCardView
@@ -150,8 +149,7 @@
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:layout_marginTop="@dimen/margin_small"
-                android:visibility="gone"
-                app:layout_constraintTop_toBottomOf="@id/inProgressText" />
+                android:visibility="gone" />
 
             <com.google.android.material.button.MaterialButton
                 android:id="@+id/cancelUploadBtn"
@@ -160,8 +158,7 @@
                 android:layout_height="wrap_content"
                 android:layout_marginTop="@dimen/margin_small"
                 android:text="@string/cancel_upload"
-                android:visibility="gone"
-                app:layout_constraintTop_toBottomOf="@id/inProgressUploadState" />
+                android:visibility="gone" />
 
             <com.google.android.material.button.MaterialButton
                 android:id="@+id/startPhotoVerificationBtn"
@@ -169,9 +166,59 @@
                 android:layout_height="wrap_content"
                 android:layout_marginTop="@dimen/margin_small"
                 android:text="@string/start_photo_verification"
+                android:visibility="gone" />
+
+
+            <com.google.android.material.card.MaterialCardView
+                android:id="@+id/errorCard"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="@dimen/margin_small"
                 android:visibility="gone"
-                app:layout_constraintTop_toBottomOf="@id/emptyText" />
-        </androidx.constraintlayout.widget.ConstraintLayout>
+                app:cardBackgroundColor="@color/errorTint"
+                app:layout_constraintTop_toBottomOf="@id/startPhotoVerificationBtn"
+                tools:visibility="visible">
+
+                <androidx.constraintlayout.widget.ConstraintLayout
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content">
+
+                    <ImageView
+                        android:id="@+id/errorIcon"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:importantForAccessibility="no"
+                        android:src="@drawable/ic_error_hex_filled"
+                        app:layout_constraintBottom_toBottomOf="parent"
+                        app:layout_constraintStart_toStartOf="parent"
+                        app:layout_constraintTop_toTopOf="parent"
+                        app:tint="@color/error" />
+
+                    <com.google.android.material.textview.MaterialTextView
+                        android:id="@+id/errorText"
+                        android:layout_width="0dp"
+                        android:layout_height="wrap_content"
+                        android:layout_marginStart="@dimen/margin_small_to_normal"
+                        android:text="@string/upload_unexpected_error"
+                        android:textAppearance="@style/TextAppearance.WeatherXM.Default.BodyMedium"
+                        android:textColor="@color/colorPrimaryVariant"
+                        app:layout_constraintEnd_toEndOf="parent"
+                        app:layout_constraintStart_toEndOf="@id/errorIcon"
+                        app:layout_constraintTop_toTopOf="parent" />
+
+                    <com.google.android.material.button.MaterialButton
+                        android:id="@+id/retryBtn"
+                        style="@style/Widget.WeatherXM.TextButton.Subtle"
+                        android:layout_width="0dp"
+                        android:layout_height="40dp"
+                        android:text="@string/action_retry_upload"
+                        app:layout_constraintStart_toEndOf="@id/errorIcon"
+                        app:layout_constraintTop_toBottomOf="@id/errorText" />
+
+                </androidx.constraintlayout.widget.ConstraintLayout>
+            </com.google.android.material.card.MaterialCardView>
+
+        </LinearLayout>
 
     </com.google.android.material.card.MaterialCardView>
 

--- a/app/src/main/res/layout/view_station_settings_device_photos.xml
+++ b/app/src/main/res/layout/view_station_settings_device_photos.xml
@@ -108,7 +108,7 @@
                         android:layout_width="160dp"
                         android:layout_height="160dp"
                         android:importantForAccessibility="no"
-                        android:scaleType="fitXY"
+                        android:scaleType="centerCrop"
                         tools:src="@drawable/photo_good_example_1" />
                 </com.google.android.material.card.MaterialCardView>
 
@@ -129,7 +129,7 @@
                             android:layout_width="160dp"
                             android:layout_height="160dp"
                             android:importantForAccessibility="no"
-                            android:scaleType="fitXY"
+                            android:scaleType="centerCrop"
                             tools:src="@drawable/photo_bad_example_1" />
 
                         <View

--- a/app/src/main/res/values/palette.xml
+++ b/app/src/main/res/values/palette.xml
@@ -58,6 +58,7 @@
     <!-- Translucent -->
     <color name="translucent_light_layer1">#33EAEBF9</color>
     <color name="translucent_black">#66000000</color>
+    <color name="translucent_black_darker">#99000000</color>
 
     <!-- Fade -->
     <color name="fade_light_top">#00FEFBFF</color>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -693,4 +693,8 @@
     <string name="start_photo_verification">Start Photo Verification</string>
     <string name="photo_verification_empty_station_settings">To ensure optimal performance and rewards, take a few quick photos of your station’s installation!</string>
     <string name="thanks_helping_see_photos">Thanks for helping us build a healthier network! Here you can see your photos.</string>
+    <string name="once_completed_photos_will_appear_here">Once completed, the photos will appear here!</string>
+    <string name="cancel_upload">Cancel upload</string>
+    <string name="yes_cancel">Yes, cancel</string>
+    <string name="cancel_upload_message">Are you sure you want to cancel the upload and lose the photos?\nYou will need to retake them. </string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -23,6 +23,7 @@
     <string name="action_favorite">Favorite</string>
     <string name="action_pair_device">Pair Device</string>
     <string name="action_retry_updating">Retry Updating</string>
+    <string name="action_retry_upload">Retry upload</string>
     <string name="action_deny">Deny</string>
     <string name="action_sounds_good">Sounds good!</string>
     <string name="action_update_firmware">Update Firmware</string>
@@ -696,5 +697,6 @@
     <string name="once_completed_photos_will_appear_here">Once completed, the photos will appear here!</string>
     <string name="cancel_upload">Cancel upload</string>
     <string name="yes_cancel">Yes, cancel</string>
-    <string name="cancel_upload_message">Are you sure you want to cancel the upload and lose the photos?\nYou will need to retake them. </string>
+    <string name="cancel_upload_message">Are you sure you want to cancel the upload and lose the photos?\nYou will need to retake them.</string>
+    <string name="upload_unexpected_error">We faced an unexpected error while uploading your photos.</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -690,4 +690,7 @@
     <string name="uploading">Uploading…</string>
     <string name="completed">Completed</string>
     <string name="upload_failed_retry">Upload failed. Tap to retry</string>
+    <string name="start_photo_verification">Start Photo Verification</string>
+    <string name="photo_verification_empty_station_settings">To ensure optimal performance and rewards, take a few quick photos of your station’s installation!</string>
+    <string name="thanks_helping_see_photos">Thanks for helping us build a healthier network! Here you can see your photos.</string>
 </resources>

--- a/app/src/test/java/com/weatherxm/ui/devicesettings/helium/DeviceSettingsHeliumViewModelTest.kt
+++ b/app/src/test/java/com/weatherxm/ui/devicesettings/helium/DeviceSettingsHeliumViewModelTest.kt
@@ -26,6 +26,7 @@ import com.weatherxm.ui.common.empty
 import com.weatherxm.ui.devicesettings.UIDeviceInfo
 import com.weatherxm.ui.devicesettings.UIDeviceInfoItem
 import com.weatherxm.usecases.AuthUseCase
+import com.weatherxm.usecases.DevicePhotoUseCase
 import com.weatherxm.usecases.StationSettingsUseCase
 import com.weatherxm.usecases.UserUseCase
 import com.weatherxm.util.Resources
@@ -45,6 +46,7 @@ import java.time.format.DateTimeFormatter
 
 class DeviceSettingsHeliumViewModelTest : BehaviorSpec({
     val settingsUseCase = mockk<StationSettingsUseCase>()
+    val photosUseCase = mockk<DevicePhotoUseCase>()
     val userUseCase = mockk<UserUseCase>()
     val authUseCase = mockk<AuthUseCase>()
     val analytics = mockk<AnalyticsWrapper>()
@@ -180,6 +182,7 @@ class DeviceSettingsHeliumViewModelTest : BehaviorSpec({
         viewModel = DeviceSettingsHeliumViewModel(
             device,
             settingsUseCase,
+            photosUseCase,
             userUseCase,
             authUseCase,
             resources,

--- a/app/src/test/java/com/weatherxm/ui/devicesettings/wifi/DeviceSettingsWifiViewModelTest.kt
+++ b/app/src/test/java/com/weatherxm/ui/devicesettings/wifi/DeviceSettingsWifiViewModelTest.kt
@@ -32,6 +32,7 @@ import com.weatherxm.ui.common.empty
 import com.weatherxm.ui.devicesettings.UIDeviceInfo
 import com.weatherxm.ui.devicesettings.UIDeviceInfoItem
 import com.weatherxm.usecases.AuthUseCase
+import com.weatherxm.usecases.DevicePhotoUseCase
 import com.weatherxm.usecases.StationSettingsUseCase
 import com.weatherxm.usecases.UserUseCase
 import com.weatherxm.util.Resources
@@ -52,6 +53,7 @@ import java.time.format.DateTimeFormatter
 
 class DeviceSettingsWifiViewModelTest : BehaviorSpec({
     val settingsUseCase = mockk<StationSettingsUseCase>()
+    val photosUseCase = mockk<DevicePhotoUseCase>()
     val userUseCase = mockk<UserUseCase>()
     val authUseCase = mockk<AuthUseCase>()
     val analytics = mockk<AnalyticsWrapper>()
@@ -238,6 +240,7 @@ class DeviceSettingsWifiViewModelTest : BehaviorSpec({
         viewModel = DeviceSettingsWifiViewModel(
             device,
             settingsUseCase,
+            photosUseCase,
             userUseCase,
             authUseCase,
             resources,


### PR DESCRIPTION
### **Why?**
Build the UI component that provides users access to the Photo Verification process from the Station Settings screen.

### **How?**
- Fixes in `PhotoGalleryActivity` to accept already prefilled photos. Also start this activity with a launcher from station settings in order to return any changes that happened and act accordingly.
- Created `DevicePhotoDataSource` , `DevicePhotoRepository`, `DevicePhotoUseCase` which provide any information needed regarding those photos.
- In `BaseDeviceSettingsViewModel`, created the functions `getDevicePhotos` which returns the photos, `onPhotosChanged` which either returns fetches the photos again or calls the `deleteAllPhotos` which deletes all photos from the remote storage.
- Created `DevicePhotosView` which is the component used in the station settings and has a lot of different states (empty, in progress, error with photos, error without photos)
- In the `DeviceSettingsHeliumActivity` and `DeviceSettingsWifiActivity` made the respective changes in order to support that new component, populate it accordingly and set the correct listeners.

### **Testing**
Go to the station settings screen and ensure everything is OK. Playing with local mock can give you back some images from json `device_photos_list.json`  