### PR TITLE
Fix QoD color outline on Reward Details

### DIFF
--- a/app/src/main/java/com/weatherxm/ui/rewarddetails/RewardDetailsActivity.kt
+++ b/app/src/main/java/com/weatherxm/ui/rewarddetails/RewardDetailsActivity.kt
@@ -224,9 +224,9 @@ class RewardDetailsActivity : BaseActivity(), RewardBoostListener {
                 analyticsScreen = AnalyticsService.Screen.DATA_QUALITY_INFO
             )
         }
-        if (qodScore >= 95) {
+        if (qodScore >= 80) {
             binding.dataQualityCard.checkmark()
-        } else if (qodScore in 10..94) {
+        } else if (qodScore >= 20) {
             binding.dataQualityCard.warning()
         } else {
             binding.dataQualityCard.error()


### PR DESCRIPTION
### **Why?**
Use the correct ranges for the QoD scores in order for the QoD card to being shown up as success/warning/error

### **How?**
Replaced the wrong ranges with the correct ones.

### **Testing**
Ensure that the new ranges work correctly in the UI. You can also play with local mock to use any number you want, in the JSON `get_device_reward_details.json`