### PR TITLE
[Photo Verification] Do not display the terms screen if the user has already accepted it.

### DIFF
--- a/app/src/main/java/com/weatherxm/data/Modules.kt
+++ b/app/src/main/java/com/weatherxm/data/Modules.kt
@@ -196,6 +196,7 @@ import com.weatherxm.ui.login.LoginViewModel
 import com.weatherxm.ui.networkstats.NetworkStatsViewModel
 import com.weatherxm.ui.passwordprompt.PasswordPromptViewModel
 import com.weatherxm.ui.photoverification.gallery.PhotoGalleryViewModel
+import com.weatherxm.ui.photoverification.intro.PhotoVerificationIntroViewModel
 import com.weatherxm.ui.preferences.PreferenceViewModel
 import com.weatherxm.ui.resetpassword.ResetPasswordViewModel
 import com.weatherxm.ui.rewardboosts.RewardBoostViewModel
@@ -436,7 +437,7 @@ private val datasources = module {
         RemoteBannersDataSourceImpl(get(), get())
     }
     single<DevicePhotoDataSource> {
-        DevicePhotoDataSourceImpl(get())
+        DevicePhotoDataSourceImpl(get(), get())
     }
 }
 
@@ -1047,6 +1048,7 @@ private val viewmodels = module {
             fromClaiming = params.get()
         )
     }
