### PR TITLE
`UpdatePromptViewModel` should use a `usecase`

### DIFF
--- a/app/src/main/java/com/weatherxm/data/Modules.kt
+++ b/app/src/main/java/com/weatherxm/data/Modules.kt
@@ -240,6 +240,8 @@ import com.weatherxm.usecases.StationSettingsUseCase
 import com.weatherxm.usecases.StationSettingsUseCaseImpl
 import com.weatherxm.usecases.StatsUseCase
 import com.weatherxm.usecases.StatsUseCaseImpl
+import com.weatherxm.usecases.UpdatePromptUseCase
+import com.weatherxm.usecases.UpdatePromptUseCaseImpl
 import com.weatherxm.usecases.UserUseCase
 import com.weatherxm.usecases.UserUseCaseImpl
 import com.weatherxm.usecases.WidgetCurrentWeatherUseCase
@@ -566,6 +568,9 @@ private val usecases = module {
     }
     single<RemoteBannersUseCase> {
         RemoteBannersUseCaseImpl(get())
+    }
+    single<UpdatePromptUseCase> {
+        UpdatePromptUseCaseImpl(get())
     }
 }
 

--- a/app/src/main/java/com/weatherxm/ui/updateprompt/UpdatePromptViewModel.kt
+++ b/app/src/main/java/com/weatherxm/ui/updateprompt/UpdatePromptViewModel.kt
@@ -1,14 +1,14 @@
 package com.weatherxm.ui.updateprompt
 
 import androidx.lifecycle.ViewModel
-import com.weatherxm.data.repository.AppConfigRepository
+import com.weatherxm.usecases.UpdatePromptUseCase
 
-class UpdatePromptViewModel(private val appConfigRepository: AppConfigRepository) : ViewModel() {
+class UpdatePromptViewModel(private val usecase: UpdatePromptUseCase) : ViewModel() {
     fun isUpdateMandatory(): Boolean {
-        return appConfigRepository.isUpdateMandatory()
+        return usecase.isUpdateMandatory()
     }
 
     fun getChangelog(): String {
-        return appConfigRepository.getChangelog()
+        return usecase.getChangelog()
     }
 }

--- a/app/src/main/java/com/weatherxm/usecases/UpdatePromptUseCase.kt
+++ b/app/src/main/java/com/weatherxm/usecases/UpdatePromptUseCase.kt
@@ -1,0 +1,20 @@
+package com.weatherxm.usecases
+
+import com.weatherxm.data.repository.AppConfigRepository
+
+interface UpdatePromptUseCase {
+    fun getChangelog(): String
+    fun isUpdateMandatory(): Boolean
+}
+
+class UpdatePromptUseCaseImpl(
+    private val appConfigRepository: AppConfigRepository
+) : UpdatePromptUseCase {
+    override fun getChangelog(): String {
+        return appConfigRepository.getChangelog()
+    }
+
+    override fun isUpdateMandatory(): Boolean {
+        return appConfigRepository.isUpdateMandatory()
+    }
+}

--- a/app/src/test/java/com/weatherxm/usecases/UpdatePromptUseCaseTest.kt
+++ b/app/src/test/java/com/weatherxm/usecases/UpdatePromptUseCaseTest.kt
@@ -1,22 +1,22 @@
-package com.weatherxm.ui.updateprompt
+package com.weatherxm.usecases
 
-import com.weatherxm.usecases.UpdatePromptUseCase
+import com.weatherxm.data.repository.AppConfigRepository
 import io.kotest.core.spec.style.BehaviorSpec
 import io.kotest.matchers.shouldBe
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
 
-class UpdatePromptViewModelTest : BehaviorSpec({
-    val usecase = mockk<UpdatePromptUseCase>()
-    val viewModel = UpdatePromptViewModel(usecase)
+class UpdatePromptUseCaseTest : BehaviorSpec({
+    val repo = mockk<AppConfigRepository>()
+    val usecase = UpdatePromptUseCaseImpl(repo)
     val testChangelog = "Changelog"
 
     fun mockUpdateMandatory(expected: Boolean) =
-        every { usecase.isUpdateMandatory() } returns expected
+        every { repo.isUpdateMandatory() } returns expected
 
     beforeSpec {
-        every { usecase.getChangelog() } returns testChangelog
+        every { repo.getChangelog() } returns testChangelog
     }
 
     context("Get update-related information") {
@@ -24,22 +24,22 @@ class UpdatePromptViewModelTest : BehaviorSpec({
             When("Update is mandatory") {
                 mockUpdateMandatory(true)
                 then("isUpdateMandatory returns true") {
-                    viewModel.isUpdateMandatory() shouldBe true
-                    verify(exactly = 1) { usecase.isUpdateMandatory() }
+                    usecase.isUpdateMandatory() shouldBe true
+                    verify(exactly = 1) { repo.isUpdateMandatory() }
                 }
             }
             When("Update is not mandatory") {
                 mockUpdateMandatory(false)
                 then("isUpdateMandatory returns false") {
-                    viewModel.isUpdateMandatory() shouldBe false
-                    verify(exactly = 2) { usecase.isUpdateMandatory() }
+                    usecase.isUpdateMandatory() shouldBe false
+                    verify(exactly = 2) { repo.isUpdateMandatory() }
                 }
             }
         }
         given("Update Changelog") {
             then("getChangelog returns the correct string") {
-                viewModel.getChangelog() shouldBe testChangelog
-                verify(exactly = 1) { usecase.getChangelog() }
+                usecase.getChangelog() shouldBe testChangelog
+                verify(exactly = 1) { repo.getChangelog() }
             }
         }
     }


### PR DESCRIPTION
### **Why?**
Currently it's `class UpdatePromptViewModel(private val appConfigRepository: AppConfigRepository)` which breaks our pattern as it should use a usecase.

### **How?**
Created the usecase, inject it in ViewModel and created the respective unit tests.

### **Testing**
Ensure project builds successfully and new tests are OK.

