### PR TITLE
Fixed no alerts in cell devices

### DIFF
--- a/app/src/main/java/com/weatherxm/usecases/ExplorerUseCaseImpl.kt
+++ b/app/src/main/java/com/weatherxm/usecases/ExplorerUseCaseImpl.kt
@@ -65,6 +65,7 @@ class ExplorerUseCaseImpl(
                 publicDevice.toUIDevice().apply {
                     this.cellCenter = cell.center
                     this.relation = getRelation(this.id)
+                    createDeviceAlerts(false)
                 }
             }.sortedWith(
                 compareByDescending<UIDevice> { it.lastWeatherStationActivity }.thenBy { it.name }


### PR DESCRIPTION
### **Why?**
Create alerts on cell devices

### **How?**
Run `createDeviceAlerts` at the respective place in the UseCase when populating each `UIDevice` of the list.

### **Testing**
Go to a cell with an offline station and ensure that the "Inactive" chip is shown in this cell screen.
