### PR TITLE
Feature/fe 1345 photo uploading mechanism

### DIFF
--- a/app/src/local/assets/mock_files/device_photos_list.json
+++ b/app/src/local/assets/mock_files/device_photos_list.json
@@ -1,11 +1,5 @@
 [
-    {
-        "url": "https://i0.wp.com/weatherxm.com/wp-content/uploads/2023/09/5-5.png"
-    },
-    {
-        "url": "https://docs.weatherxm.com/img/wxm-devices/deployments/good-example-1.jpg"
-    },
-    {
-        "url": "https://docs.weatherxm.com/img/wxm-devices/deployments/good-example-2.jpg"
-    }
+    "https://i0.wp.com/weatherxm.com/wp-content/uploads/2023/09/5-5.png",
+    "https://docs.weatherxm.com/img/wxm-devices/deployments/good-example-1.jpg",
+    "https://docs.weatherxm.com/img/wxm-devices/deployments/good-example-2.jpg"
 ]

--- a/app/src/local/assets/mock_files/get_photos_presigned_metadata.json
+++ b/app/src/local/assets/mock_files/get_photos_presigned_metadata.json
@@ -1,0 +1,13 @@
+{
+    "url": "https://weatherxm.com",
+    "fields": {
+        "bucket": "bucket",
+        "X-Amz-Algorithm": "X-Amz-Algorithm",
+        "X-Amz-Credential": "X-Amz-Credential",
+        "X-Amz-Date": "X-Amz-Date",
+        "X-Amz-Security-Token": "X-Amz-Security-Token",
+        "key": "key",
+        "Policy": "Policy",
+        "X-Amz-Signature": "X-Amz-Signature"
+    }
+}

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -328,6 +328,10 @@
             android:screenOrientation="portrait"
             android:theme="@style/Theme.WeatherXM" />
         <activity
+            android:name="com.weatherxm.ui.photoverification.upload.PhotoUploadActivity"
+            android:screenOrientation="portrait"
+            android:theme="@style/Theme.WeatherXM" />
+        <activity
             android:name="com.journeyapps.barcodescanner.CaptureActivity"
             android:screenOrientation="portrait"
             tools:replace="screenOrientation" />

--- a/app/src/main/java/com/weatherxm/app/App.kt
+++ b/app/src/main/java/com/weatherxm/app/App.kt
@@ -38,7 +38,6 @@ class App : Application() {
         )
         UploadServiceConfig.httpStack = OkHttpStack()
         UploadServiceLogger.setLogLevel(UploadServiceLogger.LogLevel.Debug)
-
         GlobalRequestObserver(this, uploadObserverService)
     }
 }

--- a/app/src/main/java/com/weatherxm/data/Modules.kt
+++ b/app/src/main/java/com/weatherxm/data/Modules.kt
@@ -796,7 +796,7 @@ val clientIdentificationHelper = module {
 
 val uploadObserverService = module {
     single {
-        GlobalUploadObserverService(get())
+        GlobalUploadObserverService(get(), get())
     }
 }
 
@@ -991,7 +991,7 @@ private val viewmodels = module {
     viewModel { DeviceEditLocationViewModel(get(), get(), get(), get()) }
     viewModel { DevicesViewModel(get(), get(), get(), get()) }
     viewModel { ExplorerViewModel(get(), get(), get()) }
-    viewModel { HomeViewModel(get(), get(), get()) }
+    viewModel { HomeViewModel(get(), get(), get(), get()) }
     viewModel { ProfileViewModel(get(), get()) }
     viewModel { LoginViewModel(get(), get(), get(), get()) }
     viewModel { NetworkStatsViewModel(get()) }
@@ -1046,11 +1046,7 @@ private val viewmodels = module {
     }
     viewModel { PhotoVerificationIntroViewModel(get()) }
     viewModel { params ->
-        PhotoUploadViewModel(
-            device = params.get(),
-            photos = params.get(),
-            get()
-        )
+        PhotoUploadViewModel(device = params.get(), photos = params.get(), get(), get(), get())
     }
 }
 

--- a/app/src/main/java/com/weatherxm/data/Modules.kt
+++ b/app/src/main/java/com/weatherxm/data/Modules.kt
@@ -195,6 +195,7 @@ import com.weatherxm.ui.networkstats.NetworkStatsViewModel
 import com.weatherxm.ui.passwordprompt.PasswordPromptViewModel
 import com.weatherxm.ui.photoverification.gallery.PhotoGalleryViewModel
 import com.weatherxm.ui.photoverification.intro.PhotoVerificationIntroViewModel
+import com.weatherxm.ui.photoverification.upload.PhotoUploadViewModel
 import com.weatherxm.ui.preferences.PreferenceViewModel
 import com.weatherxm.ui.resetpassword.ResetPasswordViewModel
 import com.weatherxm.ui.rewardboosts.RewardBoostViewModel
@@ -1039,10 +1040,18 @@ private val viewmodels = module {
         PhotoGalleryViewModel(
             device = params.get(),
             photos = params.get(),
-            fromClaiming = params.get()
+            fromClaiming = params.get(),
+            get()
         )
     }
     viewModel { PhotoVerificationIntroViewModel(get()) }
+    viewModel { params ->
+        PhotoUploadViewModel(
+            device = params.get(),
+            photos = params.get(),
+            get()
+        )
+    }
 }
 
 val modules = listOf(

--- a/app/src/main/java/com/weatherxm/data/datasource/DevicePhotoDataSource.kt
+++ b/app/src/main/java/com/weatherxm/data/datasource/DevicePhotoDataSource.kt
@@ -26,7 +26,6 @@ interface DevicePhotoDataSource {
         request: MultipartUploadRequest
     )
 
-    fun removeDevicePhotoUploadId(deviceId: String, uploadId: String)
     fun getUploadIdRequest(uploadId: String): MultipartUploadRequest?
 }
 