+    viewModel { PhotoVerificationIntroViewModel(get()) }
 }
 
 val modules = listOf(

--- a/app/src/main/java/com/weatherxm/data/datasource/DevicePhotoDataSource.kt
+++ b/app/src/main/java/com/weatherxm/data/datasource/DevicePhotoDataSource.kt
@@ -5,13 +5,27 @@ import com.weatherxm.data.mapResponse
 import com.weatherxm.data.models.DevicePhoto
 import com.weatherxm.data.models.Failure
 import com.weatherxm.data.network.ApiService
+import com.weatherxm.data.services.CacheService
 
 interface DevicePhotoDataSource {
     suspend fun getDevicePhotos(deviceId: String): Either<Failure, List<DevicePhoto>>
+    fun getAcceptedTerms(): Boolean
+    fun setAcceptedTerms()
 }
 
-class DevicePhotoDataSourceImpl(private val apiService: ApiService) : DevicePhotoDataSource {
+class DevicePhotoDataSourceImpl(
+    private val apiService: ApiService,
+    private val cacheService: CacheService
+) : DevicePhotoDataSource {
     override suspend fun getDevicePhotos(deviceId: String): Either<Failure, List<DevicePhoto>> {
         return apiService.getDevicePhotos(deviceId).mapResponse()
+    }
+
+    override fun getAcceptedTerms(): Boolean {
+        return cacheService.getPhotoVerificationAcceptedTerms()
+    }
+
+    override fun setAcceptedTerms() {
+        cacheService.setPhotoVerificationAcceptedTerms()
     }
 }

--- a/app/src/main/java/com/weatherxm/data/repository/DevicePhotoRepository.kt
+++ b/app/src/main/java/com/weatherxm/data/repository/DevicePhotoRepository.kt
@@ -7,6 +7,8 @@ import com.weatherxm.data.models.Failure
 
 interface DevicePhotoRepository {
     suspend fun getDevicePhotos(deviceId: String): Either<Failure, List<DevicePhoto>>
+    fun getAcceptedTerms(): Boolean
+    fun setAcceptedTerms()
 }
 
 class DevicePhotoRepositoryImpl(
@@ -14,5 +16,13 @@ class DevicePhotoRepositoryImpl(
 ) : DevicePhotoRepository {
     override suspend fun getDevicePhotos(deviceId: String): Either<Failure, List<DevicePhoto>> {
         return datasource.getDevicePhotos(deviceId)
+    }
+
+    override fun getAcceptedTerms(): Boolean {
+        return datasource.getAcceptedTerms()
+    }
+
+    override fun setAcceptedTerms() {
+        datasource.setAcceptedTerms()
     }
 }

--- a/app/src/main/java/com/weatherxm/data/services/CacheService.kt
+++ b/app/src/main/java/com/weatherxm/data/services/CacheService.kt
@@ -46,6 +46,7 @@ class CacheService(
         const val KEY_INSTALLATION_ID = "installation_id"
         const val KEY_DISMISSED_SURVEY_ID = "dismissed_survey_id"
         const val KEY_DISMISSED_INFO_BANNER_ID = "dismissed_info_banner_id"
+        const val KEY_PHOTO_VERIFICATION_ACCEPTED_TERMS = "photo_verification_accepted_terms"
 
         // Default in-memory cache expiration time 15 minutes
         val DEFAULT_CACHE_EXPIRATION = TimeUnit.MINUTES.toMillis(15L)
@@ -311,6 +312,14 @@ class CacheService(
 
     fun setLastDismissedInfoBannerId(infoBannerId: String) {
         preferences.edit().putString(KEY_DISMISSED_INFO_BANNER_ID, infoBannerId).apply()
+    }
+
+    fun getPhotoVerificationAcceptedTerms(): Boolean {
+        return preferences.getBoolean(KEY_PHOTO_VERIFICATION_ACCEPTED_TERMS, false)
+    }
+
+    fun setPhotoVerificationAcceptedTerms() {
+        preferences.edit().putBoolean(KEY_PHOTO_VERIFICATION_ACCEPTED_TERMS, true).apply()
     }
 
     fun getCountriesInfo(): List<CountryInfo> {

--- a/app/src/main/java/com/weatherxm/ui/devicesettings/helium/DeviceSettingsHeliumActivity.kt
+++ b/app/src/main/java/com/weatherxm/ui/devicesettings/helium/DeviceSettingsHeliumActivity.kt
@@ -163,7 +163,17 @@ class DeviceSettingsHeliumActivity : BaseActivity() {
                 devicePhotos.forEach {
                     photos.add(it.url)
                 }
-                navigator.showPhotoGallery(photoGalleryLauncher, this, model.device, photos, false)
+                if (photos.isEmpty()) {
+                    navigator.showPhotoVerificationIntro(this, model.device)
+                } else {
+                    navigator.showPhotoGallery(
+                        photoGalleryLauncher,
+                        this,
+                        model.device,
+                        photos,
+                        false
+                    )
+                }
             },
             onCancelUpload = {
                 ActionDialogFragment

--- a/app/src/main/java/com/weatherxm/ui/devicesettings/wifi/DeviceSettingsWifiActivity.kt
+++ b/app/src/main/java/com/weatherxm/ui/devicesettings/wifi/DeviceSettingsWifiActivity.kt
@@ -158,7 +158,17 @@ class DeviceSettingsWifiActivity : BaseActivity() {
                 devicePhotos.forEach {
                     photos.add(it.url)
                 }
-                navigator.showPhotoGallery(photoGalleryLauncher, this, model.device, photos, false)
+                if (photos.isEmpty()) {
+                    navigator.showPhotoVerificationIntro(this, model.device)
+                } else {
+                    navigator.showPhotoGallery(
+                        photoGalleryLauncher,
+                        this,
+                        model.device,
+                        photos,
+                        false
+                    )
+                }
             },
             onCancelUpload = {
                 ActionDialogFragment

--- a/app/src/main/java/com/weatherxm/ui/photoverification/intro/PhotoVerificationIntroActivity.kt
+++ b/app/src/main/java/com/weatherxm/ui/photoverification/intro/PhotoVerificationIntroActivity.kt
@@ -11,9 +11,11 @@ import com.weatherxm.ui.common.parcelable
 import com.weatherxm.ui.components.ActionDialogFragment
 import com.weatherxm.ui.components.BaseActivity
 import com.weatherxm.ui.photoverification.PhotoVerificationInstructionsFragment
+import org.koin.androidx.viewmodel.ext.android.viewModel
 
 class PhotoVerificationIntroActivity : BaseActivity() {
     private lateinit var binding: ActivityPhotoVerificationIntroBinding
+    private val viewModel: PhotoVerificationIntroViewModel by viewModel()
 
     private var instructionsOnly = false
     private var device = UIDevice.empty()
@@ -26,6 +28,11 @@ class PhotoVerificationIntroActivity : BaseActivity() {
 
         instructionsOnly = intent.getBooleanExtra(ARG_INSTRUCTIONS_ONLY, false)
         device = intent.parcelable<UIDevice>(ARG_DEVICE) ?: UIDevice.empty()
+
+        if (viewModel.getAcceptedTerms()) {
+            navigator.showPhotoGallery(null, this, device, arrayListOf(), true)
+            finish()
+        }
     }
 
     override fun onResume() {
@@ -50,6 +57,7 @@ class PhotoVerificationIntroActivity : BaseActivity() {
                             .show(this)
                     },
                     onTakePhoto = {
+                        viewModel.setAcceptedTerms()
                         navigator.showPhotoGallery(
                             null,
                             this@PhotoVerificationIntroActivity,

--- a/app/src/main/java/com/weatherxm/ui/photoverification/intro/PhotoVerificationIntroViewModel.kt
+++ b/app/src/main/java/com/weatherxm/ui/photoverification/intro/PhotoVerificationIntroViewModel.kt
@@ -1,0 +1,9 @@
+package com.weatherxm.ui.photoverification.intro
+
+import androidx.lifecycle.ViewModel
+import com.weatherxm.usecases.DevicePhotoUseCase
+
+class PhotoVerificationIntroViewModel(private val useCase: DevicePhotoUseCase) : ViewModel() {
+    fun getAcceptedTerms(): Boolean = useCase.getAcceptedTerms()
+    fun setAcceptedTerms() = useCase.setAcceptedTerms()
+}

--- a/app/src/main/java/com/weatherxm/usecases/DevicePhotoUseCase.kt
+++ b/app/src/main/java/com/weatherxm/usecases/DevicePhotoUseCase.kt
@@ -7,6 +7,8 @@ import com.weatherxm.data.repository.DevicePhotoRepository
 
 interface DevicePhotoUseCase {
     suspend fun getDevicePhotos(deviceId: String): Either<Failure, List<DevicePhoto>>
+    fun getAcceptedTerms(): Boolean
+    fun setAcceptedTerms()
 }
 
 class DevicePhotoUseCaseImpl(
@@ -14,5 +16,13 @@ class DevicePhotoUseCaseImpl(
 ) : DevicePhotoUseCase {
     override suspend fun getDevicePhotos(deviceId: String): Either<Failure, List<DevicePhoto>> {
         return repository.getDevicePhotos(deviceId)
+    }
+
+    override fun getAcceptedTerms(): Boolean {
+        return repository.getAcceptedTerms()
+    }
+
+    override fun setAcceptedTerms() {
+        repository.setAcceptedTerms()
     }
 }

--- a/app/src/test/java/com/weatherxm/data/services/PrefsSingleVarTest.kt
+++ b/app/src/test/java/com/weatherxm/data/services/PrefsSingleVarTest.kt
@@ -6,6 +6,7 @@ import com.weatherxm.data.services.CacheService.Companion.KEY_ANALYTICS_OPT_IN_O
 import com.weatherxm.data.services.CacheService.Companion.KEY_DISMISSED_INFO_BANNER_ID
 import com.weatherxm.data.services.CacheService.Companion.KEY_DISMISSED_SURVEY_ID
 import com.weatherxm.data.services.CacheService.Companion.KEY_LAST_REMINDED_VERSION
+import com.weatherxm.data.services.CacheService.Companion.KEY_PHOTO_VERIFICATION_ACCEPTED_TERMS
 import com.weatherxm.data.services.CacheService.Companion.KEY_WALLET_WARNING_DISMISSED_TIMESTAMP
 import io.kotest.core.spec.style.BehaviorSpec
 import io.kotest.matchers.shouldBe
@@ -109,6 +110,15 @@ class PrefsSingleVarTest(
             { prefEditor.putString(KEY_DISMISSED_INFO_BANNER_ID, infoBannerId) },
             { cacheService.getLastDismissedInfoBannerId() },
             { cacheService.setLastDismissedInfoBannerId(infoBannerId) }
+        )
+
+        behaviorSpec.testGetSetSingleVar(
+            "if the user has accepted the terms of photo verification",
+            true,
+            { sharedPref.getBoolean(KEY_PHOTO_VERIFICATION_ACCEPTED_TERMS, false) },
+            { prefEditor.putBoolean(KEY_PHOTO_VERIFICATION_ACCEPTED_TERMS, false) },
+            { cacheService.getPhotoVerificationAcceptedTerms() },
+            { cacheService.setPhotoVerificationAcceptedTerms(false) }
         )
     }
 


### PR DESCRIPTION
### **Why?**
Do not show the intro screen of the photo verification if the user has already accepted the terms once

### **How?**
1. Used `CacheService` to set/get a `boolean` indicating if the user has accepted the terms or not.
2. Pass this data through data source, repo and use case.
3. In `PhotoVerificationIntroActivity` if the user has already accepted the terms, `finish()` it and open `PhotoGalleryActivity`. Created `PhotoVerificationViewModel` to get that data.
4. In Station Settings if the gallery is empty, the intro screen show open and not the gallery directly.


### **Testing**
Use local mock flavour. Navigate to the photo verification flow from claiming flow or through the settings and ensure that after accepting the terms once and move past the intro screen, it doesn't show up again in the next attempt.