### PR TITLE
Add support of Float with 2 decimals for reward split percentages

### DIFF
--- a/app/src/main/java/com/weatherxm/data/models/ApiModels.kt
+++ b/app/src/main/java/com/weatherxm/data/models/ApiModels.kt
@@ -755,7 +755,7 @@ data class WalletRewards(
 @Parcelize
 data class RewardSplit(
     val wallet: String,
-    val stake: Int,
+    val stake: Float,
     val reward: Float?
 ) : Parcelable
 

--- a/app/src/main/java/com/weatherxm/ui/common/RewardSplitStakeholderAdapter.kt
+++ b/app/src/main/java/com/weatherxm/ui/common/RewardSplitStakeholderAdapter.kt
@@ -11,6 +11,7 @@ import com.weatherxm.R
 import com.weatherxm.data.models.RewardSplit
 import com.weatherxm.databinding.ListItemRewardSplitStakeholderBinding
 import com.weatherxm.util.Mask
+import com.weatherxm.util.NumberUtils.formatNumber
 import com.weatherxm.util.NumberUtils.formatTokens
 
 class RewardSplitStakeholderAdapter(
@@ -54,12 +55,13 @@ class RewardSplitStakeholderAdapter(
                 binding.address.text = Mask.maskHash(item.wallet)
             }
 
+            val formattedPercentage = formatNumber(item.stake, 2)
             if (isInStationSettings) {
-                binding.percentage.text = "${item.stake}%"
+                binding.percentage.text = "$formattedPercentage%"
             } else {
                 binding.amount.text =
                     itemView.context.getString(R.string.wxm_amount, formatTokens(item.reward))
-                binding.percentage.text = "(${item.stake}%)"
+                binding.percentage.text = "($formattedPercentage%)"
             }
         }
     }

--- a/app/src/main/res/layout/list_item_reward_split_stakeholder.xml
+++ b/app/src/main/res/layout/list_item_reward_split_stakeholder.xml
@@ -11,13 +11,14 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:orientation="horizontal"
-        android:weightSum="6"
+        android:weightSum="9"
         app:layout_constraintTop_toTopOf="parent">
 
         <androidx.constraintlayout.widget.ConstraintLayout
             android:layout_width="0dp"
             android:layout_height="wrap_content"
-            android:layout_weight="5"
+            android:layout_marginEnd="@dimen/margin_small"
+            android:layout_weight="7"
             app:layout_constraintTop_toTopOf="parent">
 
             <com.google.android.material.textview.MaterialTextView
@@ -48,13 +49,13 @@
             android:id="@+id/percentage"
             android:layout_width="0dp"
             android:layout_height="wrap_content"
-            android:layout_weight="1"
+            android:layout_weight="2"
             android:gravity="end"
             android:textAppearance="@style/TextAppearance.WeatherXM.Default.BodyLarge"
             android:textColor="@color/darkGrey"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintTop_toTopOf="parent"
-            tools:text="(50%)" />
+            tools:text="(50.00%)" />
     </LinearLayout>
 
     <com.google.android.material.divider.MaterialDivider

--- a/app/src/test/java/com/weatherxm/ui/devicesettings/helium/DeviceSettingsHeliumViewModelTest.kt
+++ b/app/src/test/java/com/weatherxm/ui/devicesettings/helium/DeviceSettingsHeliumViewModelTest.kt
@@ -82,7 +82,7 @@ class DeviceSettingsHeliumViewModelTest : BehaviorSpec({
         null
     )
     val stakeholderSplits = RewardSplitsData(
-        listOf(RewardSplit("walletAddress", 50, 50F), RewardSplit("wallet", 50, 50F)),
+        listOf(RewardSplit("walletAddress", 50F, 50F), RewardSplit("wallet", 50F, 50F)),
         "walletAddress"
     )
     val deviceInfo = DeviceInfo(

--- a/app/src/test/java/com/weatherxm/ui/devicesettings/wifi/DeviceSettingsWifiViewModelTest.kt
+++ b/app/src/test/java/com/weatherxm/ui/devicesettings/wifi/DeviceSettingsWifiViewModelTest.kt
@@ -89,11 +89,11 @@ class DeviceSettingsWifiViewModelTest : BehaviorSpec({
     )
     val newFriendlyName = "newFriendlyName"
     val stakeholderSplits = RewardSplitsData(
-        listOf(RewardSplit("walletAddress", 50, 50F), RewardSplit("wallet", 50, 50F)),
+        listOf(RewardSplit("walletAddress", 50F, 50F), RewardSplit("wallet", 50F, 50F)),
         "walletAddress"
     )
     val nonStakeholderSplits = RewardSplitsData(
-        listOf(RewardSplit("wallet", 50, 50F), RewardSplit("wallet2", 50, 50F)),
+        listOf(RewardSplit("wallet", 50F, 50F), RewardSplit("wallet2", 50F, 50F)),
         "non-stakeholder-wallet"
     )
     val uiDeviceInfoToShare = UIDeviceInfo(

--- a/app/src/test/java/com/weatherxm/ui/rewarddetails/RewardDetailsViewModelTest.kt
+++ b/app/src/test/java/com/weatherxm/ui/rewarddetails/RewardDetailsViewModelTest.kt
@@ -42,8 +42,8 @@ class RewardDetailsViewModelTest : BehaviorSpec({
     val walletAddress = "walletAddress"
     val timestamp = ZonedDateTime.now()
     val rewardSplits = listOf(
-        RewardSplit(walletAddress, 50, 50F),
-        RewardSplit("", 50, 50F)
+        RewardSplit(walletAddress, 50F, 50F),
+        RewardSplit("", 50F, 50F)
     )
     val rewardDetails = RewardDetails(
         timestamp,


### PR DESCRIPTION
### **Why?**
Reward split breaks when receives FLOAT instead of INT

### **How?**
Instead of `Int` we now use `Float` in the `ApiModels` and minor adjustments in the UI to use a bit more space and show 2 decimals.

### **Testing**
Ensure everything is OK, test station: Tame Canvas Forecast