@@ -72,11 +71,6 @@ class DevicePhotoDataSourceImpl(
     ) {
         cacheService.setUploadIdRequest(uploadId, request)
         cacheService.addDevicePhotoUploadId(deviceId, uploadId)
-    }
-
-    override fun removeDevicePhotoUploadId(deviceId: String, uploadId: String) {
-        cacheService.removeUploadIdRequest(uploadId)
-        cacheService.removeDevicePhotoUploadId(deviceId, uploadId)
     }
 
     override fun getUploadIdRequest(uploadId: String): MultipartUploadRequest? {

--- a/app/src/main/java/com/weatherxm/data/datasource/DevicePhotoDataSource.kt
+++ b/app/src/main/java/com/weatherxm/data/datasource/DevicePhotoDataSource.kt
@@ -2,13 +2,13 @@ package com.weatherxm.data.datasource
 
 import arrow.core.Either
 import com.weatherxm.data.mapResponse
-import com.weatherxm.data.models.DevicePhoto
 import com.weatherxm.data.models.Failure
 import com.weatherxm.data.network.ApiService
 import com.weatherxm.data.services.CacheService
 
 interface DevicePhotoDataSource {
-    suspend fun getDevicePhotos(deviceId: String): Either<Failure, List<DevicePhoto>>
+    suspend fun getDevicePhotos(deviceId: String): Either<Failure, List<String>>
+    suspend fun deleteDevicePhoto(deviceId: String, photoName: String): Either<Failure, Unit>
     fun getAcceptedTerms(): Boolean
     fun setAcceptedTerms()
 }
@@ -17,8 +17,15 @@ class DevicePhotoDataSourceImpl(
     private val apiService: ApiService,
     private val cacheService: CacheService
 ) : DevicePhotoDataSource {
-    override suspend fun getDevicePhotos(deviceId: String): Either<Failure, List<DevicePhoto>> {
+    override suspend fun getDevicePhotos(deviceId: String): Either<Failure, List<String>> {
         return apiService.getDevicePhotos(deviceId).mapResponse()
+    }
+
+    override suspend fun deleteDevicePhoto(
+        deviceId: String,
+        photoName: String
+    ): Either<Failure, Unit> {
+        return apiService.deleteDevicePhoto(deviceId, photoName).mapResponse()
     }
 
     override fun getAcceptedTerms(): Boolean {

--- a/app/src/main/java/com/weatherxm/data/datasource/DevicePhotoDataSource.kt
+++ b/app/src/main/java/com/weatherxm/data/datasource/DevicePhotoDataSource.kt
@@ -7,6 +7,7 @@ import com.weatherxm.data.models.PhotoPresignedMetadata
 import com.weatherxm.data.network.ApiService
 import com.weatherxm.data.network.PhotoNamesBody
 import com.weatherxm.data.services.CacheService
+import net.gotev.uploadservice.protocols.multipart.MultipartUploadRequest
 
 interface DevicePhotoDataSource {
     suspend fun getDevicePhotos(deviceId: String): Either<Failure, List<String>>
@@ -18,9 +19,15 @@ interface DevicePhotoDataSource {
 
     fun getAcceptedTerms(): Boolean
     fun setAcceptedTerms()
-    fun getDevicePhotoUploadingIds(deviceId: String): List<String>
-    fun addDevicePhotoUploadingId(deviceId: String, uploadingId: String)
-    fun removeDevicePhotoUploadingId(deviceId: String, uploadingId: String)
+    fun getDevicePhotoUploadIds(deviceId: String): List<String>
+    fun addDevicePhotoUploadIdAndRequest(
+        deviceId: String,
+        uploadId: String,
+        request: MultipartUploadRequest
+    )
+
+    fun removeDevicePhotoUploadId(deviceId: String, uploadId: String)
+    fun getUploadIdRequest(uploadId: String): MultipartUploadRequest?
 }
 
 class DevicePhotoDataSourceImpl(
@@ -54,15 +61,25 @@ class DevicePhotoDataSourceImpl(
         cacheService.setPhotoVerificationAcceptedTerms()
     }
 
-    override fun getDevicePhotoUploadingIds(deviceId: String): List<String> {
-        return cacheService.getDevicePhotoUploadingIds(deviceId)
+    override fun getDevicePhotoUploadIds(deviceId: String): List<String> {
+        return cacheService.getDevicePhotoUploadIds(deviceId)
     }
 
-    override fun addDevicePhotoUploadingId(deviceId: String, uploadingId: String) {
-        cacheService.addDevicePhotoUploadingId(deviceId, uploadingId)
+    override fun addDevicePhotoUploadIdAndRequest(
+        deviceId: String,
+        uploadId: String,
+        request: MultipartUploadRequest
+    ) {
+        cacheService.setUploadIdRequest(uploadId, request)
+        cacheService.addDevicePhotoUploadId(deviceId, uploadId)
     }
 
-    override fun removeDevicePhotoUploadingId(deviceId: String, uploadingId: String) {
-        cacheService.removeDevicePhotoUploadingId(deviceId, uploadingId)
+    override fun removeDevicePhotoUploadId(deviceId: String, uploadId: String) {
+        cacheService.removeUploadIdRequest(uploadId)
+        cacheService.removeDevicePhotoUploadId(deviceId, uploadId)
+    }
+
+    override fun getUploadIdRequest(uploadId: String): MultipartUploadRequest? {
+        return cacheService.getUploadIdRequest(uploadId)
     }
 }

--- a/app/src/main/java/com/weatherxm/data/datasource/DevicePhotoDataSource.kt
+++ b/app/src/main/java/com/weatherxm/data/datasource/DevicePhotoDataSource.kt
@@ -3,12 +3,18 @@ package com.weatherxm.data.datasource
 import arrow.core.Either
 import com.weatherxm.data.mapResponse
 import com.weatherxm.data.models.Failure
+import com.weatherxm.data.models.PhotoPresignedMetadata
 import com.weatherxm.data.network.ApiService
 import com.weatherxm.data.services.CacheService
 
 interface DevicePhotoDataSource {
     suspend fun getDevicePhotos(deviceId: String): Either<Failure, List<String>>
     suspend fun deleteDevicePhoto(deviceId: String, photoName: String): Either<Failure, Unit>
+    suspend fun getPhotosMetadataForUpload(
+        deviceId: String,
+        photoNames: List<String>
+    ): Either<Failure, List<PhotoPresignedMetadata>>
+
     fun getAcceptedTerms(): Boolean
     fun setAcceptedTerms()
 }
@@ -26,6 +32,13 @@ class DevicePhotoDataSourceImpl(
         photoName: String
     ): Either<Failure, Unit> {
         return apiService.deleteDevicePhoto(deviceId, photoName).mapResponse()
+    }
+
+    override suspend fun getPhotosMetadataForUpload(
+        deviceId: String,
+        photoNames: List<String>
+    ): Either<Failure, List<PhotoPresignedMetadata>> {
+        return apiService.getPhotosMetadataForUpload(deviceId, photoNames).mapResponse()
     }
 
     override fun getAcceptedTerms(): Boolean {

--- a/app/src/main/java/com/weatherxm/data/datasource/DevicePhotoDataSource.kt
+++ b/app/src/main/java/com/weatherxm/data/datasource/DevicePhotoDataSource.kt
@@ -18,6 +18,9 @@ interface DevicePhotoDataSource {
 
     fun getAcceptedTerms(): Boolean
     fun setAcceptedTerms()
+    fun getDevicePhotoUploadingIds(deviceId: String): List<String>
+    fun addDevicePhotoUploadingId(deviceId: String, uploadingId: String)
+    fun removeDevicePhotoUploadingId(deviceId: String, uploadingId: String)
 }
 
 class DevicePhotoDataSourceImpl(
@@ -49,5 +52,17 @@ class DevicePhotoDataSourceImpl(
 
     override fun setAcceptedTerms() {
         cacheService.setPhotoVerificationAcceptedTerms()
+    }
+
+    override fun getDevicePhotoUploadingIds(deviceId: String): List<String> {
+        return cacheService.getDevicePhotoUploadingIds(deviceId)
+    }
+
+    override fun addDevicePhotoUploadingId(deviceId: String, uploadingId: String) {
+        cacheService.addDevicePhotoUploadingId(deviceId, uploadingId)
+    }
+
+    override fun removeDevicePhotoUploadingId(deviceId: String, uploadingId: String) {
+        cacheService.removeDevicePhotoUploadingId(deviceId, uploadingId)
     }
 }

--- a/app/src/main/java/com/weatherxm/data/datasource/DevicePhotoDataSource.kt
+++ b/app/src/main/java/com/weatherxm/data/datasource/DevicePhotoDataSource.kt
@@ -5,6 +5,7 @@ import com.weatherxm.data.mapResponse
 import com.weatherxm.data.models.Failure
 import com.weatherxm.data.models.PhotoPresignedMetadata
 import com.weatherxm.data.network.ApiService
+import com.weatherxm.data.network.PhotoNamesBody
 import com.weatherxm.data.services.CacheService
 
 interface DevicePhotoDataSource {
@@ -38,7 +39,8 @@ class DevicePhotoDataSourceImpl(
         deviceId: String,
         photoNames: List<String>
     ): Either<Failure, List<PhotoPresignedMetadata>> {
-        return apiService.getPhotosMetadataForUpload(deviceId, photoNames).mapResponse()
+        return apiService.getPhotosMetadataForUpload(deviceId, PhotoNamesBody(photoNames))
+            .mapResponse()
     }
 
     override fun getAcceptedTerms(): Boolean {

--- a/app/src/main/java/com/weatherxm/data/models/ApiModels.kt
+++ b/app/src/main/java/com/weatherxm/data/models/ApiModels.kt
@@ -831,6 +831,34 @@ data class DeviceRewardsSummaryDetails(
     }
 }
 
+@Keep
+@JsonClass(generateAdapter = true)
+@Parcelize
+data class PhotoPresignedMetadata(
+    val url: String,
+    val fields: AWSMetadata
+) : Parcelable
+
+@Keep
+@JsonClass(generateAdapter = true)
+@Parcelize
+data class AWSMetadata(
+    val bucket: String,
+    @Json(name = "X-Amz-Algorithm")
+    val xAmzAlgo: String,
+    @Json(name = "X-Amz-Credential")
+    val xAmzCredentials: String,
+    @Json(name = "X-Amz-Date")
+    val xAmzDate: String,
+// TODO STOPSHIP: Do what with this?   @Json(name = "X-Amz-Security-Token")
+//    val xAmzSecurityToken: String,
+    @Json(name = "X-Amz-Signature")
+    val xAmzSignature: String,
+    val key: String,
+    @Json(name = "Policy")
+    val policy: String,
+) : Parcelable
+
 @Suppress("EnumNaming")
 enum class Connectivity {
     wifi,

--- a/app/src/main/java/com/weatherxm/data/models/ApiModels.kt
+++ b/app/src/main/java/com/weatherxm/data/models/ApiModels.kt
@@ -843,20 +843,20 @@ data class PhotoPresignedMetadata(
 @JsonClass(generateAdapter = true)
 @Parcelize
 data class AWSMetadata(
-    val bucket: String,
+    val bucket: String?,
     @Json(name = "X-Amz-Algorithm")
-    val xAmzAlgo: String,
+    val xAmzAlgo: String?,
     @Json(name = "X-Amz-Credential")
-    val xAmzCredentials: String,
+    val xAmzCredentials: String?,
     @Json(name = "X-Amz-Date")
-    val xAmzDate: String,
-// TODO STOPSHIP: Do what with this?   @Json(name = "X-Amz-Security-Token")
-//    val xAmzSecurityToken: String,
+    val xAmzDate: String?,
+    @Json(name = "X-Amz-Security-Token")
+    val xAmzSecurityToken: String?,
     @Json(name = "X-Amz-Signature")
-    val xAmzSignature: String,
-    val key: String,
+    val xAmzSignature: String?,
+    val key: String?,
     @Json(name = "Policy")
-    val policy: String,
+    val policy: String?,
 ) : Parcelable
 
 @Suppress("EnumNaming")

--- a/app/src/main/java/com/weatherxm/data/models/ApiModels.kt
+++ b/app/src/main/java/com/weatherxm/data/models/ApiModels.kt
@@ -831,13 +831,6 @@ data class DeviceRewardsSummaryDetails(
     }
 }
 
-@Keep
-@JsonClass(generateAdapter = true)
-@Parcelize
-data class DevicePhoto(
-    val url: String
-) : Parcelable
-
 @Suppress("EnumNaming")
 enum class Connectivity {
     wifi,

--- a/app/src/main/java/com/weatherxm/data/network/ApiService.kt
+++ b/app/src/main/java/com/weatherxm/data/network/ApiService.kt
@@ -307,6 +307,6 @@ interface ApiService {
     @POST("/api/v1/me/devices/{deviceId}/photos")
     suspend fun getPhotosMetadataForUpload(
         @Path("deviceId") deviceId: String,
-        @Body photoNames: List<String>
+        @Body names: PhotoNamesBody
     ): NetworkResponse<List<PhotoPresignedMetadata>, ErrorResponse>
 }

--- a/app/src/main/java/com/weatherxm/data/network/ApiService.kt
+++ b/app/src/main/java/com/weatherxm/data/network/ApiService.kt
@@ -7,7 +7,6 @@ import com.haroldadmin.cnradapter.NetworkResponse
 import com.weatherxm.data.models.BoostRewardResponse
 import com.weatherxm.data.models.Device
 import com.weatherxm.data.models.DeviceInfo
-import com.weatherxm.data.models.DevicePhoto
 import com.weatherxm.data.models.DeviceRewardsSummary
 import com.weatherxm.data.models.DevicesRewards
 import com.weatherxm.data.models.NetworkSearchResults
@@ -287,8 +286,17 @@ interface ApiService {
     @Mock
     @MockBehavior(durationDeviation = 500, durationMillis = 2000)
     @MockResponse(code = 200, body = "mock_files/device_photos_list.json")
-    @POST("/api/v1/me/devices/{deviceId}/photos")
+    @GET("/api/v1/me/devices/{deviceId}/photos")
     suspend fun getDevicePhotos(
         @Path("deviceId") deviceId: String
-    ): NetworkResponse<List<DevicePhoto>, ErrorResponse>
+    ): NetworkResponse<List<String>, ErrorResponse>
+
+    @Mock
+    @MockBehavior(durationDeviation = 500, durationMillis = 2000)
+    @MockResponse(code = 204, body = "mock_files/empty_response.json")
+    @DELETE("/api/v1/me/devices/{deviceId}/photos/{photoId}")
+    suspend fun deleteDevicePhoto(
+        @Path("deviceId") deviceId: String,
+        @Path("photoId") photoName: String
+    ): NetworkResponse<Unit, ErrorResponse>
 }

--- a/app/src/main/java/com/weatherxm/data/network/ApiService.kt
+++ b/app/src/main/java/com/weatherxm/data/network/ApiService.kt
@@ -11,6 +11,7 @@ import com.weatherxm.data.models.DeviceRewardsSummary
 import com.weatherxm.data.models.DevicesRewards
 import com.weatherxm.data.models.NetworkSearchResults
 import com.weatherxm.data.models.NetworkStatsResponse
+import com.weatherxm.data.models.PhotoPresignedMetadata
 import com.weatherxm.data.models.PublicDevice
 import com.weatherxm.data.models.PublicHex
 import com.weatherxm.data.models.RewardDetails
@@ -299,4 +300,13 @@ interface ApiService {
         @Path("deviceId") deviceId: String,
         @Path("photoId") photoName: String
     ): NetworkResponse<Unit, ErrorResponse>
+
+    @Mock
+    @MockBehavior(durationDeviation = 500, durationMillis = 2000)
+    @MockResponse(code = 204, body = "mock_files/get_photos_presigned_metadata.json")
+    @POST("/api/v1/me/devices/{deviceId}/photos")
+    suspend fun getPhotosMetadataForUpload(
+        @Path("deviceId") deviceId: String,
+        @Body photoNames: List<String>
+    ): NetworkResponse<List<PhotoPresignedMetadata>, ErrorResponse>
 }

--- a/app/src/main/java/com/weatherxm/data/network/Payloads.kt
+++ b/app/src/main/java/com/weatherxm/data/network/Payloads.kt
@@ -71,3 +71,9 @@ data class LocationBody(
     val lat: Double,
     val lon: Double
 ) : Parcelable
+
+@JsonClass(generateAdapter = true)
+@Parcelize
+data class PhotoNamesBody(
+    val names: List<String>
+) : Parcelable

--- a/app/src/main/java/com/weatherxm/data/repository/DevicePhotoRepository.kt
+++ b/app/src/main/java/com/weatherxm/data/repository/DevicePhotoRepository.kt
@@ -4,6 +4,7 @@ import arrow.core.Either
 import com.weatherxm.data.datasource.DevicePhotoDataSource
 import com.weatherxm.data.models.Failure
 import com.weatherxm.data.models.PhotoPresignedMetadata
+import java.util.UUID
 
 interface DevicePhotoRepository {
     suspend fun getDevicePhotos(deviceId: String): Either<Failure, List<String>>
@@ -41,8 +42,9 @@ class DevicePhotoRepositoryImpl(
         deviceId: String,
         photoPaths: List<String>
     ): Either<Failure, List<PhotoPresignedMetadata>> {
-        val photoNames = photoPaths.mapIndexed { i, path ->
-            path.substringAfterLast('/').replaceBeforeLast('.', "img$i")
+        val photoNames = photoPaths.map {
+            val uuid = UUID.nameUUIDFromBytes(it.substringAfterLast('/').toByteArray()).toString()
+            "$uuid.jpg"
         }
         return datasource.getPhotosMetadataForUpload(deviceId, photoNames)
     }

--- a/app/src/main/java/com/weatherxm/data/repository/DevicePhotoRepository.kt
+++ b/app/src/main/java/com/weatherxm/data/repository/DevicePhotoRepository.kt
@@ -24,7 +24,6 @@ interface DevicePhotoRepository {
         request: MultipartUploadRequest
     )
 
-    fun removeDevicePhotoUploadId(deviceId: String, uploadId: String)
     fun getUploadIdRequest(uploadId: String): MultipartUploadRequest?
 }
 
@@ -77,10 +76,6 @@ class DevicePhotoRepositoryImpl(
         request: MultipartUploadRequest
     ) {
         datasource.addDevicePhotoUploadIdAndRequest(deviceId, uploadId, request)
-    }
-
-    override fun removeDevicePhotoUploadId(deviceId: String, uploadId: String) {
-        datasource.removeDevicePhotoUploadId(deviceId, uploadId)
     }
 
     override fun getUploadIdRequest(uploadId: String): MultipartUploadRequest? {

--- a/app/src/main/java/com/weatherxm/data/repository/DevicePhotoRepository.kt
+++ b/app/src/main/java/com/weatherxm/data/repository/DevicePhotoRepository.kt
@@ -31,9 +31,9 @@ class DevicePhotoRepositoryImpl(
         /**
          * photoPath = https://weatherxm.com/my-weather-station/photo1.jpg
          * will become
-         * photoName = photo1
+         * photoName = photo1.jpg
          */
-        val photoName = photoPath.substringAfterLast('/').substringBeforeLast('.')
+        val photoName = photoPath.substringAfterLast('/')
         return datasource.deleteDevicePhoto(deviceId, photoName)
     }
 

--- a/app/src/main/java/com/weatherxm/data/repository/DevicePhotoRepository.kt
+++ b/app/src/main/java/com/weatherxm/data/repository/DevicePhotoRepository.kt
@@ -2,11 +2,11 @@ package com.weatherxm.data.repository
 
 import arrow.core.Either
 import com.weatherxm.data.datasource.DevicePhotoDataSource
-import com.weatherxm.data.models.DevicePhoto
 import com.weatherxm.data.models.Failure
 
 interface DevicePhotoRepository {
-    suspend fun getDevicePhotos(deviceId: String): Either<Failure, List<DevicePhoto>>
+    suspend fun getDevicePhotos(deviceId: String): Either<Failure, List<String>>
+    suspend fun deleteDevicePhoto(deviceId: String, photoPath: String): Either<Failure, Unit>
     fun getAcceptedTerms(): Boolean
     fun setAcceptedTerms()
 }
@@ -14,8 +14,21 @@ interface DevicePhotoRepository {
 class DevicePhotoRepositoryImpl(
     private val datasource: DevicePhotoDataSource
 ) : DevicePhotoRepository {
-    override suspend fun getDevicePhotos(deviceId: String): Either<Failure, List<DevicePhoto>> {
+    override suspend fun getDevicePhotos(deviceId: String): Either<Failure, List<String>> {
         return datasource.getDevicePhotos(deviceId)
+    }
+
+    override suspend fun deleteDevicePhoto(
+        deviceId: String,
+        photoPath: String
+    ): Either<Failure, Unit> {
+        /**
+         * photoPath = https://weatherxm.com/my-weather-station/photo1.jpg
+         * will become
+         * photoName = photo1
+         */
+        val photoName = photoPath.substringAfterLast('/').substringBeforeLast('.')
+        return datasource.deleteDevicePhoto(deviceId, photoName)
     }
 
     override fun getAcceptedTerms(): Boolean {

--- a/app/src/main/java/com/weatherxm/data/repository/DevicePhotoRepository.kt
+++ b/app/src/main/java/com/weatherxm/data/repository/DevicePhotoRepository.kt
@@ -16,6 +16,9 @@ interface DevicePhotoRepository {
 
     fun getAcceptedTerms(): Boolean
     fun setAcceptedTerms()
+    fun getDevicePhotoUploadingIds(deviceId: String): List<String>
+    fun addDevicePhotoUploadingId(deviceId: String, uploadingId: String)
+    fun removeDevicePhotoUploadingId(deviceId: String, uploadingId: String)
 }
 
 class DevicePhotoRepositoryImpl(
@@ -55,5 +58,17 @@ class DevicePhotoRepositoryImpl(
 
     override fun setAcceptedTerms() {
         datasource.setAcceptedTerms()
+    }
+
+    override fun getDevicePhotoUploadingIds(deviceId: String): List<String> {
+        return datasource.getDevicePhotoUploadingIds(deviceId)
+    }
+
+    override fun addDevicePhotoUploadingId(deviceId: String, uploadingId: String) {
+        datasource.addDevicePhotoUploadingId(deviceId, uploadingId)
+    }
+
+    override fun removeDevicePhotoUploadingId(deviceId: String, uploadingId: String) {
+        datasource.removeDevicePhotoUploadingId(deviceId, uploadingId)
     }
 }

--- a/app/src/main/java/com/weatherxm/data/repository/DevicePhotoRepository.kt
+++ b/app/src/main/java/com/weatherxm/data/repository/DevicePhotoRepository.kt
@@ -4,6 +4,7 @@ import arrow.core.Either
 import com.weatherxm.data.datasource.DevicePhotoDataSource
 import com.weatherxm.data.models.Failure
 import com.weatherxm.data.models.PhotoPresignedMetadata
+import net.gotev.uploadservice.protocols.multipart.MultipartUploadRequest
 import java.util.UUID
 
 interface DevicePhotoRepository {
@@ -16,9 +17,15 @@ interface DevicePhotoRepository {
 
     fun getAcceptedTerms(): Boolean
     fun setAcceptedTerms()
-    fun getDevicePhotoUploadingIds(deviceId: String): List<String>
-    fun addDevicePhotoUploadingId(deviceId: String, uploadingId: String)
-    fun removeDevicePhotoUploadingId(deviceId: String, uploadingId: String)
+    fun getDevicePhotoUploadIds(deviceId: String): List<String>
+    fun addDevicePhotoUploadIdAndRequest(
+        deviceId: String,
+        uploadId: String,
+        request: MultipartUploadRequest
+    )
+
+    fun removeDevicePhotoUploadId(deviceId: String, uploadId: String)
+    fun getUploadIdRequest(uploadId: String): MultipartUploadRequest?
 }
 
 class DevicePhotoRepositoryImpl(
@@ -60,15 +67,23 @@ class DevicePhotoRepositoryImpl(
         datasource.setAcceptedTerms()
     }
 
-    override fun getDevicePhotoUploadingIds(deviceId: String): List<String> {
-        return datasource.getDevicePhotoUploadingIds(deviceId)
+    override fun getDevicePhotoUploadIds(deviceId: String): List<String> {
+        return datasource.getDevicePhotoUploadIds(deviceId)
     }
 
-    override fun addDevicePhotoUploadingId(deviceId: String, uploadingId: String) {
-        datasource.addDevicePhotoUploadingId(deviceId, uploadingId)
+    override fun addDevicePhotoUploadIdAndRequest(
+        deviceId: String,
+        uploadId: String,
+        request: MultipartUploadRequest
+    ) {
+        datasource.addDevicePhotoUploadIdAndRequest(deviceId, uploadId, request)
     }
 
-    override fun removeDevicePhotoUploadingId(deviceId: String, uploadingId: String) {
-        datasource.removeDevicePhotoUploadingId(deviceId, uploadingId)
+    override fun removeDevicePhotoUploadId(deviceId: String, uploadId: String) {
+        datasource.removeDevicePhotoUploadId(deviceId, uploadId)
+    }
+
+    override fun getUploadIdRequest(uploadId: String): MultipartUploadRequest? {
+        return datasource.getUploadIdRequest(uploadId)
     }
 }

--- a/app/src/main/java/com/weatherxm/data/repository/DevicePhotoRepository.kt
+++ b/app/src/main/java/com/weatherxm/data/repository/DevicePhotoRepository.kt
@@ -3,10 +3,16 @@ package com.weatherxm.data.repository
 import arrow.core.Either
 import com.weatherxm.data.datasource.DevicePhotoDataSource
 import com.weatherxm.data.models.Failure
+import com.weatherxm.data.models.PhotoPresignedMetadata
 
 interface DevicePhotoRepository {
     suspend fun getDevicePhotos(deviceId: String): Either<Failure, List<String>>
     suspend fun deleteDevicePhoto(deviceId: String, photoPath: String): Either<Failure, Unit>
+    suspend fun getPhotosMetadataForUpload(
+        deviceId: String,
+        photoPaths: List<String>
+    ): Either<Failure, List<PhotoPresignedMetadata>>
+
     fun getAcceptedTerms(): Boolean
     fun setAcceptedTerms()
 }
@@ -29,6 +35,16 @@ class DevicePhotoRepositoryImpl(
          */
         val photoName = photoPath.substringAfterLast('/').substringBeforeLast('.')
         return datasource.deleteDevicePhoto(deviceId, photoName)
+    }
+
+    override suspend fun getPhotosMetadataForUpload(
+        deviceId: String,
+        photoPaths: List<String>
+    ): Either<Failure, List<PhotoPresignedMetadata>> {
+        val photoNames = photoPaths.mapIndexed { i, path ->
+            path.substringAfterLast('/').replaceBeforeLast('.', "img$i")
+        }
+        return datasource.getPhotosMetadataForUpload(deviceId, photoNames)
     }
 
     override fun getAcceptedTerms(): Boolean {

--- a/app/src/main/java/com/weatherxm/data/services/CacheService.kt
+++ b/app/src/main/java/com/weatherxm/data/services/CacheService.kt
@@ -211,7 +211,11 @@ class CacheService(
     }
 
     fun addDevicePhotoUploadId(deviceId: String, uploadId: String) {
-        this.devicePhotoUploadIds[deviceId]?.add(uploadId)
+        if (this.devicePhotoUploadIds[deviceId] == null) {
+            this.devicePhotoUploadIds[deviceId] = mutableListOf(uploadId)
+        } else {
+            this.devicePhotoUploadIds[deviceId]?.add(uploadId)
+        }
     }
 
     fun removeDevicePhotoUploadId(deviceId: String, uploadId: String) {

--- a/app/src/main/java/com/weatherxm/data/services/CacheService.kt
+++ b/app/src/main/java/com/weatherxm/data/services/CacheService.kt
@@ -18,6 +18,7 @@ import com.weatherxm.data.models.WeatherData
 import com.weatherxm.data.network.AuthToken
 import com.weatherxm.ui.common.empty
 import com.weatherxm.util.Resources
+import net.gotev.uploadservice.protocols.multipart.MultipartUploadRequest
 import okhttp3.Cache
 import java.util.concurrent.TimeUnit
 
@@ -70,7 +71,8 @@ class CacheService(
     private var forecasts: ArrayMap<String, TimedForecastData> = ArrayMap()
     private var suggestions: ArrayMap<String, List<SearchSuggestion>> = ArrayMap()
     private var locations: ArrayMap<String, Location> = ArrayMap()
-    private var devicePhotoUploadingIds: ArrayMap<String, MutableList<String>> = ArrayMap()
+    private var devicePhotoUploadIds: ArrayMap<String, MutableList<String>> = ArrayMap()
+    private var uploadIdRequest: ArrayMap<String, MultipartUploadRequest> = ArrayMap()
     private var followedStationsIds = listOf<String>()
     private var userStationsIds = listOf<String>()
     private var countriesInfo = listOf<CountryInfo>()
@@ -204,16 +206,28 @@ class CacheService(
         locations[suggestion.id] = location
     }
 
-    fun getDevicePhotoUploadingIds(deviceId: String): List<String> {
-        return devicePhotoUploadingIds[deviceId] ?: listOf()
+    fun getDevicePhotoUploadIds(deviceId: String): List<String> {
+        return devicePhotoUploadIds[deviceId] ?: listOf()
     }
 
-    fun addDevicePhotoUploadingId(deviceId: String, uploadingId: String) {
-        this.devicePhotoUploadingIds[deviceId]?.add(uploadingId)
+    fun addDevicePhotoUploadId(deviceId: String, uploadId: String) {
+        this.devicePhotoUploadIds[deviceId]?.add(uploadId)
     }
 
-    fun removeDevicePhotoUploadingId(deviceId: String, uploadingId: String) {
-        this.devicePhotoUploadingIds[deviceId]?.remove(uploadingId)
+    fun removeDevicePhotoUploadId(deviceId: String, uploadId: String) {
+        this.devicePhotoUploadIds[deviceId]?.remove(uploadId)
+    }
+
+    fun getUploadIdRequest(uploadId: String): MultipartUploadRequest? {
+        return uploadIdRequest[uploadId]
+    }
+
+    fun setUploadIdRequest(uploadId: String, request: MultipartUploadRequest) {
+        uploadIdRequest[uploadId] = request
+    }
+
+    fun removeUploadIdRequest(uploadId: String) {
+        uploadIdRequest.remove(uploadId)
     }
 
     fun setWalletWarningDismissTimestamp(timestamp: Long) {
@@ -353,14 +367,15 @@ class CacheService(
     }
 
     fun clearAll() {
-        this.walletAddress = null
-        this.user = null
-        this.forecasts.clear()
-        this.suggestions.clear()
-        this.devicePhotoUploadingIds.clear()
-        this.locations.clear()
-        this.followedStationsIds = listOf()
-        this.userStationsIds = listOf()
+        walletAddress = null
+        user = null
+        forecasts.clear()
+        suggestions.clear()
+        devicePhotoUploadIds.clear()
+        uploadIdRequest.clear()
+        locations.clear()
+        followedStationsIds = listOf()
+        userStationsIds = listOf()
 
         okHttpCache.evictAll()
         encryptedPreferences.edit().clear().apply()
@@ -370,7 +385,8 @@ class CacheService(
     fun isCacheEmpty(): Boolean {
         return walletAddress == null && user == null && forecasts.isEmpty()
             && suggestions.isEmpty() && locations.isEmpty() && followedStationsIds.isEmpty()
-            && userStationsIds.isEmpty() && devicePhotoUploadingIds.isEmpty()
+            && userStationsIds.isEmpty() && devicePhotoUploadIds.isEmpty()
+            && uploadIdRequest.isEmpty()
     }
 
     /**

--- a/app/src/main/java/com/weatherxm/data/services/CacheService.kt
+++ b/app/src/main/java/com/weatherxm/data/services/CacheService.kt
@@ -70,6 +70,7 @@ class CacheService(
     private var forecasts: ArrayMap<String, TimedForecastData> = ArrayMap()
     private var suggestions: ArrayMap<String, List<SearchSuggestion>> = ArrayMap()
     private var locations: ArrayMap<String, Location> = ArrayMap()
+    private var devicePhotoUploadingIds: ArrayMap<String, MutableList<String>> = ArrayMap()
     private var followedStationsIds = listOf<String>()
     private var userStationsIds = listOf<String>()
     private var countriesInfo = listOf<CountryInfo>()
@@ -201,6 +202,18 @@ class CacheService(
 
     fun setSuggestionLocation(suggestion: SearchSuggestion, location: Location) {
         locations[suggestion.id] = location
+    }
+
+    fun getDevicePhotoUploadingIds(deviceId: String): List<String> {
+        return devicePhotoUploadingIds[deviceId] ?: listOf()
+    }
+
+    fun addDevicePhotoUploadingId(deviceId: String, uploadingId: String) {
+        this.devicePhotoUploadingIds[deviceId]?.add(uploadingId)
+    }
+
+    fun removeDevicePhotoUploadingId(deviceId: String, uploadingId: String) {
+        this.devicePhotoUploadingIds[deviceId]?.remove(uploadingId)
     }
 
     fun setWalletWarningDismissTimestamp(timestamp: Long) {
@@ -344,6 +357,7 @@ class CacheService(
         this.user = null
         this.forecasts.clear()
         this.suggestions.clear()
+        this.devicePhotoUploadingIds.clear()
         this.locations.clear()
         this.followedStationsIds = listOf()
         this.userStationsIds = listOf()
@@ -356,7 +370,7 @@ class CacheService(
     fun isCacheEmpty(): Boolean {
         return walletAddress == null && user == null && forecasts.isEmpty()
             && suggestions.isEmpty() && locations.isEmpty() && followedStationsIds.isEmpty()
-            && userStationsIds.isEmpty()
+            && userStationsIds.isEmpty() && devicePhotoUploadingIds.isEmpty()
     }
 
     /**

--- a/app/src/main/java/com/weatherxm/service/GlobalUploadObserverService.kt
+++ b/app/src/main/java/com/weatherxm/service/GlobalUploadObserverService.kt
@@ -36,7 +36,8 @@ class GlobalUploadObserverService(
             UploadPhotosState(
                 device,
                 uploadInfo.progressPercent,
-                false
+                isSuccess = false,
+                isError = false
             )
         )
     }
@@ -57,7 +58,8 @@ class GlobalUploadObserverService(
             UploadPhotosState(
                 device,
                 uploadInfo.progressPercent,
-                true
+                isSuccess = true,
+                isError = false
             )
         )
 
@@ -84,8 +86,8 @@ class GlobalUploadObserverService(
             UploadPhotosState(
                 device,
                 uploadInfo.progressPercent,
-                false,
-                uploadInfo
+                isSuccess = false,
+                isError = true
             )
         )
     }

--- a/app/src/main/java/com/weatherxm/service/GlobalUploadObserverService.kt
+++ b/app/src/main/java/com/weatherxm/service/GlobalUploadObserverService.kt
@@ -70,22 +70,39 @@ class GlobalUploadObserverService(
         when (exception) {
             is UserCancelledUploadException -> {
                 Timber.e(exception, "[UPLOAD SERVICE] User Cancelled: $uploadInfo")
+                onUploadPhotosState.tryEmit(
+                    UploadPhotosState(
+                        device,
+                        uploadInfo.progressPercent,
+                        isSuccess = false,
+                        isError = false,
+                        isCancelled = true
+                    )
+                )
             }
             is UploadError -> {
                 Timber.e(exception, "[UPLOAD SERVICE] Error: ${exception.serverResponse}")
+                onUploadPhotosState.tryEmit(
+                    UploadPhotosState(
+                        device,
+                        uploadInfo.progressPercent,
+                        isSuccess = false,
+                        isError = true
+                    )
+                )
             }
             else -> {
                 Timber.e(exception, "[UPLOAD SERVICE] Error: $uploadInfo")
+                onUploadPhotosState.tryEmit(
+                    UploadPhotosState(
+                        device,
+                        uploadInfo.progressPercent,
+                        isSuccess = false,
+                        isError = true
+                    )
+                )
             }
         }
-        onUploadPhotosState.tryEmit(
-            UploadPhotosState(
-                device,
-                uploadInfo.progressPercent,
-                isSuccess = false,
-                isError = true
-            )
-        )
     }
 
     override fun onCompleted(context: Context, uploadInfo: UploadInfo) {

--- a/app/src/main/java/com/weatherxm/service/GlobalUploadObserverService.kt
+++ b/app/src/main/java/com/weatherxm/service/GlobalUploadObserverService.kt
@@ -17,7 +17,6 @@ import net.gotev.uploadservice.exceptions.UserCancelledUploadException
 import net.gotev.uploadservice.network.ServerResponse
 import net.gotev.uploadservice.observer.request.RequestObserverDelegate
 import timber.log.Timber
-import java.io.File
 
 class GlobalUploadObserverService(
     private val analytics: AnalyticsWrapper,
@@ -62,9 +61,6 @@ class GlobalUploadObserverService(
                 isError = false
             )
         )
-        uploadInfo.files.forEach {
-            File(it.path).delete()
-        }
         cacheService.removeUploadIdRequest(uploadInfo.uploadId)
         cacheService.removeDevicePhotoUploadId(device.id, uploadInfo.uploadId)
         onUploadPhotosState.resetReplayCache()

--- a/app/src/main/java/com/weatherxm/service/GlobalUploadObserverService.kt
+++ b/app/src/main/java/com/weatherxm/service/GlobalUploadObserverService.kt
@@ -16,6 +16,7 @@ import net.gotev.uploadservice.exceptions.UserCancelledUploadException
 import net.gotev.uploadservice.network.ServerResponse
 import net.gotev.uploadservice.observer.request.RequestObserverDelegate
 import timber.log.Timber
+import java.io.File
 
 class GlobalUploadObserverService(
     private val analytics: AnalyticsWrapper
@@ -57,6 +58,10 @@ class GlobalUploadObserverService(
                 true
             )
         )
+
+        uploadInfo.files.forEach {
+            File(it.path).delete()
+        }
         onUploadPhotosState.resetReplayCache()
     }
 

--- a/app/src/main/java/com/weatherxm/service/GlobalUploadObserverService.kt
+++ b/app/src/main/java/com/weatherxm/service/GlobalUploadObserverService.kt
@@ -64,7 +64,7 @@ class GlobalUploadObserverService(
         uploadInfo.files.forEach {
             File(it.path).delete()
         }
-        cacheService.removeDevicePhotoUploadingId(device.id, uploadInfo.uploadId)
+        cacheService.removeDevicePhotoUploadId(device.id, uploadInfo.uploadId)
         onUploadPhotosState.resetReplayCache()
     }
 

--- a/app/src/main/java/com/weatherxm/service/GlobalUploadObserverService.kt
+++ b/app/src/main/java/com/weatherxm/service/GlobalUploadObserverService.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import com.google.firebase.analytics.FirebaseAnalytics
 import com.weatherxm.analytics.AnalyticsService
 import com.weatherxm.analytics.AnalyticsWrapper
+import com.weatherxm.data.services.CacheService
 import com.weatherxm.ui.common.UIDevice
 import com.weatherxm.ui.common.UploadPhotosState
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -19,7 +20,8 @@ import timber.log.Timber
 import java.io.File
 
 class GlobalUploadObserverService(
-    private val analytics: AnalyticsWrapper
+    private val analytics: AnalyticsWrapper,
+    private val cacheService: CacheService
 ) : RequestObserverDelegate {
 
     private var device = UIDevice.empty()
@@ -62,6 +64,7 @@ class GlobalUploadObserverService(
         uploadInfo.files.forEach {
             File(it.path).delete()
         }
+        cacheService.removeDevicePhotoUploadingId(device.id, uploadInfo.uploadId)
         onUploadPhotosState.resetReplayCache()
     }
 

--- a/app/src/main/java/com/weatherxm/service/GlobalUploadObserverService.kt
+++ b/app/src/main/java/com/weatherxm/service/GlobalUploadObserverService.kt
@@ -62,10 +62,10 @@ class GlobalUploadObserverService(
                 isError = false
             )
         )
-
         uploadInfo.files.forEach {
             File(it.path).delete()
         }
+        cacheService.removeUploadIdRequest(uploadInfo.uploadId)
         cacheService.removeDevicePhotoUploadId(device.id, uploadInfo.uploadId)
         onUploadPhotosState.resetReplayCache()
     }

--- a/app/src/main/java/com/weatherxm/service/workers/UploadPhotoWorker.kt
+++ b/app/src/main/java/com/weatherxm/service/workers/UploadPhotoWorker.kt
@@ -105,7 +105,7 @@ class UploadPhotoWorker(
             policy?.let { addParameter(POLICY, policy) }
             addFileToUpload(photoPath, "file")
             val uploadId = startUpload()
-            photoRepository.addDevicePhotoUploadingId(deviceId, uploadId)
+            photoRepository.addDevicePhotoUploadIdAndRequest(deviceId, uploadId, this)
         }
 
         return Result.success()

--- a/app/src/main/java/com/weatherxm/service/workers/UploadPhotoWorker.kt
+++ b/app/src/main/java/com/weatherxm/service/workers/UploadPhotoWorker.kt
@@ -113,6 +113,7 @@ class UploadPhotoWorker(
             setNotificationConfig { _, uploadId ->
                 getNotificationConfig(uploadId)
             }
+            setAutoDeleteFilesAfterSuccessfulUpload(true)
             val uploadId = startUpload()
             photoRepository.addDevicePhotoUploadIdAndRequest(deviceId, uploadId, this)
         }

--- a/app/src/main/java/com/weatherxm/service/workers/UploadPhotoWorker.kt
+++ b/app/src/main/java/com/weatherxm/service/workers/UploadPhotoWorker.kt
@@ -1,0 +1,101 @@
+package com.weatherxm.service.workers
+
+import android.content.Context
+import androidx.work.Constraints
+import androidx.work.CoroutineWorker
+import androidx.work.Data
+import androidx.work.ExistingWorkPolicy
+import androidx.work.OneTimeWorkRequestBuilder
+import androidx.work.WorkManager
+import androidx.work.WorkerParameters
+import com.weatherxm.data.models.PhotoPresignedMetadata
+import com.weatherxm.data.requireNetwork
+import com.weatherxm.ui.common.Contracts.ARG_DEVICE_ID
+import net.gotev.uploadservice.protocols.multipart.MultipartUploadRequest
+import org.koin.core.component.KoinComponent
+import timber.log.Timber
+
+class UploadPhotoWorker(
+    private val context: Context,
+    private val workerParams: WorkerParameters
+) : CoroutineWorker(context, workerParams), KoinComponent {
+    companion object {
+        private const val UPLOAD_URL = "uploadUrl"
+        private const val PHOTO_PATH = "photoPath"
+        private const val BUCKET = "bucket"
+        private const val ALGO = "X-Amz-Algorithm"
+        private const val CREDENTIALS = "X-Amz-Credential"
+        private const val DATE = "X-Amz-Date"
+        private const val SECURITY_TOKEN = "X-Amz-Security-Token"
+        private const val SIGNATURE = "X-Amz-Signature"
+        private const val KEY = "key"
+        private const val POLICY = "Policy"
+
+        fun initAndStart(
+            context: Context,
+            metadata: PhotoPresignedMetadata,
+            photoPath: String,
+            deviceId: String
+        ) {
+            Timber.d("Creating Upload Photos Work Manager for device [$deviceId].")
+            val data = Data.Builder()
+                .putString(ARG_DEVICE_ID, deviceId)
+                .putString(PHOTO_PATH, photoPath)
+                .putString(UPLOAD_URL, metadata.url)
+                .putString(BUCKET, metadata.fields.bucket)
+                .putString(ALGO, metadata.fields.xAmzAlgo)
+                .putString(CREDENTIALS, metadata.fields.xAmzCredentials)
+                .putString(DATE, metadata.fields.xAmzDate)
+                .putString(SECURITY_TOKEN, metadata.fields.xAmzSecurityToken)
+                .putString(SIGNATURE, metadata.fields.xAmzSignature)
+                .putString(KEY, metadata.fields.key)
+                .putString(POLICY, metadata.fields.policy)
+
+            val uploadRequest = OneTimeWorkRequestBuilder<UploadPhotoWorker>()
+                .setConstraints(Constraints.requireNetwork())
+                .setInputData(data.build())
+                .build()
+
+            WorkManager.getInstance(context).enqueueUniqueWork(
+                "UPLOAD_PHOTO_${photoPath}_$deviceId",
+                ExistingWorkPolicy.REPLACE,
+                uploadRequest
+            )
+        }
+    }
+
+    override suspend fun doWork(): Result {
+        val deviceId = workerParams.inputData.getString(ARG_DEVICE_ID)
+        val uploadUrl = workerParams.inputData.getString(UPLOAD_URL)
+        val photoPath = workerParams.inputData.getString(PHOTO_PATH)
+        val bucket = workerParams.inputData.getString(BUCKET)
+        val algo = workerParams.inputData.getString(ALGO)
+        val credentials = workerParams.inputData.getString(CREDENTIALS)
+        val date = workerParams.inputData.getString(DATE)
+        val securityToken = workerParams.inputData.getString(SECURITY_TOKEN)
+        val signature = workerParams.inputData.getString(SIGNATURE)
+        val key = workerParams.inputData.getString(KEY)
+        val policy = workerParams.inputData.getString(POLICY)
+        if (deviceId.isNullOrEmpty() || uploadUrl.isNullOrEmpty() || photoPath.isNullOrEmpty()) {
+            Timber.d("Cancelling Upload Photos Work Manager for device [$deviceId].")
+            WorkManager.getInstance(context).cancelWorkById(workerParams.id)
+            return Result.failure()
+        }
+        Timber.d("Starting Upload Photos Work Manager for device [$deviceId].")
+
+        with(MultipartUploadRequest(context, uploadUrl).setMethod("POST")) {
+            bucket?.let { addParameter(BUCKET, bucket) }
+            algo?.let { addParameter(ALGO, algo) }
+            credentials?.let { addParameter(CREDENTIALS, credentials) }
+            date?.let { addParameter(DATE, date) }
+            securityToken?.let { addParameter(SECURITY_TOKEN, securityToken) }
+            signature?.let { addParameter(SIGNATURE, signature) }
+            key?.let { addParameter(KEY, key) }
+            policy?.let { addParameter(POLICY, policy) }
+            addFileToUpload(photoPath, "file")
+            startUpload()
+        }
+
+        return Result.success()
+    }
+}

--- a/app/src/main/java/com/weatherxm/ui/Navigator.kt
+++ b/app/src/main/java/com/weatherxm/ui/Navigator.kt
@@ -41,9 +41,9 @@ import com.weatherxm.ui.common.Contracts.ARG_DEVICE_ID
 import com.weatherxm.ui.common.Contracts.ARG_DEVICE_TYPE
 import com.weatherxm.ui.common.Contracts.ARG_EXPLORER_CELL
 import com.weatherxm.ui.common.Contracts.ARG_FORECAST_SELECTED_DAY
-import com.weatherxm.ui.common.Contracts.ARG_NEW_PHOTO_VERIFICATION
 import com.weatherxm.ui.common.Contracts.ARG_INSTRUCTIONS_ONLY
 import com.weatherxm.ui.common.Contracts.ARG_NEEDS_PHOTO_VERIFICATION
+import com.weatherxm.ui.common.Contracts.ARG_NEW_PHOTO_VERIFICATION
 import com.weatherxm.ui.common.Contracts.ARG_OPEN_EXPLORER_ON_BACK
 import com.weatherxm.ui.common.Contracts.ARG_PHOTOS
 import com.weatherxm.ui.common.Contracts.ARG_REMOTE_MESSAGE
@@ -83,6 +83,7 @@ import com.weatherxm.ui.networkstats.NetworkStatsActivity
 import com.weatherxm.ui.passwordprompt.PasswordPromptFragment
 import com.weatherxm.ui.photoverification.gallery.PhotoGalleryActivity
 import com.weatherxm.ui.photoverification.intro.PhotoVerificationIntroActivity
+import com.weatherxm.ui.photoverification.upload.PhotoUploadActivity
 import com.weatherxm.ui.preferences.PreferenceActivity
 import com.weatherxm.ui.resetpassword.ResetPasswordActivity
 import com.weatherxm.ui.rewardboosts.RewardBoostActivity
@@ -537,6 +538,21 @@ class Navigator(private val analytics: AnalyticsWrapper) {
             context.startActivity(intent)
         } else {
             activityResultLauncher.launch(intent)
+        }
+    }
+
+    fun showPhotoUpload(
+        context: Context?,
+        device: UIDevice,
+        photos: ArrayList<String>
+    ) {
+        context?.let {
+            it.startActivity(
+                Intent(it, PhotoUploadActivity::class.java)
+                    .addFlags(Intent.FLAG_ACTIVITY_SINGLE_TOP or Intent.FLAG_ACTIVITY_CLEAR_TOP)
+                    .putExtra(ARG_DEVICE, device)
+                    .putStringArrayListExtra(ARG_PHOTOS, photos)
+            )
         }
     }
 

--- a/app/src/main/java/com/weatherxm/ui/Navigator.kt
+++ b/app/src/main/java/com/weatherxm/ui/Navigator.kt
@@ -510,6 +510,7 @@ class Navigator(private val analytics: AnalyticsWrapper) {
     fun showPhotoVerificationIntro(
         context: Context?,
         device: UIDevice,
+        photos: ArrayList<String> = arrayListOf(),
         instructionsOnly: Boolean = false
     ) {
         context?.let {
@@ -517,6 +518,7 @@ class Navigator(private val analytics: AnalyticsWrapper) {
                 Intent(it, PhotoVerificationIntroActivity::class.java)
                     .addFlags(Intent.FLAG_ACTIVITY_SINGLE_TOP or Intent.FLAG_ACTIVITY_CLEAR_TOP)
                     .putExtra(ARG_DEVICE, device)
+                    .putStringArrayListExtra(ARG_PHOTOS, photos)
                     .putExtra(ARG_INSTRUCTIONS_ONLY, instructionsOnly)
             )
         }

--- a/app/src/main/java/com/weatherxm/ui/common/UIModels.kt
+++ b/app/src/main/java/com/weatherxm/ui/common/UIModels.kt
@@ -640,7 +640,7 @@ data class UploadPhotosState(
     val device: UIDevice,
     val progress: Int,
     val isSuccess: Boolean,
-    val error: UploadInfo? = null
+    val isError: Boolean
 )
 
 enum class RewardTimelineType {

--- a/app/src/main/java/com/weatherxm/ui/common/UIModels.kt
+++ b/app/src/main/java/com/weatherxm/ui/common/UIModels.kt
@@ -16,7 +16,6 @@ import com.weatherxm.data.models.RewardSplit
 import com.weatherxm.data.models.SeverityLevel
 import com.weatherxm.data.repository.RewardsRepositoryImpl
 import kotlinx.parcelize.Parcelize
-import net.gotev.uploadservice.data.UploadInfo
 import java.time.LocalDate
 import java.time.ZonedDateTime
 

--- a/app/src/main/java/com/weatherxm/ui/common/UIModels.kt
+++ b/app/src/main/java/com/weatherxm/ui/common/UIModels.kt
@@ -639,7 +639,8 @@ data class UploadPhotosState(
     val device: UIDevice,
     val progress: Int,
     val isSuccess: Boolean,
-    val isError: Boolean
+    val isError: Boolean,
+    val isCancelled: Boolean = false
 )
 
 enum class RewardTimelineType {

--- a/app/src/main/java/com/weatherxm/ui/components/BaseInterface.kt
+++ b/app/src/main/java/com/weatherxm/ui/components/BaseInterface.kt
@@ -1,6 +1,8 @@
 package com.weatherxm.ui.components
 
 import android.Manifest
+import android.content.Context
+import android.graphics.BitmapFactory
 import android.view.View
 import android.view.ViewGroup
 import androidx.annotation.StringRes
@@ -8,10 +10,16 @@ import androidx.fragment.app.FragmentActivity
 import com.google.android.material.snackbar.Snackbar
 import com.weatherxm.R
 import com.weatherxm.analytics.AnalyticsWrapper
+import com.weatherxm.data.models.PhotoPresignedMetadata
+import com.weatherxm.service.workers.UploadPhotoWorker
 import com.weatherxm.ui.Navigator
 import com.weatherxm.ui.common.toast
+import com.weatherxm.util.ImageFileHelper.compressImageFile
+import com.weatherxm.util.ImageFileHelper.copyExifMetadata
+import com.weatherxm.util.ImageFileHelper.copyInputStreamToFile
 import com.weatherxm.util.checkPermissionsAndThen
 import timber.log.Timber
+import java.io.File
 
 interface BaseInterface {
     val analytics: AnalyticsWrapper
@@ -62,5 +70,30 @@ interface BaseInterface {
             onGranted = { onGranted.invoke() },
             onDenied = { activity.toast(R.string.error_claim_gps_failed) }
         )
+    }
+
+    fun prepareAndStartUpload(
+        context: Context,
+        photoPath: String?,
+        deviceId: String,
+        index: Int,
+        metadata: PhotoPresignedMetadata
+    ) {
+        /**
+         * Use the current photo name in cache otherwise default to "deviceId_img$index.jpg"
+         */
+        val fileName = photoPath?.substringAfterLast('/') ?: "${deviceId}_img$index.jpg"
+        val file = File(context.cacheDir, fileName)
+        val imageBitmap = BitmapFactory.decodeFile(photoPath)
+        file.copyInputStreamToFile(compressImageFile(imageBitmap))
+        copyExifMetadata(photoPath, file.path)
+
+        // Copied the photo in cache. Delete it from the external storage it was saved.
+        photoPath?.let {
+            File(it).delete()
+        }
+
+        // Start the work manager to upload the photo.
+        UploadPhotoWorker.initAndStart(context, metadata, file.path, deviceId)
     }
 }

--- a/app/src/main/java/com/weatherxm/ui/components/BaseInterface.kt
+++ b/app/src/main/java/com/weatherxm/ui/components/BaseInterface.kt
@@ -1,8 +1,6 @@
 package com.weatherxm.ui.components
 
 import android.Manifest
-import android.content.Context
-import android.graphics.BitmapFactory
 import android.view.View
 import android.view.ViewGroup
 import androidx.annotation.StringRes
@@ -10,16 +8,10 @@ import androidx.fragment.app.FragmentActivity
 import com.google.android.material.snackbar.Snackbar
 import com.weatherxm.R
 import com.weatherxm.analytics.AnalyticsWrapper
-import com.weatherxm.data.models.PhotoPresignedMetadata
-import com.weatherxm.service.workers.UploadPhotoWorker
 import com.weatherxm.ui.Navigator
 import com.weatherxm.ui.common.toast
-import com.weatherxm.util.ImageFileHelper.compressImageFile
-import com.weatherxm.util.ImageFileHelper.copyExifMetadata
-import com.weatherxm.util.ImageFileHelper.copyInputStreamToFile
 import com.weatherxm.util.checkPermissionsAndThen
 import timber.log.Timber
-import java.io.File
 
 interface BaseInterface {
     val analytics: AnalyticsWrapper
@@ -70,30 +62,5 @@ interface BaseInterface {
             onGranted = { onGranted.invoke() },
             onDenied = { activity.toast(R.string.error_claim_gps_failed) }
         )
-    }
-
-    fun prepareAndStartUpload(
-        context: Context,
-        photoPath: String?,
-        deviceId: String,
-        index: Int,
-        metadata: PhotoPresignedMetadata
-    ) {
-        /**
-         * Use the current photo name in cache otherwise default to "deviceId_img$index.jpg"
-         */
-        val fileName = photoPath?.substringAfterLast('/') ?: "${deviceId}_img$index.jpg"
-        val file = File(context.cacheDir, fileName)
-        val imageBitmap = BitmapFactory.decodeFile(photoPath)
-        file.copyInputStreamToFile(compressImageFile(imageBitmap))
-        copyExifMetadata(photoPath, file.path)
-
-        // Copied the photo in cache. Delete it from the external storage it was saved.
-        photoPath?.let {
-            File(it).delete()
-        }
-
-        // Start the work manager to upload the photo.
-        UploadPhotoWorker.initAndStart(context, metadata, file.path, deviceId)
     }
 }

--- a/app/src/main/java/com/weatherxm/ui/components/PhotoUploadStateView.kt
+++ b/app/src/main/java/com/weatherxm/ui/components/PhotoUploadStateView.kt
@@ -29,7 +29,7 @@ fun PhotoUploadState(state: UploadPhotosState, showStationName: Boolean) {
             verticalAlignment = Alignment.Bottom,
             horizontalArrangement = Arrangement.spacedBy(dimensionResource(R.dimen.margin_small))
         ) {
-            if (state.error == null) {
+            if (!state.isError) {
                 Text(
                     text = "${state.progress}%",
                     fontSize = 24.sp,
@@ -57,7 +57,7 @@ fun PhotoUploadState(state: UploadPhotosState, showStationName: Boolean) {
                 )
             }
         }
-        if (state.error == null) {
+        if (!state.isError) {
             LinearProgressIndicator(
                 progress = { state.progress.toFloat() },
                 modifier = Modifier.fillMaxWidth(),

--- a/app/src/main/java/com/weatherxm/ui/components/PhotoUploadStateView.kt
+++ b/app/src/main/java/com/weatherxm/ui/components/PhotoUploadStateView.kt
@@ -68,7 +68,7 @@ fun PhotoUploadState(state: UploadPhotosState, showStationName: Boolean) {
         }
         if (showStationName) {
             Text(
-                text = state.device.name,
+                text = state.device.getDefaultOrFriendlyName(),
                 style = MaterialTheme.typography.bodySmall,
                 color = colorResource(R.color.darkGrey)
             )

--- a/app/src/main/java/com/weatherxm/ui/devicesettings/BaseDeviceSettingsViewModel.kt
+++ b/app/src/main/java/com/weatherxm/ui/devicesettings/BaseDeviceSettingsViewModel.kt
@@ -210,6 +210,7 @@ abstract class BaseDeviceSettingsViewModel(
     }
 
     fun retryPhotoUpload() = photosUseCase.retryUpload(device.id)
+    fun getAcceptedPhotoTerms() = photosUseCase.getAcceptedTerms()
 
     abstract fun getDeviceInformation(context: Context)
     abstract suspend fun handleInfo(context: Context, info: DeviceInfo)

--- a/app/src/main/java/com/weatherxm/ui/devicesettings/BaseDeviceSettingsViewModel.kt
+++ b/app/src/main/java/com/weatherxm/ui/devicesettings/BaseDeviceSettingsViewModel.kt
@@ -186,6 +186,7 @@ abstract class BaseDeviceSettingsViewModel(
             onLoading.postValue(true)
             if (shouldDeleteAllPhotos == true) {
                 deleteAllPhotos(photosToDelete)
+                getDevicePhotos()
             } else {
                 getDevicePhotos()
             }
@@ -193,15 +194,13 @@ abstract class BaseDeviceSettingsViewModel(
         }
     }
 
-    private fun deleteAllPhotos(photos: ArrayList<StationPhoto>?) {
+    private suspend fun deleteAllPhotos(photos: ArrayList<StationPhoto>?) {
         photos?.forEach { photo ->
             photo.localPath?.let {
                 File(it).delete()
             }
             photo.remotePath?.let {
-                viewModelScope.launch(dispatcher) {
-                    photosUseCase.deleteDevicePhoto(device.id, it)
-                }
+                photosUseCase.deleteDevicePhoto(device.id, it)
             }
         }
     }

--- a/app/src/main/java/com/weatherxm/ui/devicesettings/BaseDeviceSettingsViewModel.kt
+++ b/app/src/main/java/com/weatherxm/ui/devicesettings/BaseDeviceSettingsViewModel.kt
@@ -11,7 +11,6 @@ import com.weatherxm.analytics.AnalyticsWrapper
 import com.weatherxm.data.models.ApiError
 import com.weatherxm.data.models.BatteryState
 import com.weatherxm.data.models.DeviceInfo
-import com.weatherxm.data.models.DevicePhoto
 import com.weatherxm.ui.common.DeviceAlert
 import com.weatherxm.ui.common.DeviceAlertType
 import com.weatherxm.ui.common.RewardSplitsData
@@ -40,13 +39,13 @@ abstract class BaseDeviceSettingsViewModel(
     private val onDeviceRemoved = MutableLiveData<Boolean>()
     private val onError = MutableLiveData<UIError>()
     protected val onLoading = MutableLiveData<Boolean>()
-    private val onPhotos = MutableLiveData<List<DevicePhoto>>()
+    private val onPhotos = MutableLiveData<List<String>>()
 
     fun onEditNameChange(): LiveData<String> = onEditNameChange
     fun onDeviceRemoved(): LiveData<Boolean> = onDeviceRemoved
     fun onError(): LiveData<UIError> = onError
     fun onLoading(): LiveData<Boolean> = onLoading
-    fun onPhotos(): LiveData<List<DevicePhoto>> = onPhotos
+    fun onPhotos(): LiveData<List<String>> = onPhotos
 
     fun setOrClearFriendlyName(friendlyName: String?) {
         if (friendlyName == null) {
@@ -173,7 +172,7 @@ abstract class BaseDeviceSettingsViewModel(
     }
 
     suspend fun getDevicePhotos() {
-        if(device.isOwned()) {
+        if (device.isOwned()) {
             photosUseCase.getDevicePhotos(device.id).onRight {
                 onPhotos.postValue(it)
             }.onLeft {
@@ -200,7 +199,9 @@ abstract class BaseDeviceSettingsViewModel(
                 File(it).delete()
             }
             photo.remotePath?.let {
-                // TODO: STOPSHIP: Call the delete endpoint for each one of them
+                viewModelScope.launch(dispatcher) {
+                    photosUseCase.deleteDevicePhoto(device.id, it)
+                }
             }
         }
     }

--- a/app/src/main/java/com/weatherxm/ui/devicesettings/BaseDeviceSettingsViewModel.kt
+++ b/app/src/main/java/com/weatherxm/ui/devicesettings/BaseDeviceSettingsViewModel.kt
@@ -205,15 +205,17 @@ abstract class BaseDeviceSettingsViewModel(
         }
     }
 
-    fun getDevicePhotoUploadingIds(): List<String> {
-        return photosUseCase.getDevicePhotoUploadingIds(device.id)
+    fun getDevicePhotoUploadIds(): List<String> {
+        return photosUseCase.getDevicePhotoUploadIds(device.id)
     }
 
-    fun cancelPhotoUploading(uploadingIds: List<String>) {
-        uploadingIds.forEach {
-            photosUseCase.removeDevicePhotoUploadingId(device.id, it)
+    fun cancelPhotoUploading(uploadIds: List<String>) {
+        uploadIds.forEach {
+            photosUseCase.removeDevicePhotoUploadId(device.id, it)
         }
     }
+
+    fun retryPhotoUpload() = photosUseCase.retryUpload(device.id)
 
     abstract fun getDeviceInformation(context: Context)
     abstract suspend fun handleInfo(context: Context, info: DeviceInfo)

--- a/app/src/main/java/com/weatherxm/ui/devicesettings/BaseDeviceSettingsViewModel.kt
+++ b/app/src/main/java/com/weatherxm/ui/devicesettings/BaseDeviceSettingsViewModel.kt
@@ -209,12 +209,6 @@ abstract class BaseDeviceSettingsViewModel(
         return photosUseCase.getDevicePhotoUploadIds(device.id)
     }
 
-    fun cancelPhotoUploading(uploadIds: List<String>) {
-        uploadIds.forEach {
-            photosUseCase.removeDevicePhotoUploadId(device.id, it)
-        }
-    }
-
     fun retryPhotoUpload() = photosUseCase.retryUpload(device.id)
 
     abstract fun getDeviceInformation(context: Context)

--- a/app/src/main/java/com/weatherxm/ui/devicesettings/BaseDeviceSettingsViewModel.kt
+++ b/app/src/main/java/com/weatherxm/ui/devicesettings/BaseDeviceSettingsViewModel.kt
@@ -205,6 +205,16 @@ abstract class BaseDeviceSettingsViewModel(
         }
     }
 
+    fun getDevicePhotoUploadingIds(): List<String> {
+        return photosUseCase.getDevicePhotoUploadingIds(device.id)
+    }
+
+    fun cancelPhotoUploading(uploadingIds: List<String>) {
+        uploadingIds.forEach {
+            photosUseCase.removeDevicePhotoUploadingId(device.id, it)
+        }
+    }
+
     abstract fun getDeviceInformation(context: Context)
     abstract suspend fun handleInfo(context: Context, info: DeviceInfo)
 }

--- a/app/src/main/java/com/weatherxm/ui/devicesettings/DevicePhotosView.kt
+++ b/app/src/main/java/com/weatherxm/ui/devicesettings/DevicePhotosView.kt
@@ -41,28 +41,28 @@ open class DevicePhotosView : LinearLayout, KoinComponent {
         orientation = VERTICAL
     }
 
-    fun initProgressView(device: UIDevice, onError: () -> Unit, onSuccess: () -> Unit) {
+    fun initProgressView(device: UIDevice, onRefresh: () -> Unit) {
         binding.inProgressUploadState.setContent {
             uploadObserverService.getUploadPhotosState().collectAsState(null).value?.let {
                 if (device.id == it.device.id) {
                     binding.photosText.visible(false)
                     binding.photosContainer.visible(false)
-                    binding.emptyText.visible(false)
-                    binding.startPhotoVerificationBtn.visible(false)
-                    binding.cancelUploadBtn.visible(!it.isSuccess && it.error == null)
+                    binding.emptyText.visible(it.isError)
+                    binding.startPhotoVerificationBtn.visible(it.isError)
+                    binding.cancelUploadBtn.visible(!it.isSuccess && !it.isError)
                     binding.inProgressText.visible(true)
                     binding.inProgressUploadState.visible(true)
 
-                    if (it.error != null) {
+                    if (it.isError) {
                         binding.inProgressText.visible(false)
                         binding.inProgressUploadState.visible(false)
-                        onError()
+                        onRefresh()
                         binding.errorCard.visible(true)
                     } else {
                         binding.errorCard.visible(false)
                     }
                     if (it.isSuccess) {
-                        onSuccess()
+                        onRefresh()
                     }
                     PhotoUploadState(it, false)
                 }

--- a/app/src/main/java/com/weatherxm/ui/devicesettings/DevicePhotosView.kt
+++ b/app/src/main/java/com/weatherxm/ui/devicesettings/DevicePhotosView.kt
@@ -49,7 +49,7 @@ open class DevicePhotosView : LinearLayout, KoinComponent {
                     binding.photosContainer.visible(false)
                     binding.emptyText.visible(it.isError)
                     binding.startPhotoVerificationBtn.visible(it.isError)
-                    binding.cancelUploadBtn.visible(!it.isSuccess && !it.isError)
+                    binding.cancelUploadBtn.visible(!it.isSuccess && !it.isError && !it.isCancelled)
                     binding.inProgressText.visible(true)
                     binding.inProgressUploadState.visible(true)
 
@@ -114,9 +114,16 @@ open class DevicePhotosView : LinearLayout, KoinComponent {
         binding.inProgressUploadState.visible(false)
         binding.photosText.visible(true)
 
-        if (devicePhotos.size >= 2) {
+        if (devicePhotos.size == 1) {
+            binding.firstPhoto.load(devicePhotos[0])
+            binding.firstPhotoContainer.visible(true)
+            binding.secondPhotoContainer.visible(false)
+            binding.photosContainer.visible(true)
+        } else if (devicePhotos.size >= 2) {
             binding.firstPhoto.load(devicePhotos[0])
             binding.secondPhoto.load(devicePhotos[1])
+            binding.firstPhotoContainer.visible(true)
+            binding.secondPhotoContainer.visible(true)
             binding.photosContainer.visible(true)
             if (devicePhotos.size > 2) {
                 binding.morePhotos.text = "+${devicePhotos.size - 2}"

--- a/app/src/main/java/com/weatherxm/ui/devicesettings/DevicePhotosView.kt
+++ b/app/src/main/java/com/weatherxm/ui/devicesettings/DevicePhotosView.kt
@@ -9,6 +9,7 @@ import androidx.compose.runtime.collectAsState
 import coil3.load
 import com.weatherxm.databinding.ViewStationSettingsDevicePhotosBinding
 import com.weatherxm.service.GlobalUploadObserverService
+import com.weatherxm.ui.common.UIDevice
 import com.weatherxm.ui.common.visible
 import com.weatherxm.ui.components.PhotoUploadState
 import org.koin.core.component.KoinComponent
@@ -40,29 +41,31 @@ open class DevicePhotosView : LinearLayout, KoinComponent {
         orientation = VERTICAL
     }
 
-    fun initProgressView(onError: () -> Unit, onSuccess: () -> Unit) {
+    fun initProgressView(device: UIDevice, onError: () -> Unit, onSuccess: () -> Unit) {
         binding.inProgressUploadState.setContent {
             uploadObserverService.getUploadPhotosState().collectAsState(null).value?.let {
-                binding.photosText.visible(false)
-                binding.photosContainer.visible(false)
-                binding.emptyText.visible(false)
-                binding.startPhotoVerificationBtn.visible(false)
-                binding.cancelUploadBtn.visible(!it.isSuccess && it.error == null)
-                binding.inProgressText.visible(true)
-                binding.inProgressUploadState.visible(true)
+                if (device.id == it.device.id) {
+                    binding.photosText.visible(false)
+                    binding.photosContainer.visible(false)
+                    binding.emptyText.visible(false)
+                    binding.startPhotoVerificationBtn.visible(false)
+                    binding.cancelUploadBtn.visible(!it.isSuccess && it.error == null)
+                    binding.inProgressText.visible(true)
+                    binding.inProgressUploadState.visible(true)
 
-                if (it.error != null) {
-                    binding.inProgressText.visible(false)
-                    binding.inProgressUploadState.visible(false)
-                    onError()
-                    binding.errorCard.visible(true)
-                } else {
-                    binding.errorCard.visible(false)
+                    if (it.error != null) {
+                        binding.inProgressText.visible(false)
+                        binding.inProgressUploadState.visible(false)
+                        onError()
+                        binding.errorCard.visible(true)
+                    } else {
+                        binding.errorCard.visible(false)
+                    }
+                    if (it.isSuccess) {
+                        onSuccess()
+                    }
+                    PhotoUploadState(it, false)
                 }
-                if (it.isSuccess) {
-                    onSuccess()
-                }
-                PhotoUploadState(it, false)
             }
         }
     }
@@ -114,7 +117,7 @@ open class DevicePhotosView : LinearLayout, KoinComponent {
             binding.firstPhoto.load(devicePhotos[0])
             binding.secondPhoto.load(devicePhotos[1])
             binding.photosContainer.visible(true)
-            if(devicePhotos.size > 2) {
+            if (devicePhotos.size > 2) {
                 binding.morePhotos.text = "+${devicePhotos.size - 2}"
             }
             binding.translucentViewOnSecondPhoto.visible(devicePhotos.size > 2)

--- a/app/src/main/java/com/weatherxm/ui/devicesettings/DevicePhotosView.kt
+++ b/app/src/main/java/com/weatherxm/ui/devicesettings/DevicePhotosView.kt
@@ -7,7 +7,6 @@ import android.view.LayoutInflater
 import android.widget.LinearLayout
 import androidx.compose.runtime.collectAsState
 import coil3.load
-import com.weatherxm.data.models.DevicePhoto
 import com.weatherxm.databinding.ViewStationSettingsDevicePhotosBinding
 import com.weatherxm.service.GlobalUploadObserverService
 import com.weatherxm.ui.common.visible
@@ -86,7 +85,7 @@ open class DevicePhotosView : LinearLayout, KoinComponent {
         }
     }
 
-    fun updateUI(devicePhotos: List<DevicePhoto>) {
+    fun updateUI(devicePhotos: List<String>) {
         if (devicePhotos.isEmpty()) {
             onEmpty()
         } else {
@@ -102,7 +101,7 @@ open class DevicePhotosView : LinearLayout, KoinComponent {
     }
 
     @SuppressLint("SetTextI18n")
-    private fun onPhotos(devicePhotos: List<DevicePhoto>) {
+    private fun onPhotos(devicePhotos: List<String>) {
         binding.emptyText.visible(false)
         binding.startPhotoVerificationBtn.visible(false)
         binding.inProgressText.visible(false)
@@ -110,8 +109,8 @@ open class DevicePhotosView : LinearLayout, KoinComponent {
         binding.photosText.visible(true)
 
         if (devicePhotos.size >= 2) {
-            binding.firstPhoto.load(devicePhotos[0].url)
-            binding.secondPhoto.load(devicePhotos[1].url)
+            binding.firstPhoto.load(devicePhotos[0])
+            binding.secondPhoto.load(devicePhotos[1])
             binding.photosContainer.visible(true)
             if(devicePhotos.size > 2) {
                 binding.morePhotos.text = "+${devicePhotos.size - 2}"

--- a/app/src/main/java/com/weatherxm/ui/devicesettings/DevicePhotosView.kt
+++ b/app/src/main/java/com/weatherxm/ui/devicesettings/DevicePhotosView.kt
@@ -96,6 +96,8 @@ open class DevicePhotosView : LinearLayout, KoinComponent {
     private fun onEmpty() {
         binding.inProgressText.visible(false)
         binding.inProgressUploadState.visible(false)
+        binding.photosText.visible(false)
+        binding.photosContainer.visible(false)
         binding.emptyText.visible(true)
         binding.startPhotoVerificationBtn.visible(true)
     }
@@ -114,8 +116,8 @@ open class DevicePhotosView : LinearLayout, KoinComponent {
             binding.photosContainer.visible(true)
             if(devicePhotos.size > 2) {
                 binding.morePhotos.text = "+${devicePhotos.size - 2}"
-                binding.translucentViewOnSecondPhoto.visible(true)
             }
+            binding.translucentViewOnSecondPhoto.visible(devicePhotos.size > 2)
         }
     }
 }

--- a/app/src/main/java/com/weatherxm/ui/devicesettings/DevicePhotosView.kt
+++ b/app/src/main/java/com/weatherxm/ui/devicesettings/DevicePhotosView.kt
@@ -101,6 +101,7 @@ open class DevicePhotosView : LinearLayout, KoinComponent {
         binding.inProgressUploadState.visible(false)
         binding.photosText.visible(false)
         binding.photosContainer.visible(false)
+        binding.cancelUploadBtn.visible(false)
         binding.emptyText.visible(true)
         binding.startPhotoVerificationBtn.visible(true)
     }

--- a/app/src/main/java/com/weatherxm/ui/devicesettings/helium/DeviceSettingsHeliumActivity.kt
+++ b/app/src/main/java/com/weatherxm/ui/devicesettings/helium/DeviceSettingsHeliumActivity.kt
@@ -7,7 +7,6 @@ import coil3.ImageLoader
 import com.google.firebase.analytics.FirebaseAnalytics
 import com.weatherxm.R
 import com.weatherxm.analytics.AnalyticsService
-import com.weatherxm.data.models.DevicePhoto
 import com.weatherxm.databinding.ActivityDeviceSettingsHeliumBinding
 import com.weatherxm.ui.common.Contracts
 import com.weatherxm.ui.common.Contracts.ARG_DEVICE
@@ -155,7 +154,7 @@ class DeviceSettingsHeliumActivity : BaseActivity() {
         setupStationLocation(false)
     }
 
-    private fun onPhotos(devicePhotos: List<DevicePhoto>) {
+    private fun onPhotos(devicePhotos: List<String>) {
         binding.devicePhotosCard.updateUI(devicePhotos)
         binding.devicePhotosCard.setOnClickListener(
             onClick = {
@@ -168,7 +167,7 @@ class DeviceSettingsHeliumActivity : BaseActivity() {
                 )
                 val photos = arrayListOf<String>()
                 devicePhotos.forEach {
-                    photos.add(it.url)
+                    photos.add(it)
                 }
                 if (photos.isEmpty()) {
                     navigator.showPhotoVerificationIntro(this, model.device)

--- a/app/src/main/java/com/weatherxm/ui/devicesettings/helium/DeviceSettingsHeliumActivity.kt
+++ b/app/src/main/java/com/weatherxm/ui/devicesettings/helium/DeviceSettingsHeliumActivity.kt
@@ -143,12 +143,7 @@ class DeviceSettingsHeliumActivity : BaseActivity() {
 
         binding.devicePhotosCard.initProgressView(
             device = model.device,
-            onError = {
-                // Trigger a refresh on the photos through the API
-                model.retryPhotoUpload()
-                model.onPhotosChanged(false, null)
-            },
-            onSuccess = {
+            onRefresh = {
                 // Trigger a refresh on the photos through the API
                 model.onPhotosChanged(false, null)
             }

--- a/app/src/main/java/com/weatherxm/ui/devicesettings/helium/DeviceSettingsHeliumActivity.kt
+++ b/app/src/main/java/com/weatherxm/ui/devicesettings/helium/DeviceSettingsHeliumActivity.kt
@@ -194,8 +194,6 @@ class DeviceSettingsHeliumActivity : BaseActivity() {
                         UploadPhotoWorker.cancelWorkers(this, model.device.id)
                         model.getDevicePhotoUploadIds().onEach {
                             getCancelUploadIntent(it).send()
-                        }.also {
-                            model.cancelPhotoUploading(it)
                         }
                         model.onPhotosChanged(false, null)
                     }

--- a/app/src/main/java/com/weatherxm/ui/devicesettings/helium/DeviceSettingsHeliumActivity.kt
+++ b/app/src/main/java/com/weatherxm/ui/devicesettings/helium/DeviceSettingsHeliumActivity.kt
@@ -145,8 +145,8 @@ class DeviceSettingsHeliumActivity : BaseActivity() {
             device = model.device,
             onError = {
                 // Trigger a refresh on the photos through the API
+                model.retryPhotoUpload()
                 model.onPhotosChanged(false, null)
-                // TODO: STOPSHIP:  Trigger retry mechanism
             },
             onSuccess = {
                 // Trigger a refresh on the photos through the API
@@ -197,7 +197,7 @@ class DeviceSettingsHeliumActivity : BaseActivity() {
                         )
                         // Trigger a refresh on the photos through the API
                         UploadPhotoWorker.cancelWorkers(this, model.device.id)
-                        model.getDevicePhotoUploadingIds().onEach {
+                        model.getDevicePhotoUploadIds().onEach {
                             getCancelUploadIntent(it).send()
                         }.also {
                             model.cancelPhotoUploading(it)
@@ -208,10 +208,10 @@ class DeviceSettingsHeliumActivity : BaseActivity() {
                     .show(this)
             },
             onRetry = {
+                model.retryPhotoUpload()
                 analytics.trackEventUserAction(
                     AnalyticsService.ParamValue.RETRY_UPLOADING_PHOTOS.paramValue
                 )
-                // TODO: STOPSHIP:  Trigger retry mechanism
             }
         )
 

--- a/app/src/main/java/com/weatherxm/ui/devicesettings/helium/DeviceSettingsHeliumActivity.kt
+++ b/app/src/main/java/com/weatherxm/ui/devicesettings/helium/DeviceSettingsHeliumActivity.kt
@@ -140,6 +140,7 @@ class DeviceSettingsHeliumActivity : BaseActivity() {
         }
 
         binding.devicePhotosCard.initProgressView(
+            device = model.device,
             onError = {
                 // Trigger a refresh on the photos through the API
                 model.onPhotosChanged(false, null)

--- a/app/src/main/java/com/weatherxm/ui/devicesettings/helium/DeviceSettingsHeliumActivity.kt
+++ b/app/src/main/java/com/weatherxm/ui/devicesettings/helium/DeviceSettingsHeliumActivity.kt
@@ -167,7 +167,7 @@ class DeviceSettingsHeliumActivity : BaseActivity() {
                 devicePhotos.forEach {
                     photos.add(it)
                 }
-                if (photos.isEmpty()) {
+                if (photos.isEmpty() || !model.getAcceptedPhotoTerms()) {
                     navigator.showPhotoVerificationIntro(this, model.device)
                 } else {
                     navigator.showPhotoGallery(

--- a/app/src/main/java/com/weatherxm/ui/devicesettings/helium/DeviceSettingsHeliumActivity.kt
+++ b/app/src/main/java/com/weatherxm/ui/devicesettings/helium/DeviceSettingsHeliumActivity.kt
@@ -8,6 +8,7 @@ import com.google.firebase.analytics.FirebaseAnalytics
 import com.weatherxm.R
 import com.weatherxm.analytics.AnalyticsService
 import com.weatherxm.databinding.ActivityDeviceSettingsHeliumBinding
+import com.weatherxm.service.workers.UploadPhotoWorker
 import com.weatherxm.ui.common.Contracts
 import com.weatherxm.ui.common.Contracts.ARG_DEVICE
 import com.weatherxm.ui.common.DeviceAlertType
@@ -31,6 +32,7 @@ import com.weatherxm.ui.components.BaseActivity
 import com.weatherxm.ui.devicesettings.DeviceInfoItemAdapter
 import com.weatherxm.ui.devicesettings.FriendlyNameDialogFragment
 import com.weatherxm.util.MapboxUtils.getMinimap
+import net.gotev.uploadservice.extensions.getCancelUploadIntent
 import org.koin.android.ext.android.inject
 import org.koin.androidx.viewmodel.ext.android.viewModel
 import org.koin.core.parameter.parametersOf
@@ -194,8 +196,13 @@ class DeviceSettingsHeliumActivity : BaseActivity() {
                             AnalyticsService.ParamValue.CANCEL_UPLOADING_PHOTOS.paramValue
                         )
                         // Trigger a refresh on the photos through the API
+                        UploadPhotoWorker.cancelWorkers(this, model.device.id)
+                        model.getDevicePhotoUploadingIds().onEach {
+                            getCancelUploadIntent(it).send()
+                        }.also {
+                            model.cancelPhotoUploading(it)
+                        }
                         model.onPhotosChanged(false, null)
-                        // TODO: STOPSHIP:  Cancel the current upload
                     }
                     .build()
                     .show(this)

--- a/app/src/main/java/com/weatherxm/ui/devicesettings/helium/DeviceSettingsHeliumActivity.kt
+++ b/app/src/main/java/com/weatherxm/ui/devicesettings/helium/DeviceSettingsHeliumActivity.kt
@@ -168,7 +168,7 @@ class DeviceSettingsHeliumActivity : BaseActivity() {
                     photos.add(it)
                 }
                 if (photos.isEmpty() || !model.getAcceptedPhotoTerms()) {
-                    navigator.showPhotoVerificationIntro(this, model.device)
+                    navigator.showPhotoVerificationIntro(this, model.device, photos)
                 } else {
                     navigator.showPhotoGallery(
                         photoGalleryLauncher,

--- a/app/src/main/java/com/weatherxm/ui/devicesettings/wifi/DeviceSettingsWifiActivity.kt
+++ b/app/src/main/java/com/weatherxm/ui/devicesettings/wifi/DeviceSettingsWifiActivity.kt
@@ -140,8 +140,8 @@ class DeviceSettingsWifiActivity : BaseActivity() {
             device = model.device,
             onError = {
                 // Trigger a refresh on the photos through the API
+                model.retryPhotoUpload()
                 model.onPhotosChanged(false, null)
-                // TODO: STOPSHIP:  Trigger retry mechanism
             },
             onSuccess = {
                 // Trigger a refresh on the photos through the API
@@ -192,7 +192,7 @@ class DeviceSettingsWifiActivity : BaseActivity() {
                     .onPositiveClick(getString(R.string.yes_cancel)) {
                         // Trigger a refresh on the photos through the API
                         UploadPhotoWorker.cancelWorkers(this, model.device.id)
-                        model.getDevicePhotoUploadingIds().onEach {
+                        model.getDevicePhotoUploadIds().onEach {
                             getCancelUploadIntent(it).send()
                         }.also {
                             model.cancelPhotoUploading(it)
@@ -203,10 +203,10 @@ class DeviceSettingsWifiActivity : BaseActivity() {
                     .show(this)
             },
             onRetry = {
+                model.retryPhotoUpload()
                 analytics.trackEventUserAction(
                     AnalyticsService.ParamValue.RETRY_UPLOADING_PHOTOS.paramValue
                 )
-                // TODO: STOPSHIP:  Trigger retry mechanism
             }
         )
         binding.devicePhotosCard.visible(true)

--- a/app/src/main/java/com/weatherxm/ui/devicesettings/wifi/DeviceSettingsWifiActivity.kt
+++ b/app/src/main/java/com/weatherxm/ui/devicesettings/wifi/DeviceSettingsWifiActivity.kt
@@ -135,6 +135,7 @@ class DeviceSettingsWifiActivity : BaseActivity() {
         }
 
         binding.devicePhotosCard.initProgressView(
+            device = model.device,
             onError = {
                 // Trigger a refresh on the photos through the API
                 model.onPhotosChanged(false, null)

--- a/app/src/main/java/com/weatherxm/ui/devicesettings/wifi/DeviceSettingsWifiActivity.kt
+++ b/app/src/main/java/com/weatherxm/ui/devicesettings/wifi/DeviceSettingsWifiActivity.kt
@@ -9,6 +9,7 @@ import com.google.firebase.analytics.FirebaseAnalytics
 import com.weatherxm.R
 import com.weatherxm.analytics.AnalyticsService
 import com.weatherxm.databinding.ActivityDeviceSettingsWifiBinding
+import com.weatherxm.service.workers.UploadPhotoWorker
 import com.weatherxm.ui.common.BundleName
 import com.weatherxm.ui.common.Contracts
 import com.weatherxm.ui.common.Contracts.ARG_DEVICE
@@ -32,6 +33,7 @@ import com.weatherxm.ui.components.BaseActivity
 import com.weatherxm.ui.devicesettings.DeviceInfoItemAdapter
 import com.weatherxm.ui.devicesettings.FriendlyNameDialogFragment
 import com.weatherxm.util.MapboxUtils.getMinimap
+import net.gotev.uploadservice.extensions.getCancelUploadIntent
 import org.koin.android.ext.android.inject
 import org.koin.androidx.viewmodel.ext.android.viewModel
 import org.koin.core.parameter.parametersOf
@@ -189,8 +191,13 @@ class DeviceSettingsWifiActivity : BaseActivity() {
                     )
                     .onPositiveClick(getString(R.string.yes_cancel)) {
                         // Trigger a refresh on the photos through the API
+                        UploadPhotoWorker.cancelWorkers(this, model.device.id)
+                        model.getDevicePhotoUploadingIds().onEach {
+                            getCancelUploadIntent(it).send()
+                        }.also {
+                            model.cancelPhotoUploading(it)
+                        }
                         model.onPhotosChanged(false, null)
-                        // TODO: STOPSHIP: Cancel the current upload
                     }
                     .build()
                     .show(this)

--- a/app/src/main/java/com/weatherxm/ui/devicesettings/wifi/DeviceSettingsWifiActivity.kt
+++ b/app/src/main/java/com/weatherxm/ui/devicesettings/wifi/DeviceSettingsWifiActivity.kt
@@ -163,7 +163,7 @@ class DeviceSettingsWifiActivity : BaseActivity() {
                     photos.add(it)
                 }
                 if (photos.isEmpty() || !model.getAcceptedPhotoTerms()) {
-                    navigator.showPhotoVerificationIntro(this, model.device)
+                    navigator.showPhotoVerificationIntro(this, model.device, photos)
                 } else {
                     navigator.showPhotoGallery(
                         photoGalleryLauncher,

--- a/app/src/main/java/com/weatherxm/ui/devicesettings/wifi/DeviceSettingsWifiActivity.kt
+++ b/app/src/main/java/com/weatherxm/ui/devicesettings/wifi/DeviceSettingsWifiActivity.kt
@@ -138,12 +138,7 @@ class DeviceSettingsWifiActivity : BaseActivity() {
 
         binding.devicePhotosCard.initProgressView(
             device = model.device,
-            onError = {
-                // Trigger a refresh on the photos through the API
-                model.retryPhotoUpload()
-                model.onPhotosChanged(false, null)
-            },
-            onSuccess = {
+            onRefresh = {
                 // Trigger a refresh on the photos through the API
                 model.onPhotosChanged(false, null)
             }

--- a/app/src/main/java/com/weatherxm/ui/devicesettings/wifi/DeviceSettingsWifiActivity.kt
+++ b/app/src/main/java/com/weatherxm/ui/devicesettings/wifi/DeviceSettingsWifiActivity.kt
@@ -162,7 +162,7 @@ class DeviceSettingsWifiActivity : BaseActivity() {
                 devicePhotos.forEach {
                     photos.add(it)
                 }
-                if (photos.isEmpty()) {
+                if (photos.isEmpty() || !model.getAcceptedPhotoTerms()) {
                     navigator.showPhotoVerificationIntro(this, model.device)
                 } else {
                     navigator.showPhotoGallery(

--- a/app/src/main/java/com/weatherxm/ui/devicesettings/wifi/DeviceSettingsWifiActivity.kt
+++ b/app/src/main/java/com/weatherxm/ui/devicesettings/wifi/DeviceSettingsWifiActivity.kt
@@ -189,8 +189,6 @@ class DeviceSettingsWifiActivity : BaseActivity() {
                         UploadPhotoWorker.cancelWorkers(this, model.device.id)
                         model.getDevicePhotoUploadIds().onEach {
                             getCancelUploadIntent(it).send()
-                        }.also {
-                            model.cancelPhotoUploading(it)
                         }
                         model.onPhotosChanged(false, null)
                     }

--- a/app/src/main/java/com/weatherxm/ui/devicesettings/wifi/DeviceSettingsWifiActivity.kt
+++ b/app/src/main/java/com/weatherxm/ui/devicesettings/wifi/DeviceSettingsWifiActivity.kt
@@ -8,7 +8,6 @@ import coil3.ImageLoader
 import com.google.firebase.analytics.FirebaseAnalytics
 import com.weatherxm.R
 import com.weatherxm.analytics.AnalyticsService
-import com.weatherxm.data.models.DevicePhoto
 import com.weatherxm.databinding.ActivityDeviceSettingsWifiBinding
 import com.weatherxm.ui.common.BundleName
 import com.weatherxm.ui.common.Contracts
@@ -150,7 +149,7 @@ class DeviceSettingsWifiActivity : BaseActivity() {
         setupStationLocation(false)
     }
 
-    private fun onPhotos(devicePhotos: List<DevicePhoto>) {
+    private fun onPhotos(devicePhotos: List<String>) {
         binding.devicePhotosCard.updateUI(devicePhotos)
         binding.devicePhotosCard.setOnClickListener(
             onClick = {
@@ -163,7 +162,7 @@ class DeviceSettingsWifiActivity : BaseActivity() {
                 )
                 val photos = arrayListOf<String>()
                 devicePhotos.forEach {
-                    photos.add(it.url)
+                    photos.add(it)
                 }
                 if (photos.isEmpty()) {
                     navigator.showPhotoVerificationIntro(this, model.device)

--- a/app/src/main/java/com/weatherxm/ui/home/HomeViewModel.kt
+++ b/app/src/main/java/com/weatherxm/ui/home/HomeViewModel.kt
@@ -10,15 +10,18 @@ import com.weatherxm.data.models.Survey
 import com.weatherxm.ui.common.SingleLiveEvent
 import com.weatherxm.ui.common.UIDevice
 import com.weatherxm.ui.common.WalletWarnings
+import com.weatherxm.usecases.DevicePhotoUseCase
 import com.weatherxm.usecases.RemoteBannersUseCase
 import com.weatherxm.usecases.UserUseCase
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 
+@Suppress("TooManyFunctions")
 class HomeViewModel(
     private val userUseCase: UserUseCase,
     private val remoteBannersUseCase: RemoteBannersUseCase,
+    private val photoUseCase: DevicePhotoUseCase,
     private val analytics: AnalyticsWrapper,
     private val dispatcher: CoroutineDispatcher = Dispatchers.IO
 ) : ViewModel() {
@@ -101,4 +104,6 @@ class HomeViewModel(
     fun dismissInfoBanner(infoBannerId: String) {
         remoteBannersUseCase.dismissInfoBanner(infoBannerId)
     }
+
+    fun retryPhotoUpload(deviceId: String) = photoUseCase.retryUpload(deviceId)
 }

--- a/app/src/main/java/com/weatherxm/ui/home/devices/DevicesFragment.kt
+++ b/app/src/main/java/com/weatherxm/ui/home/devices/DevicesFragment.kt
@@ -161,7 +161,7 @@ class DevicesFragment : BaseFragment(), DeviceListener {
             if (uploadState?.error != null) {
                 binding.uploadStateCard.swipeToDismiss {
                     binding.uploadStateContainer.visible(false)
-                    deleteAllStationPhotos(context, uploadState?.device)
+                    deleteAllStationPhotos(context, uploadState.device)
                 }
                 binding.uploadStateCard.setOnClickListener {
                     // TODO: STOPSHIP: Invoke retry mechanism

--- a/app/src/main/java/com/weatherxm/ui/home/devices/DevicesFragment.kt
+++ b/app/src/main/java/com/weatherxm/ui/home/devices/DevicesFragment.kt
@@ -34,7 +34,6 @@ import com.weatherxm.ui.common.toast
 import com.weatherxm.ui.common.visible
 import com.weatherxm.ui.components.BaseFragment
 import com.weatherxm.ui.components.PhotoUploadState
-import com.weatherxm.ui.home.HomeActivity
 import com.weatherxm.ui.home.HomeViewModel
 import com.weatherxm.util.ImageFileHelper.deleteAllStationPhotos
 import com.weatherxm.util.NumberUtils.formatTokens
@@ -164,7 +163,7 @@ class DevicesFragment : BaseFragment(), DeviceListener {
                     deleteAllStationPhotos(context, uploadState.device)
                 }
                 binding.uploadStateCard.setOnClickListener {
-                    // TODO: STOPSHIP: Invoke retry mechanism
+                    parentModel.retryPhotoUpload(uploadState.device.id)
                 }
             } else if (uploadState?.isSuccess == true) {
                 removeUploadStateOnPause = true

--- a/app/src/main/java/com/weatherxm/ui/home/devices/DevicesFragment.kt
+++ b/app/src/main/java/com/weatherxm/ui/home/devices/DevicesFragment.kt
@@ -177,6 +177,10 @@ class DevicesFragment : BaseFragment(), DeviceListener {
                 binding.uploadAnimation.setAnimation(R.raw.anim_upload_success)
                 binding.uploadAnimation.repeatCount = 0
             } else if (uploadState?.progress == 0) {
+                binding.uploadStateCard.setOnClickListener {
+                    navigator.showStationSettings(context, uploadState.device)
+                    binding.uploadStateContainer.visible(false)
+                }
                 binding.uploadAnimation.setAnimation(R.raw.anim_uploading)
                 binding.uploadAnimation.repeatCount = INFINITE
             }

--- a/app/src/main/java/com/weatherxm/ui/home/devices/DevicesFragment.kt
+++ b/app/src/main/java/com/weatherxm/ui/home/devices/DevicesFragment.kt
@@ -154,10 +154,10 @@ class DevicesFragment : BaseFragment(), DeviceListener {
                 uploadObserverService.getUploadPhotosState().collectAsState(null).value
             binding.uploadStateContainer.visible(uploadState != null)
 
-            binding.uploadAnimation.visible(uploadState?.error == null)
-            binding.uploadRetryIcon.visible(uploadState?.error != null)
+            binding.uploadAnimation.visible(uploadState?.isError == false)
+            binding.uploadRetryIcon.visible(uploadState?.isError == true)
 
-            if (uploadState?.error != null) {
+            if (uploadState?.isError == true) {
                 binding.uploadStateCard.swipeToDismiss {
                     binding.uploadStateContainer.visible(false)
                     deleteAllStationPhotos(context, uploadState.device)

--- a/app/src/main/java/com/weatherxm/ui/home/devices/DevicesFragment.kt
+++ b/app/src/main/java/com/weatherxm/ui/home/devices/DevicesFragment.kt
@@ -34,6 +34,7 @@ import com.weatherxm.ui.common.toast
 import com.weatherxm.ui.common.visible
 import com.weatherxm.ui.components.BaseFragment
 import com.weatherxm.ui.components.PhotoUploadState
+import com.weatherxm.ui.home.HomeActivity
 import com.weatherxm.ui.home.HomeViewModel
 import com.weatherxm.util.ImageFileHelper.deleteAllStationPhotos
 import com.weatherxm.util.NumberUtils.formatTokens

--- a/app/src/main/java/com/weatherxm/ui/photoverification/gallery/PhotoGalleryActivity.kt
+++ b/app/src/main/java/com/weatherxm/ui/photoverification/gallery/PhotoGalleryActivity.kt
@@ -292,7 +292,7 @@ class PhotoGalleryActivity : BaseActivity() {
 
     private fun createPhotoFile(): File {
         val storageDir: File? = getExternalFilesDir(Environment.DIRECTORY_PICTURES)
-        return File.createTempFile(model.device.normalizedName(), ".jpg", storageDir).apply {
+        return File.createTempFile(model.device.id, ".jpg", storageDir).apply {
             latestPhotoTakenPath = absolutePath
         }
     }

--- a/app/src/main/java/com/weatherxm/ui/photoverification/gallery/PhotoGalleryActivity.kt
+++ b/app/src/main/java/com/weatherxm/ui/photoverification/gallery/PhotoGalleryActivity.kt
@@ -30,7 +30,6 @@ import coil3.load
 import com.weatherxm.R
 import com.weatherxm.analytics.AnalyticsService
 import com.weatherxm.databinding.ActivityPhotoGalleryBinding
-import com.weatherxm.service.GlobalUploadObserverService
 import com.weatherxm.ui.common.Contracts
 import com.weatherxm.ui.common.Contracts.ARG_DEVICE
 import com.weatherxm.ui.common.Contracts.ARG_NEW_PHOTO_VERIFICATION
@@ -47,7 +46,6 @@ import com.weatherxm.ui.components.ActionDialogFragment
 import com.weatherxm.ui.components.BaseActivity
 import com.weatherxm.util.checkPermissionsAndThen
 import com.weatherxm.util.hasPermission
-import org.koin.android.ext.android.inject
 import org.koin.androidx.viewmodel.ext.android.viewModel
 import org.koin.core.parameter.parametersOf
 import java.io.File
@@ -57,8 +55,6 @@ class PhotoGalleryActivity : BaseActivity() {
         const val MIN_PHOTOS = 2
         const val MAX_PHOTOS = 6
     }
-
-    private val uploadObserverService: GlobalUploadObserverService by inject()
 
     private lateinit var binding: ActivityPhotoGalleryBinding
 

--- a/app/src/main/java/com/weatherxm/ui/photoverification/gallery/PhotoGalleryActivity.kt
+++ b/app/src/main/java/com/weatherxm/ui/photoverification/gallery/PhotoGalleryActivity.kt
@@ -49,7 +49,6 @@ import com.weatherxm.util.hasPermission
 import org.koin.androidx.viewmodel.ext.android.viewModel
 import org.koin.core.parameter.parametersOf
 import java.io.File
-import kotlin.math.sign
 
 class PhotoGalleryActivity : BaseActivity() {
     companion object {
@@ -124,7 +123,7 @@ class PhotoGalleryActivity : BaseActivity() {
         }
 
         binding.instructionsBtn.setOnClickListener {
-            navigator.showPhotoVerificationIntro(this, model.device, true)
+            navigator.showPhotoVerificationIntro(this, model.device, instructionsOnly = true)
         }
 
         binding.openSettingsBtn.setOnClickListener {
@@ -217,7 +216,7 @@ class PhotoGalleryActivity : BaseActivity() {
                 binding.deletePhotoBtn.enable()
             }
             else -> {
-                binding.toolbar.subtitle = if(model.getLocalPhotosNumber() == 0) {
+                binding.toolbar.subtitle = if (model.getLocalPhotosNumber() == 0) {
                     getString(R.string.add_1_more_to_upload)
                 } else {
                     null

--- a/app/src/main/java/com/weatherxm/ui/photoverification/gallery/PhotoGalleryActivity.kt
+++ b/app/src/main/java/com/weatherxm/ui/photoverification/gallery/PhotoGalleryActivity.kt
@@ -49,6 +49,7 @@ import com.weatherxm.util.hasPermission
 import org.koin.androidx.viewmodel.ext.android.viewModel
 import org.koin.core.parameter.parametersOf
 import java.io.File
+import kotlin.math.sign
 
 class PhotoGalleryActivity : BaseActivity() {
     companion object {
@@ -204,7 +205,7 @@ class PhotoGalleryActivity : BaseActivity() {
 
     private fun onPhotosNumber(photosNumber: Int) {
         binding.addPhotoBtn.visible(photosNumber < MAX_PHOTOS)
-        binding.uploadBtn.isEnabled = photosNumber >= MIN_PHOTOS
+        binding.uploadBtn.isEnabled = photosNumber >= MIN_PHOTOS && model.getLocalPhotosNumber() > 0
         when (photosNumber) {
             0 -> {
                 binding.toolbar.subtitle = getString(R.string.add_2_more_to_upload)
@@ -216,7 +217,11 @@ class PhotoGalleryActivity : BaseActivity() {
                 binding.deletePhotoBtn.enable()
             }
             else -> {
-                binding.toolbar.subtitle = null
+                binding.toolbar.subtitle = if(model.getLocalPhotosNumber() == 0) {
+                    getString(R.string.add_1_more_to_upload)
+                } else {
+                    null
+                }
                 binding.deletePhotoBtn.enable()
             }
         }

--- a/app/src/main/java/com/weatherxm/ui/photoverification/gallery/PhotoGalleryViewModel.kt
+++ b/app/src/main/java/com/weatherxm/ui/photoverification/gallery/PhotoGalleryViewModel.kt
@@ -29,6 +29,8 @@ class PhotoGalleryViewModel(
 
     fun onPhotosNumber(): LiveData<Int> = onPhotosNumber
 
+    fun getLocalPhotosNumber() = photos.filter { it.localPath != null }.size
+
     fun addPhoto(path: String) {
         if (path.isNotEmpty() && photos.firstOrNull { it.localPath == path } == null) {
             val stationPhoto = StationPhoto(null, path)

--- a/app/src/main/java/com/weatherxm/ui/photoverification/gallery/PhotoGalleryViewModel.kt
+++ b/app/src/main/java/com/weatherxm/ui/photoverification/gallery/PhotoGalleryViewModel.kt
@@ -1,7 +1,5 @@
 package com.weatherxm.ui.photoverification.gallery
 
-import android.content.Context
-import android.net.Uri
 import androidx.compose.runtime.mutableStateListOf
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
@@ -10,7 +8,6 @@ import androidx.lifecycle.viewModelScope
 import com.weatherxm.ui.common.StationPhoto
 import com.weatherxm.ui.common.UIDevice
 import com.weatherxm.usecases.DevicePhotoUseCase
-import com.weatherxm.util.ImageFileHelper.getUriForFile
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
@@ -44,7 +41,7 @@ class PhotoGalleryViewModel(
     fun deletePhoto(photo: StationPhoto) {
         photo.remotePath?.let { photoRemotePath ->
             if (photos.firstOrNull { it.remotePath == photoRemotePath } != null) {
-                viewModelScope.launch {
+                viewModelScope.launch(dispatcher) {
                     usecase.deleteDevicePhoto(device.id, photoRemotePath).onLeft {
                         Timber.e("Failed to delete photo $photo")
                     }
@@ -66,13 +63,13 @@ class PhotoGalleryViewModel(
         onPhotosNumber.postValue(photos.size)
     }
 
-    fun getUrisOfLocalPhotos(context: Context): ArrayList<Uri> {
-        val uris = arrayListOf<Uri>()
+    fun getPhotosLocalPaths(): ArrayList<String> {
+        val photosLocalPaths = arrayListOf<String>()
         photos.forEach {
             if (!it.localPath.isNullOrEmpty()) {
-                uris.add(File(it.localPath).getUriForFile(context))
+                photosLocalPaths.add(it.localPath)
             }
         }
-        return uris
+        return photosLocalPaths
     }
 }

--- a/app/src/main/java/com/weatherxm/ui/photoverification/intro/PhotoVerificationIntroActivity.kt
+++ b/app/src/main/java/com/weatherxm/ui/photoverification/intro/PhotoVerificationIntroActivity.kt
@@ -5,6 +5,7 @@ import android.os.Bundle
 import com.weatherxm.R
 import com.weatherxm.analytics.AnalyticsService
 import com.weatherxm.databinding.ActivityPhotoVerificationIntroBinding
+import com.weatherxm.ui.common.Contracts
 import com.weatherxm.ui.common.Contracts.ARG_DEVICE
 import com.weatherxm.ui.common.Contracts.ARG_INSTRUCTIONS_ONLY
 import com.weatherxm.ui.common.UIDevice
@@ -20,6 +21,7 @@ class PhotoVerificationIntroActivity : BaseActivity() {
 
     private var instructionsOnly = false
     private var device = UIDevice.empty()
+    private var stationPhotoUrls: ArrayList<String> = arrayListOf()
 
     @SuppressLint("MissingPermission")
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -29,6 +31,7 @@ class PhotoVerificationIntroActivity : BaseActivity() {
 
         instructionsOnly = intent.getBooleanExtra(ARG_INSTRUCTIONS_ONLY, false)
         device = intent.parcelable<UIDevice>(ARG_DEVICE) ?: UIDevice.empty()
+        stationPhotoUrls = intent.getStringArrayListExtra(Contracts.ARG_PHOTOS) ?: arrayListOf()
 
         /**
          * User opened this screen from an empty state (either no photos in settings or in claiming
@@ -36,7 +39,7 @@ class PhotoVerificationIntroActivity : BaseActivity() {
          * case so we just redirect to Photo Gallery.
          */
         if (viewModel.getAcceptedTerms() && !instructionsOnly) {
-            navigator.showPhotoGallery(null, this, device, arrayListOf(), true)
+            navigator.showPhotoGallery(null, this, device, stationPhotoUrls, true)
             finish()
         }
     }
@@ -73,7 +76,7 @@ class PhotoVerificationIntroActivity : BaseActivity() {
                             null,
                             this@PhotoVerificationIntroActivity,
                             device,
-                            arrayListOf(),
+                            stationPhotoUrls,
                             true
                         )
                         finish()

--- a/app/src/main/java/com/weatherxm/ui/photoverification/intro/PhotoVerificationIntroActivity.kt
+++ b/app/src/main/java/com/weatherxm/ui/photoverification/intro/PhotoVerificationIntroActivity.kt
@@ -30,7 +30,12 @@ class PhotoVerificationIntroActivity : BaseActivity() {
         instructionsOnly = intent.getBooleanExtra(ARG_INSTRUCTIONS_ONLY, false)
         device = intent.parcelable<UIDevice>(ARG_DEVICE) ?: UIDevice.empty()
 
-        if (viewModel.getAcceptedTerms()) {
+        /**
+         * User opened this screen from an empty state (either no photos in settings or in claiming
+         * but the user has already accepted the terms before, and it's not a "Show Instructions"
+         * case so we just redirect to Photo Gallery.
+         */
+        if (viewModel.getAcceptedTerms() && !instructionsOnly) {
             navigator.showPhotoGallery(null, this, device, arrayListOf(), true)
             finish()
         }

--- a/app/src/main/java/com/weatherxm/ui/photoverification/upload/PhotoUploadActivity.kt
+++ b/app/src/main/java/com/weatherxm/ui/photoverification/upload/PhotoUploadActivity.kt
@@ -1,6 +1,5 @@
 package com.weatherxm.ui.photoverification.upload
 
-import android.graphics.BitmapFactory
 import android.os.Bundle
 import com.weatherxm.R
 import com.weatherxm.data.models.PhotoPresignedMetadata
@@ -14,14 +13,9 @@ import com.weatherxm.ui.common.UIDevice
 import com.weatherxm.ui.common.parcelable
 import com.weatherxm.ui.common.visible
 import com.weatherxm.ui.components.BaseActivity
-import com.weatherxm.util.ImageFileHelper.compressImageFile
-import com.weatherxm.util.ImageFileHelper.copyExifMetadata
-import com.weatherxm.util.ImageFileHelper.copyInputStreamToFile
-import net.gotev.uploadservice.protocols.multipart.MultipartUploadRequest
 import org.koin.android.ext.android.inject
 import org.koin.androidx.viewmodel.ext.android.viewModel
 import org.koin.core.parameter.parametersOf
-import java.io.File
 
 class PhotoUploadActivity : BaseActivity() {
     private val uploadObserverService: GlobalUploadObserverService by inject()
@@ -79,23 +73,7 @@ class PhotoUploadActivity : BaseActivity() {
         uploadObserverService.setDevice(model.device)
         model.photos.forEachIndexed { index, stationPhoto ->
             photosPresignedMetadata.getOrNull(index)?.let {
-                val file = File(cacheDir, "img$index.jpeg")
-                val imageBitmap = BitmapFactory.decodeFile(stationPhoto.localPath)
-                file.copyInputStreamToFile(compressImageFile(imageBitmap))
-                copyExifMetadata(stationPhoto.localPath, file.path)
-
-                val uploadRequest = MultipartUploadRequest(this, it.url)
-                    .setMethod("POST")
-                    .addParameter("bucket", it.fields.bucket)
-                    .addParameter("X-Amz-Algorithm", it.fields.xAmzAlgo)
-                    .addParameter("X-Amz-Credential", it.fields.xAmzCredentials)
-                    .addParameter("X-Amz-Date", it.fields.xAmzDate)
-                    //TODO: STOPSHIP .addParameter("X-Amz-Security-Token", it.fields.xAmzSecurityToken)
-                    .addParameter("X-Amz-Signature", it.fields.xAmzSignature)
-                    .addParameter("key", it.fields.key)
-                    .addParameter("Policy", it.fields.policy)
-                    .addFileToUpload(file.path, "file")
-                uploadRequest.startUpload()
+                prepareAndStartUpload(this, stationPhoto.localPath, model.device.id, index, it)
             }
         }
     }

--- a/app/src/main/java/com/weatherxm/ui/photoverification/upload/PhotoUploadActivity.kt
+++ b/app/src/main/java/com/weatherxm/ui/photoverification/upload/PhotoUploadActivity.kt
@@ -58,7 +58,13 @@ class PhotoUploadActivity : BaseActivity() {
                     binding.continueBtn.visible(true)
                 }
                 Status.ERROR -> {
-                    TODO()
+                    binding.status
+                        .clear()
+                        .animation(R.raw.anim_error)
+                        .title(R.string.upload_failed_to_start)
+                        .subtitle(resource.message)
+                        .action(getString(R.string.action_retry_upload))
+                        .setOnClickListener { model.prepareUpload() }
                 }
                 Status.LOADING -> {
                     // Do nothing. Already in loading state.

--- a/app/src/main/java/com/weatherxm/ui/photoverification/upload/PhotoUploadActivity.kt
+++ b/app/src/main/java/com/weatherxm/ui/photoverification/upload/PhotoUploadActivity.kt
@@ -1,0 +1,102 @@
+package com.weatherxm.ui.photoverification.upload
+
+import android.graphics.BitmapFactory
+import android.os.Bundle
+import com.weatherxm.R
+import com.weatherxm.data.models.PhotoPresignedMetadata
+import com.weatherxm.databinding.ActivityPhotoUploadBinding
+import com.weatherxm.service.GlobalUploadObserverService
+import com.weatherxm.ui.common.Contracts
+import com.weatherxm.ui.common.Contracts.ARG_DEVICE
+import com.weatherxm.ui.common.StationPhoto
+import com.weatherxm.ui.common.Status
+import com.weatherxm.ui.common.UIDevice
+import com.weatherxm.ui.common.parcelable
+import com.weatherxm.ui.common.visible
+import com.weatherxm.ui.components.BaseActivity
+import com.weatherxm.util.ImageFileHelper.compressImageFile
+import com.weatherxm.util.ImageFileHelper.copyExifMetadata
+import com.weatherxm.util.ImageFileHelper.copyInputStreamToFile
+import net.gotev.uploadservice.protocols.multipart.MultipartUploadRequest
+import org.koin.android.ext.android.inject
+import org.koin.androidx.viewmodel.ext.android.viewModel
+import org.koin.core.parameter.parametersOf
+import java.io.File
+
+class PhotoUploadActivity : BaseActivity() {
+    private val uploadObserverService: GlobalUploadObserverService by inject()
+
+    private lateinit var binding: ActivityPhotoUploadBinding
+
+    private val model: PhotoUploadViewModel by viewModel {
+        val photoLocalPaths = intent.getStringArrayListExtra(Contracts.ARG_PHOTOS) ?: arrayListOf()
+        parametersOf(
+            intent.parcelable<UIDevice>(ARG_DEVICE) ?: UIDevice.empty(),
+            photoLocalPaths.map { StationPhoto(null, it) }
+        )
+    }
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        binding = ActivityPhotoUploadBinding.inflate(layoutInflater)
+        setContentView(binding.root)
+
+        binding.shareBtn.setOnClickListener {
+            navigator.openShareImages(this, model.getUrisOfLocalPhotos(this))
+        }
+
+        binding.continueBtn.setOnClickListener {
+            finish()
+        }
+
+        model.onPhotosPresignedMetadata().observe(this) { resource ->
+            when (resource.status) {
+                Status.SUCCESS -> {
+                    resource.data?.let {
+                        upload(it)
+                    }
+                    binding.status
+                        .clear()
+                        .animation(R.raw.anim_upload_success)
+                        .title(R.string.upload_started)
+                        .subtitle(R.string.upload_started_subtitle)
+                    binding.shareBtn.visible(true)
+                    binding.continueBtn.visible(true)
+                }
+                Status.ERROR -> {
+                    TODO()
+                }
+                Status.LOADING -> {
+                    // Do nothing. Already in loading state.
+                }
+            }
+        }
+
+        model.prepareUpload()
+    }
+
+    fun upload(photosPresignedMetadata: List<PhotoPresignedMetadata>) {
+        uploadObserverService.setDevice(model.device)
+        model.photos.forEachIndexed { index, stationPhoto ->
+            photosPresignedMetadata.getOrNull(index)?.let {
+                val file = File(cacheDir, "img$index.jpeg")
+                val imageBitmap = BitmapFactory.decodeFile(stationPhoto.localPath)
+                file.copyInputStreamToFile(compressImageFile(imageBitmap))
+                copyExifMetadata(stationPhoto.localPath, file.path)
+
+                val uploadRequest = MultipartUploadRequest(this, it.url)
+                    .setMethod("POST")
+                    .addParameter("bucket", it.fields.bucket)
+                    .addParameter("X-Amz-Algorithm", it.fields.xAmzAlgo)
+                    .addParameter("X-Amz-Credential", it.fields.xAmzCredentials)
+                    .addParameter("X-Amz-Date", it.fields.xAmzDate)
+                    //TODO: STOPSHIP .addParameter("X-Amz-Security-Token", it.fields.xAmzSecurityToken)
+                    .addParameter("X-Amz-Signature", it.fields.xAmzSignature)
+                    .addParameter("key", it.fields.key)
+                    .addParameter("Policy", it.fields.policy)
+                    .addFileToUpload(file.path, file.name)
+                uploadRequest.startUpload()
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/weatherxm/ui/photoverification/upload/PhotoUploadActivity.kt
+++ b/app/src/main/java/com/weatherxm/ui/photoverification/upload/PhotoUploadActivity.kt
@@ -94,7 +94,7 @@ class PhotoUploadActivity : BaseActivity() {
                     .addParameter("X-Amz-Signature", it.fields.xAmzSignature)
                     .addParameter("key", it.fields.key)
                     .addParameter("Policy", it.fields.policy)
-                    .addFileToUpload(file.path, file.name)
+                    .addFileToUpload(file.path, "file")
                 uploadRequest.startUpload()
             }
         }

--- a/app/src/main/java/com/weatherxm/ui/photoverification/upload/PhotoUploadViewModel.kt
+++ b/app/src/main/java/com/weatherxm/ui/photoverification/upload/PhotoUploadViewModel.kt
@@ -52,10 +52,13 @@ class PhotoUploadViewModel(
             usecase.getPhotosMetadataForUpload(device.id, photos.mapNotNull { it.localPath })
                 .onRight {
                     onPhotosPresignedMetadata.postValue(Resource.success(it))
-                }.onLeft {
+                }
+                .onLeft {
                     analytics.trackEventFailure(it.code)
                     val errorMessage = when (it) {
-                        is ApiError.DeviceNotFound -> resources.getString(R.string.error_device_not_found)
+                        is ApiError.DeviceNotFound -> {
+                            resources.getString(R.string.error_device_not_found)
+                        }
                         is ApiError.GenericError.JWTError.UnauthorizedError -> it.message
                         else -> it.getDefaultMessage(R.string.error_reach_out_short)
                     } ?: resources.getString(R.string.error_reach_out_short)

--- a/app/src/main/java/com/weatherxm/ui/photoverification/upload/PhotoUploadViewModel.kt
+++ b/app/src/main/java/com/weatherxm/ui/photoverification/upload/PhotoUploadViewModel.kt
@@ -46,7 +46,7 @@ class PhotoUploadViewModel(
                 .onRight {
                     onPhotosPresignedMetadata.postValue(Resource.success(it))
                 }.onLeft {
-                    // TODO: Handle Failer
+                    // TODO: Handle Failure
                 }
         }
     }

--- a/app/src/main/java/com/weatherxm/ui/photoverification/upload/PhotoUploadViewModel.kt
+++ b/app/src/main/java/com/weatherxm/ui/photoverification/upload/PhotoUploadViewModel.kt
@@ -1,0 +1,53 @@
+package com.weatherxm.ui.photoverification.upload
+
+import android.content.Context
+import android.net.Uri
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.MutableLiveData
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.weatherxm.data.models.PhotoPresignedMetadata
+import com.weatherxm.ui.common.Resource
+import com.weatherxm.ui.common.StationPhoto
+import com.weatherxm.ui.common.UIDevice
+import com.weatherxm.usecases.DevicePhotoUseCase
+import com.weatherxm.util.ImageFileHelper.getUriForFile
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import java.io.File
+
+class PhotoUploadViewModel(
+    val device: UIDevice,
+    val photos: MutableList<StationPhoto>,
+    private val usecase: DevicePhotoUseCase,
+    val dispatcher: CoroutineDispatcher = Dispatchers.IO
+) : ViewModel() {
+    private val onPhotosPresignedMetadata =
+        MutableLiveData<Resource<List<PhotoPresignedMetadata>>>()
+
+    fun onPhotosPresignedMetadata(): LiveData<Resource<List<PhotoPresignedMetadata>>> =
+        onPhotosPresignedMetadata
+
+    fun getUrisOfLocalPhotos(context: Context): ArrayList<Uri> {
+        val uris = arrayListOf<Uri>()
+        photos.forEach {
+            if (!it.localPath.isNullOrEmpty()) {
+                uris.add(File(it.localPath).getUriForFile(context))
+            }
+        }
+        return uris
+    }
+
+    fun prepareUpload() {
+        viewModelScope.launch(dispatcher) {
+            onPhotosPresignedMetadata.postValue(Resource.loading())
+            usecase.getPhotosMetadataForUpload(device.id, photos.mapNotNull { it.localPath })
+                .onRight {
+                    onPhotosPresignedMetadata.postValue(Resource.success(it))
+                }.onLeft {
+                    // TODO: Handle Failer
+                }
+        }
+    }
+}

--- a/app/src/main/java/com/weatherxm/usecases/DevicePhotoUseCase.kt
+++ b/app/src/main/java/com/weatherxm/usecases/DevicePhotoUseCase.kt
@@ -54,10 +54,12 @@ class DevicePhotoUseCaseImpl(
 
     override fun retryUpload(deviceId: String) {
         getDevicePhotoUploadIds(deviceId).forEach {
-            // TODO: STOPSHIP: This crashes. https://github.com/gotev/android-upload-service/issues/672 
-            val request = repository.getUploadIdRequest(it)
-            request?.setUploadID(it)
-            request?.startUpload()
+            /**
+             * TODO: STOPSHIP: This crashes. https://github.com/gotev/android-upload-service/issues/672
+             * PR: https://github.com/gotev/android-upload-service/pull/673
+             */
+//            val request = repository.getUploadIdRequest(it)
+//            request?.startUpload()
         }
     }
 }

--- a/app/src/main/java/com/weatherxm/usecases/DevicePhotoUseCase.kt
+++ b/app/src/main/java/com/weatherxm/usecases/DevicePhotoUseCase.kt
@@ -1,12 +1,12 @@
 package com.weatherxm.usecases
 
 import arrow.core.Either
-import com.weatherxm.data.models.DevicePhoto
 import com.weatherxm.data.models.Failure
 import com.weatherxm.data.repository.DevicePhotoRepository
 
 interface DevicePhotoUseCase {
-    suspend fun getDevicePhotos(deviceId: String): Either<Failure, List<DevicePhoto>>
+    suspend fun getDevicePhotos(deviceId: String): Either<Failure, List<String>>
+    suspend fun deleteDevicePhoto(deviceId: String, photoPath: String): Either<Failure, Unit>
     fun getAcceptedTerms(): Boolean
     fun setAcceptedTerms()
 }
@@ -14,8 +14,15 @@ interface DevicePhotoUseCase {
 class DevicePhotoUseCaseImpl(
     private val repository: DevicePhotoRepository
 ) : DevicePhotoUseCase {
-    override suspend fun getDevicePhotos(deviceId: String): Either<Failure, List<DevicePhoto>> {
+    override suspend fun getDevicePhotos(deviceId: String): Either<Failure, List<String>> {
         return repository.getDevicePhotos(deviceId)
+    }
+
+    override suspend fun deleteDevicePhoto(
+        deviceId: String,
+        photoPath: String
+    ): Either<Failure, Unit> {
+        return repository.deleteDevicePhoto(deviceId, photoPath)
     }
 
     override fun getAcceptedTerms(): Boolean {

--- a/app/src/main/java/com/weatherxm/usecases/DevicePhotoUseCase.kt
+++ b/app/src/main/java/com/weatherxm/usecases/DevicePhotoUseCase.kt
@@ -2,11 +2,17 @@ package com.weatherxm.usecases
 
 import arrow.core.Either
 import com.weatherxm.data.models.Failure
+import com.weatherxm.data.models.PhotoPresignedMetadata
 import com.weatherxm.data.repository.DevicePhotoRepository
 
 interface DevicePhotoUseCase {
     suspend fun getDevicePhotos(deviceId: String): Either<Failure, List<String>>
     suspend fun deleteDevicePhoto(deviceId: String, photoPath: String): Either<Failure, Unit>
+    suspend fun getPhotosMetadataForUpload(
+        deviceId: String,
+        photoPaths: List<String>
+    ): Either<Failure, List<PhotoPresignedMetadata>>
+
     fun getAcceptedTerms(): Boolean
     fun setAcceptedTerms()
 }
@@ -23,6 +29,13 @@ class DevicePhotoUseCaseImpl(
         photoPath: String
     ): Either<Failure, Unit> {
         return repository.deleteDevicePhoto(deviceId, photoPath)
+    }
+
+    override suspend fun getPhotosMetadataForUpload(
+        deviceId: String,
+        photoPaths: List<String>
+    ): Either<Failure, List<PhotoPresignedMetadata>> {
+        return repository.getPhotosMetadataForUpload(deviceId, photoPaths)
     }
 
     override fun getAcceptedTerms(): Boolean {

--- a/app/src/main/java/com/weatherxm/usecases/DevicePhotoUseCase.kt
+++ b/app/src/main/java/com/weatherxm/usecases/DevicePhotoUseCase.kt
@@ -54,12 +54,9 @@ class DevicePhotoUseCaseImpl(
 
     override fun retryUpload(deviceId: String) {
         getDevicePhotoUploadIds(deviceId).forEach {
-            /**
-             * TODO: STOPSHIP: This crashes. https://github.com/gotev/android-upload-service/issues/672
-             * PR: https://github.com/gotev/android-upload-service/pull/673
-             */
-//            val request = repository.getUploadIdRequest(it)
-//            request?.startUpload()
+            val request = repository.getUploadIdRequest(it)
+            request?.setUploadID(it)
+            request?.startUpload()
         }
     }
 }

--- a/app/src/main/java/com/weatherxm/usecases/DevicePhotoUseCase.kt
+++ b/app/src/main/java/com/weatherxm/usecases/DevicePhotoUseCase.kt
@@ -15,6 +15,8 @@ interface DevicePhotoUseCase {
 
     fun getAcceptedTerms(): Boolean
     fun setAcceptedTerms()
+    fun getDevicePhotoUploadingIds(deviceId: String): List<String>
+    fun removeDevicePhotoUploadingId(deviceId: String, uploadingId: String)
 }
 
 class DevicePhotoUseCaseImpl(
@@ -44,5 +46,13 @@ class DevicePhotoUseCaseImpl(
 
     override fun setAcceptedTerms() {
         repository.setAcceptedTerms()
+    }
+
+    override fun getDevicePhotoUploadingIds(deviceId: String): List<String> {
+        return repository.getDevicePhotoUploadingIds(deviceId)
+    }
+
+    override fun removeDevicePhotoUploadingId(deviceId: String, uploadingId: String) {
+        repository.removeDevicePhotoUploadingId(deviceId, uploadingId)
     }
 }

--- a/app/src/main/java/com/weatherxm/usecases/DevicePhotoUseCase.kt
+++ b/app/src/main/java/com/weatherxm/usecases/DevicePhotoUseCase.kt
@@ -15,8 +15,9 @@ interface DevicePhotoUseCase {
 
     fun getAcceptedTerms(): Boolean
     fun setAcceptedTerms()
-    fun getDevicePhotoUploadingIds(deviceId: String): List<String>
-    fun removeDevicePhotoUploadingId(deviceId: String, uploadingId: String)
+    fun getDevicePhotoUploadIds(deviceId: String): List<String>
+    fun removeDevicePhotoUploadId(deviceId: String, uploadId: String)
+    fun retryUpload(deviceId: String)
 }
 
 class DevicePhotoUseCaseImpl(
@@ -48,11 +49,17 @@ class DevicePhotoUseCaseImpl(
         repository.setAcceptedTerms()
     }
 
-    override fun getDevicePhotoUploadingIds(deviceId: String): List<String> {
-        return repository.getDevicePhotoUploadingIds(deviceId)
+    override fun getDevicePhotoUploadIds(deviceId: String): List<String> {
+        return repository.getDevicePhotoUploadIds(deviceId)
     }
 
-    override fun removeDevicePhotoUploadingId(deviceId: String, uploadingId: String) {
-        repository.removeDevicePhotoUploadingId(deviceId, uploadingId)
+    override fun removeDevicePhotoUploadId(deviceId: String, uploadId: String) {
+        repository.removeDevicePhotoUploadId(deviceId, uploadId)
+    }
+
+    override fun retryUpload(deviceId: String) {
+        getDevicePhotoUploadIds(deviceId).forEach {
+            repository.getUploadIdRequest(it)?.startUpload()
+        }
     }
 }

--- a/app/src/main/java/com/weatherxm/usecases/DevicePhotoUseCase.kt
+++ b/app/src/main/java/com/weatherxm/usecases/DevicePhotoUseCase.kt
@@ -16,7 +16,6 @@ interface DevicePhotoUseCase {
     fun getAcceptedTerms(): Boolean
     fun setAcceptedTerms()
     fun getDevicePhotoUploadIds(deviceId: String): List<String>
-    fun removeDevicePhotoUploadId(deviceId: String, uploadId: String)
     fun retryUpload(deviceId: String)
 }
 
@@ -51,10 +50,6 @@ class DevicePhotoUseCaseImpl(
 
     override fun getDevicePhotoUploadIds(deviceId: String): List<String> {
         return repository.getDevicePhotoUploadIds(deviceId)
-    }
-
-    override fun removeDevicePhotoUploadId(deviceId: String, uploadId: String) {
-        repository.removeDevicePhotoUploadId(deviceId, uploadId)
     }
 
     override fun retryUpload(deviceId: String) {

--- a/app/src/main/java/com/weatherxm/usecases/DevicePhotoUseCase.kt
+++ b/app/src/main/java/com/weatherxm/usecases/DevicePhotoUseCase.kt
@@ -59,7 +59,10 @@ class DevicePhotoUseCaseImpl(
 
     override fun retryUpload(deviceId: String) {
         getDevicePhotoUploadIds(deviceId).forEach {
-            repository.getUploadIdRequest(it)?.startUpload()
+            // TODO: STOPSHIP: This crashes. https://github.com/gotev/android-upload-service/issues/672 
+            val request = repository.getUploadIdRequest(it)
+            request?.setUploadID(it)
+            request?.startUpload()
         }
     }
 }

--- a/app/src/main/java/com/weatherxm/util/ImageFileHelper.kt
+++ b/app/src/main/java/com/weatherxm/util/ImageFileHelper.kt
@@ -45,7 +45,10 @@ object ImageFileHelper {
         }
     }
 
-    fun copyExifMetadata(sourcePath: String, destPath: String) {
+    fun copyExifMetadata(sourcePath: String?, destPath: String) {
+        if (sourcePath == null) {
+            return
+        }
         val oldExifInterface = ExifInterface(sourcePath)
         val newExifInterface = ExifInterface(destPath)
 

--- a/app/src/main/res/layout/activity_device_settings_helium.xml
+++ b/app/src/main/res/layout/activity_device_settings_helium.xml
@@ -40,6 +40,7 @@
         <androidx.constraintlayout.widget.ConstraintLayout
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
+            android:clipChildren="false"
             android:clipToPadding="false"
             android:paddingBottom="@dimen/padding_normal">
 

--- a/app/src/main/res/layout/activity_photo_upload.xml
+++ b/app/src/main/res/layout/activity_photo_upload.xml
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.coordinatorlayout.widget.CoordinatorLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/root"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:fitsSystemWindows="true">
+
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:layout_marginHorizontal="@dimen/margin_normal"
+        android:layout_marginBottom="@dimen/margin_large">
+
+        <com.weatherxm.ui.components.EmptyView
+            android:id="@+id/status"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            app:empty_animation="@raw/anim_loading"
+            app:empty_subtitle="@string/preparing_the_upload_subtitle"
+            app:empty_title="@string/preparing_the_upload"
+            app:layout_constraintBottom_toTopOf="@id/shareBtn"
+            app:layout_constraintTop_toTopOf="parent" />
+
+        <com.google.android.material.button.MaterialButton
+            android:id="@+id/shareBtn"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginBottom="@dimen/margin_small_to_normal"
+            android:text="@string/share"
+            android:visibility="gone"
+            app:layout_constraintBottom_toTopOf="@id/continueBtn"
+            tools:visibility="visible" />
+
+        <com.google.android.material.button.MaterialButton
+            android:id="@+id/continueBtn"
+            style="@style/Widget.WeatherXM.Button.Subtle.Borders"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:text="@string/action_continue"
+            android:visibility="gone"
+            app:layout_constraintBottom_toBottomOf="parent"
+            tools:visibility="visible" />
+    </androidx.constraintlayout.widget.ConstraintLayout>
+
+</androidx.coordinatorlayout.widget.CoordinatorLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -701,5 +701,6 @@
     <string name="preparing_the_upload">Preparing the upload…</string>
     <string name="preparing_the_upload_subtitle">Almost there! We’ll let you know once everything is ready.</string>
     <string name="upload_started">Upload started successfully</string>
+    <string name="upload_failed_to_start">Upload failed to start</string>
     <string name="upload_started_subtitle">Thanks for helping us build a healthier network!\n\nOnce uploaded, the photos will appear in your station’s settings.</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -10,6 +10,7 @@
     <string name="action_cancel">Cancel</string>
     <string name="action_change">Change</string>
     <string name="action_confirm">Confirm</string>
+    <string name="action_continue">Continue</string>
     <string name="action_back">Back</string>
     <string name="action_skip">Skip</string>
     <string name="action_logout">Logout</string>
@@ -697,4 +698,8 @@
     <string name="cancel_upload_message">Are you sure you want to cancel the upload and lose the photos?\nYou will need to retake them.</string>
     <string name="upload_unexpected_error">We faced an unexpected error while uploading your photos.</string>
     <string name="accept_acceptable_use_policy"><![CDATA[I have read and accept the <a href="%1$s">Acceptable Use Policy (AUP)</a>]]></string>
+    <string name="preparing_the_upload">Preparing the upload…</string>
+    <string name="preparing_the_upload_subtitle">Almost there! We’ll let you know once everything is ready.</string>
+    <string name="upload_started">Upload started successfully</string>
+    <string name="upload_started_subtitle">Thanks for helping us build a healthier network!\n\nOnce uploaded, the photos will appear in your station’s settings.</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -703,4 +703,9 @@
     <string name="upload_started">Upload started successfully</string>
     <string name="upload_failed_to_start">Upload failed to start</string>
     <string name="upload_started_subtitle">Thanks for helping us build a healthier network!\n\nOnce uploaded, the photos will appear in your station’s settings.</string>
+    <string name="upload_notification_in_progress_title">Uploading 1 file</string>
+    <string name="upload_notification_success_title">Uploaded 1 file</string>
+    <string name="upload_notification_error_title">Upload failed</string>
+    <string name="upload_notification_error_message">An error occurred</string>
+    <string name="upload_notification_cancelled_title">Upload cancelled</string>
 </resources>

--- a/app/src/test/java/com/weatherxm/data/datasource/DevicePhotoDataSourceTest.kt
+++ b/app/src/test/java/com/weatherxm/data/datasource/DevicePhotoDataSourceTest.kt
@@ -2,10 +2,13 @@ package com.weatherxm.data.datasource
 
 import com.haroldadmin.cnradapter.NetworkResponse
 import com.weatherxm.TestConfig.cacheService
+import com.weatherxm.TestConfig.successUnitResponse
 import com.weatherxm.TestUtils.retrofitResponse
 import com.weatherxm.TestUtils.testNetworkCall
+import com.weatherxm.data.models.PhotoPresignedMetadata
 import com.weatherxm.data.network.ApiService
 import com.weatherxm.data.network.ErrorResponse
+import com.weatherxm.data.network.PhotoNamesBody
 import io.kotest.core.spec.style.BehaviorSpec
 import io.kotest.matchers.shouldBe
 import io.mockk.every
@@ -18,24 +21,62 @@ class DevicePhotoDataSourceTest : BehaviorSpec({
     val datasource = DevicePhotoDataSourceImpl(apiService, cacheService)
 
     val deviceId = "deviceId"
-    val devicePhotos = listOf<String>()
-    val photosResponse = NetworkResponse.Success<List<String>, ErrorResponse>(
-        devicePhotos,
-        retrofitResponse(devicePhotos)
+    val photoName = "photoName"
+    val emptyListString = listOf<String>()
+    val uploadIds = listOf("uploadIds")
+    val photosMetadata = listOf<PhotoPresignedMetadata>()
+    val devicePhotosResponse = NetworkResponse.Success<List<String>, ErrorResponse>(
+        emptyListString,
+        retrofitResponse(emptyListString)
     )
+    val photosMetadataResponse =
+        NetworkResponse.Success<List<PhotoPresignedMetadata>, ErrorResponse>(
+            photosMetadata,
+            retrofitResponse(photosMetadata)
+        )
 
     beforeSpec {
         justRun { cacheService.setPhotoVerificationAcceptedTerms() }
+        every { cacheService.getDevicePhotoUploadIds(deviceId) } returns uploadIds
     }
 
     context("Get device photos") {
         When("Using the Network Source") {
             testNetworkCall(
                 "the list of photos",
-                devicePhotos,
-                photosResponse,
+                emptyListString,
+                devicePhotosResponse,
                 mockFunction = { apiService.getDevicePhotos(deviceId) },
                 runFunction = { datasource.getDevicePhotos(deviceId) }
+            )
+        }
+    }
+
+    context("Delete device photo") {
+        When("Using the Network Source") {
+            testNetworkCall(
+                "the response of the request indicated by Unit as a success",
+                Unit,
+                successUnitResponse,
+                mockFunction = { apiService.deleteDevicePhoto(deviceId, photoName) },
+                runFunction = { datasource.deleteDevicePhoto(deviceId, photoName) }
+            )
+        }
+    }
+
+    context("Get device photos metadata") {
+        When("Using the Network Source") {
+            testNetworkCall(
+                "the list of photos metadata",
+                photosMetadata,
+                photosMetadataResponse,
+                mockFunction = {
+                    apiService.getPhotosMetadataForUpload(
+                        deviceId,
+                        PhotoNamesBody(listOf(photoName))
+                    )
+                },
+                runFunction = { datasource.getPhotosMetadataForUpload(deviceId, listOf(photoName)) }
             )
         }
     }
@@ -61,6 +102,14 @@ class DevicePhotoDataSourceTest : BehaviorSpec({
                     datasource.setAcceptedTerms()
                     verify(exactly = 1) { cacheService.setPhotoVerificationAcceptedTerms() }
                 }
+            }
+        }
+    }
+
+    context("Get device photos upload IDs") {
+        given("a device ID") {
+            then("return the list of upload IDs") {
+                datasource.getDevicePhotoUploadIds(deviceId) shouldBe uploadIds
             }
         }
     }

--- a/app/src/test/java/com/weatherxm/data/datasource/DevicePhotoDataSourceTest.kt
+++ b/app/src/test/java/com/weatherxm/data/datasource/DevicePhotoDataSourceTest.kt
@@ -4,7 +4,6 @@ import com.haroldadmin.cnradapter.NetworkResponse
 import com.weatherxm.TestConfig.cacheService
 import com.weatherxm.TestUtils.retrofitResponse
 import com.weatherxm.TestUtils.testNetworkCall
-import com.weatherxm.data.models.DevicePhoto
 import com.weatherxm.data.network.ApiService
 import com.weatherxm.data.network.ErrorResponse
 import io.kotest.core.spec.style.BehaviorSpec
@@ -19,8 +18,8 @@ class DevicePhotoDataSourceTest : BehaviorSpec({
     val datasource = DevicePhotoDataSourceImpl(apiService, cacheService)
 
     val deviceId = "deviceId"
-    val devicePhotos = listOf<DevicePhoto>()
-    val photosResponse = NetworkResponse.Success<List<DevicePhoto>, ErrorResponse>(
+    val devicePhotos = listOf<String>()
+    val photosResponse = NetworkResponse.Success<List<String>, ErrorResponse>(
         devicePhotos,
         retrofitResponse(devicePhotos)
     )

--- a/app/src/test/java/com/weatherxm/ui/devicesettings/wifi/DeviceSettingsWifiViewModelTest.kt
+++ b/app/src/test/java/com/weatherxm/ui/devicesettings/wifi/DeviceSettingsWifiViewModelTest.kt
@@ -504,6 +504,25 @@ class DeviceSettingsWifiViewModelTest : BehaviorSpec({
         }
     }
 
+    context("Get if the user has accepted the uploading photos terms") {
+        given("The usecase providing the GET / SET mechanisms") {
+            When("We should get the user's accepted status") {
+                and("user has not accepted the terms") {
+                    every { photosUseCase.getAcceptedTerms() } returns false
+                    then("return false") {
+                        viewModel.getAcceptedPhotoTerms() shouldBe false
+                    }
+                }
+                and("user has accepted the terms") {
+                    every { photosUseCase.getAcceptedTerms() } returns true
+                    then("return true") {
+                        viewModel.getAcceptedPhotoTerms() shouldBe true
+                    }
+                }
+            }
+        }
+    }
+
     afterSpec {
         stopKoin()
     }

--- a/app/src/test/java/com/weatherxm/ui/devicesettings/wifi/DeviceSettingsWifiViewModelTest.kt
+++ b/app/src/test/java/com/weatherxm/ui/devicesettings/wifi/DeviceSettingsWifiViewModelTest.kt
@@ -186,6 +186,7 @@ class DeviceSettingsWifiViewModelTest : BehaviorSpec({
     val stationPhotos = arrayListOf(
         StationPhoto("remotePath", "localPath")
     )
+    val uploadIds = listOf("uploadId")
 
     val invalidClaimIdFailure = ApiError.UserError.ClaimError.InvalidClaimId("")
 
@@ -240,6 +241,12 @@ class DeviceSettingsWifiViewModelTest : BehaviorSpec({
         } returns "Last Station Activity"
         every { resources.getString(R.string.latest_hint) } returns "(latest)"
         every { resources.getString(R.string.firmware_version) } returns "Firmware Version"
+        coMockEitherRight(
+            { photosUseCase.deleteDevicePhoto(device.id, stationPhotos[0].remotePath!!) },
+            Unit
+        )
+        every { photosUseCase.getDevicePhotoUploadIds(device.id) } returns uploadIds
+        justRun { photosUseCase.retryUpload(device.id) }
 
         viewModel = DeviceSettingsWifiViewModel(
             device,
@@ -443,6 +450,23 @@ class DeviceSettingsWifiViewModelTest : BehaviorSpec({
                     runTest { viewModel.getDevicePhotos() }
                     viewModel.onPhotos().value shouldBe listOf("testUrl")
                 }
+            }
+        }
+    }
+
+    context("Get device photos upload IDs") {
+        given("a device ID") {
+            then("return the list of upload IDs") {
+                viewModel.getDevicePhotoUploadIds() shouldBe uploadIds
+            }
+        }
+    }
+
+    context("Retry photo uploading") {
+        given("a deviceId") {
+            then("trigger the retrying of photo uploading") {
+                viewModel.retryPhotoUpload()
+                verify(exactly = 1) { photosUseCase.retryUpload(device.id) }
             }
         }
     }

--- a/app/src/test/java/com/weatherxm/ui/photoverification/upload/PhotoUploadViewModelTest.kt
+++ b/app/src/test/java/com/weatherxm/ui/photoverification/upload/PhotoUploadViewModelTest.kt
@@ -12,7 +12,6 @@ import com.weatherxm.TestUtils.coMockEitherRight
 import com.weatherxm.TestUtils.isSuccess
 import com.weatherxm.TestUtils.testHandleFailureViewModel
 import com.weatherxm.analytics.AnalyticsWrapper
-import com.weatherxm.data.HOUR_FORMAT_24H
 import com.weatherxm.data.models.ApiError
 import com.weatherxm.data.models.PhotoPresignedMetadata
 import com.weatherxm.ui.InstantExecutorListener
@@ -34,10 +33,8 @@ import io.mockk.mockkObject
 import kotlinx.coroutines.test.runTest
 import org.koin.core.context.startKoin
 import org.koin.core.context.stopKoin
-import org.koin.core.qualifier.named
 import org.koin.dsl.module
 import java.io.File
-import java.time.format.DateTimeFormatter
 
 class PhotoUploadViewModelTest : BehaviorSpec({
     val device = UIDevice.empty()

--- a/app/src/test/java/com/weatherxm/ui/photoverification/upload/PhotoUploadViewModelTest.kt
+++ b/app/src/test/java/com/weatherxm/ui/photoverification/upload/PhotoUploadViewModelTest.kt
@@ -1,0 +1,54 @@
+package com.weatherxm.ui.photoverification.upload
+
+import android.net.Uri
+import com.weatherxm.TestConfig.context
+import com.weatherxm.TestConfig.dispatcher
+import com.weatherxm.ui.InstantExecutorListener
+import com.weatherxm.ui.common.StationPhoto
+import com.weatherxm.ui.common.UIDevice
+import com.weatherxm.usecases.DevicePhotoUseCase
+import com.weatherxm.util.ImageFileHelper
+import com.weatherxm.util.ImageFileHelper.getUriForFile
+import io.kotest.core.spec.style.BehaviorSpec
+import io.kotest.matchers.shouldBe
+import io.mockk.clearMocks
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkObject
+import java.io.File
+
+class PhotoUploadViewModelTest : BehaviorSpec({
+    val device = UIDevice.empty()
+    val usecase = mockk<DevicePhotoUseCase>()
+    val viewModel = PhotoUploadViewModel(device, mutableListOf(), usecase, dispatcher)
+
+    val localPath = "localPath"
+    val localPhoto = StationPhoto(null, localPath)
+    val uri = mockk<Uri>()
+    val listOfUrisOfLocalPhotos = arrayListOf(uri)
+
+    listener(InstantExecutorListener())
+
+    beforeSpec {
+        mockkObject(ImageFileHelper)
+        every { File(localPath).getUriForFile(context) } returns uri
+    }
+
+    context("Get the URIs of the local photos") {
+        When("There are no photos with local paths") {
+            then("return an empty arraylist") {
+                viewModel.getUrisOfLocalPhotos(context) shouldBe arrayListOf()
+            }
+        }
+        When("There are some photos with local path") {
+            viewModel.photos.add(localPhoto)
+            then("return the arraylist containing the URIs of those photos") {
+                viewModel.getUrisOfLocalPhotos(context) shouldBe listOfUrisOfLocalPhotos
+            }
+        }
+    }
+
+    afterSpec {
+        clearMocks(ImageFileHelper)
+    }
+})

--- a/app/src/test/java/com/weatherxm/ui/photoverification/upload/PhotoUploadViewModelTest.kt
+++ b/app/src/test/java/com/weatherxm/ui/photoverification/upload/PhotoUploadViewModelTest.kt
@@ -1,37 +1,90 @@
 package com.weatherxm.ui.photoverification.upload
 
 import android.net.Uri
+import com.weatherxm.TestConfig.DEVICE_NOT_FOUND_MSG
+import com.weatherxm.TestConfig.REACH_OUT_MSG
 import com.weatherxm.TestConfig.context
 import com.weatherxm.TestConfig.dispatcher
+import com.weatherxm.TestConfig.failure
+import com.weatherxm.TestConfig.resources
+import com.weatherxm.TestUtils.coMockEitherLeft
+import com.weatherxm.TestUtils.coMockEitherRight
+import com.weatherxm.TestUtils.isSuccess
+import com.weatherxm.TestUtils.testHandleFailureViewModel
+import com.weatherxm.analytics.AnalyticsWrapper
+import com.weatherxm.data.HOUR_FORMAT_24H
+import com.weatherxm.data.models.ApiError
+import com.weatherxm.data.models.PhotoPresignedMetadata
 import com.weatherxm.ui.InstantExecutorListener
 import com.weatherxm.ui.common.StationPhoto
 import com.weatherxm.ui.common.UIDevice
+import com.weatherxm.ui.common.empty
 import com.weatherxm.usecases.DevicePhotoUseCase
 import com.weatherxm.util.ImageFileHelper
 import com.weatherxm.util.ImageFileHelper.getUriForFile
+import com.weatherxm.util.Resources
 import io.kotest.core.spec.style.BehaviorSpec
+import io.kotest.core.spec.style.scopes.BehaviorSpecWhenContainerScope
 import io.kotest.matchers.shouldBe
 import io.mockk.clearMocks
 import io.mockk.every
+import io.mockk.justRun
 import io.mockk.mockk
 import io.mockk.mockkObject
+import kotlinx.coroutines.test.runTest
+import org.koin.core.context.startKoin
+import org.koin.core.context.stopKoin
+import org.koin.core.qualifier.named
+import org.koin.dsl.module
 import java.io.File
+import java.time.format.DateTimeFormatter
 
 class PhotoUploadViewModelTest : BehaviorSpec({
     val device = UIDevice.empty()
     val usecase = mockk<DevicePhotoUseCase>()
-    val viewModel = PhotoUploadViewModel(device, mutableListOf(), usecase, dispatcher)
+    val analytics = mockk<AnalyticsWrapper>()
+    val viewModel =
+        PhotoUploadViewModel(device, mutableListOf(), usecase, resources, analytics, dispatcher)
 
     val localPath = "localPath"
     val localPhoto = StationPhoto(null, localPath)
+    val remotePhoto = StationPhoto("remotePath", null)
+    val localPhotosPaths = listOf(localPhoto.localPath!!)
     val uri = mockk<Uri>()
     val listOfUrisOfLocalPhotos = arrayListOf(uri)
+    val metadata = listOf<PhotoPresignedMetadata>()
+
+    val deviceNotFoundFailure = ApiError.DeviceNotFound("")
+    val unauthorizedFailure = ApiError.GenericError.JWTError.UnauthorizedError("", "unauthorized")
 
     listener(InstantExecutorListener())
 
     beforeSpec {
+        startKoin {
+            modules(
+                module {
+                    single<Resources> {
+                        resources
+                    }
+                }
+            )
+        }
         mockkObject(ImageFileHelper)
         every { File(localPath).getUriForFile(context) } returns uri
+        justRun { analytics.trackEventFailure(any()) }
+    }
+
+    suspend fun BehaviorSpecWhenContainerScope.testPrepareUploadFailure(
+        verifyNumberOfFailureEvents: Int,
+        errorMsg: String?
+    ) {
+        testHandleFailureViewModel(
+            { viewModel.prepareUpload() },
+            analytics,
+            viewModel.onPhotosPresignedMetadata(),
+            verifyNumberOfFailureEvents,
+            errorMsg ?: String.empty()
+        )
     }
 
     context("Get the URIs of the local photos") {
@@ -48,7 +101,48 @@ class PhotoUploadViewModelTest : BehaviorSpec({
         }
     }
 
+    context("Prepare upload (i.e. get the photos metadata needed)") {
+        given("a usecase providing the response containing the metadata") {
+            viewModel.photos.add(remotePhoto)
+            When("it is a failure") {
+                and("It's a DeviceNotFound failure") {
+                    coMockEitherLeft(
+                        { usecase.getPhotosMetadataForUpload(device.id, localPhotosPaths) },
+                        deviceNotFoundFailure
+                    )
+                    testPrepareUploadFailure(1, DEVICE_NOT_FOUND_MSG)
+                }
+                and("It's an UnauthorizedFailure failure") {
+                    coMockEitherLeft(
+                        { usecase.getPhotosMetadataForUpload(device.id, localPhotosPaths) },
+                        unauthorizedFailure
+                    )
+                    testPrepareUploadFailure(2, unauthorizedFailure.message)
+                }
+                and("it's any other failure") {
+                    coMockEitherLeft(
+                        { usecase.getPhotosMetadataForUpload(device.id, localPhotosPaths) },
+                        failure
+                    )
+                    testPrepareUploadFailure(3, REACH_OUT_MSG)
+                }
+            }
+            When("it is a success") {
+                coMockEitherRight(
+                    { usecase.getPhotosMetadataForUpload(device.id, localPhotosPaths) },
+                    metadata
+                )
+                runTest { viewModel.prepareUpload() }
+
+                then("LiveData at onPhotosPresignedMetadata posts a success with the metadata") {
+                    viewModel.onPhotosPresignedMetadata().isSuccess(metadata)
+                }
+            }
+        }
+    }
+
     afterSpec {
         clearMocks(ImageFileHelper)
+        stopKoin()
     }
 })

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -56,7 +56,7 @@ okhttp-bom = "4.12.0"
 retrofit = "2.11.0"
 retromock = "1.1.1"
 timber = "5.0.1"
-upload-service = "4.9.3"
+upload-service = "4.9.4"
 
 # Plugins
 android-gradle-plugin = "8.8.0"


### PR DESCRIPTION
### **Why?**
Photo Uploading Mechanism

### **How?**
- Created in our flow the functions `deleteDevicePhoto()` (for deleting a photo), `getPhotosMetadataForUpload()` (for fetching a photo's metadata from the API), `getDevicePhotoUploadIds()` (in order to cancel them if needed), `addDevicePhotoUploadIdAndRequest()` (save the request in order to get it again if needed e.g. on retry), `getUploadIdRequest()` (get the request in order to retry it).
- Created  the respective `ApiModels` for the metadata of a photo
- Created the respective API endpoints in `ApiService`
- Fixed UI Model `UploadPhotosState` to better represent the error state
- Created the worker `UploadPhotoWorker` which is responsible of creating an upload request, prepare it and start it.
- Created the `PhotoUploadActivity` and `PhotoUploadViewModel`. In this activity we contact the API to get the metadata, copy the captures photos to cache and copy their EXIF metadata and then start the above worker (**one worker for each photo as we need different, parallel uploads**).
- Created more unit tests that were needed (some last ones are still pending - To Be Completed with the retry functionality).

### **Testing**
Ensure that all tests look OK. Simulator works OK for taking pictures and uploading them etc. You can also emulate bad internet connection by clicking the 3 dots at the top right of the emulator window.
