### PR TITLE
Legal Terms Prompts and Checks

### DIFF
--- a/app/src/main/java/com/weatherxm/analytics/AnalyticsService.kt
+++ b/app/src/main/java/com/weatherxm/analytics/AnalyticsService.kt
@@ -256,7 +256,9 @@ interface AnalyticsService {
         TOKENS_EARNED_PRESSED("Tokens Earned pressed"),
         DEVICE_REWARD_ANALYTICS_CARD("Device Reward Analytics Card"),
         OPEN("open"),
-        CLOSED("closed")
+        CLOSED("closed"),
+        TERMS_OF_USE("Terms Of Use"),
+        PRIVACY_POLICY("Privacy Policy"),
     }
 
     // Custom Param Names

--- a/app/src/main/java/com/weatherxm/data/Modules.kt
+++ b/app/src/main/java/com/weatherxm/data/Modules.kt
@@ -504,7 +504,7 @@ private val usecases = module {
         ExplorerUseCaseImpl(get(), get(), get(), get())
     }
     single<DeviceDetailsUseCase> {
-        DeviceDetailsUseCaseImpl(get(), get(), get(), get())
+        DeviceDetailsUseCaseImpl(get(), get(), get(), get(), get())
     }
     single<ForecastUseCase> {
         ForecastUseCaseImpl(get())

--- a/app/src/main/java/com/weatherxm/data/datasource/UserPreferenceDataSource.kt
+++ b/app/src/main/java/com/weatherxm/data/datasource/UserPreferenceDataSource.kt
@@ -9,6 +9,8 @@ interface UserPreferenceDataSource {
     fun setDevicesSortFilterOptions(sortOrder: String, filter: String, groupBy: String)
     fun setWalletWarningDismissTimestamp()
     fun getWalletWarningDismissTimestamp(): Long
+    fun getAcceptTermsTimestamp(): Long
+    fun setAcceptTerms()
 }
 
 class UserPreferenceDataSourceImpl(
@@ -37,5 +39,13 @@ class UserPreferenceDataSourceImpl(
 
     override fun getWalletWarningDismissTimestamp(): Long {
         return cacheService.getWalletWarningDismissTimestamp()
+    }
+
+    override fun getAcceptTermsTimestamp(): Long {
+        return cacheService.getAcceptTermsTimestamp()
+    }
+
+    override fun setAcceptTerms() {
+        cacheService.setAcceptTermsTimestamp(System.currentTimeMillis())
     }
 }

--- a/app/src/main/java/com/weatherxm/data/repository/AuthRepositoryImpl.kt
+++ b/app/src/main/java/com/weatherxm/data/repository/AuthRepositoryImpl.kt
@@ -57,6 +57,8 @@ class AuthRepositoryImpl(
         lastName: String?
     ): Either<Failure, Unit> {
         return networkAuthDataSource.signup(username, firstName, lastName).onRight {
+            // The user has signed-up successfully so the terms should be marked as accepted
+            cacheService.setAcceptTermsTimestamp(System.currentTimeMillis())
             Timber.d("Signup success. Email sent to user: $username")
         }
     }

--- a/app/src/main/java/com/weatherxm/data/repository/UserPreferencesRepository.kt
+++ b/app/src/main/java/com/weatherxm/data/repository/UserPreferencesRepository.kt
@@ -9,6 +9,8 @@ interface UserPreferencesRepository {
     fun setWalletWarningDismissTimestamp()
     fun getDevicesSortFilterOptions(): List<String>
     fun setDevicesSortFilterOptions(sortOrder: String, filter: String, groupBy: String)
+    fun shouldShowTermsPrompt(): Boolean
+    fun setAcceptTerms()
 }
 
 class UserPreferencesRepositoryImpl(
@@ -37,5 +39,13 @@ class UserPreferencesRepositoryImpl(
 
     override fun setDevicesSortFilterOptions(sortOrder: String, filter: String, groupBy: String) {
         datasource.setDevicesSortFilterOptions(sortOrder, filter, groupBy)
+    }
+
+    override fun shouldShowTermsPrompt(): Boolean {
+        return datasource.getAcceptTermsTimestamp() == 0L
+    }
+
+    override fun setAcceptTerms() {
+        datasource.setAcceptTerms()
     }
 }

--- a/app/src/main/java/com/weatherxm/data/services/CacheService.kt
+++ b/app/src/main/java/com/weatherxm/data/services/CacheService.kt
@@ -46,6 +46,7 @@ class CacheService(
         const val KEY_INSTALLATION_ID = "installation_id"
         const val KEY_DISMISSED_SURVEY_ID = "dismissed_survey_id"
         const val KEY_DISMISSED_INFO_BANNER_ID = "dismissed_info_banner_id"
+        const val KEY_ACCEPT_TERMS_TIMESTAMP = "accept_terms_timestamp"
 
         // Default in-memory cache expiration time 15 minutes
         val DEFAULT_CACHE_EXPIRATION = TimeUnit.MINUTES.toMillis(15L)
@@ -117,6 +118,14 @@ class CacheService(
 
     fun getAnalyticsDecisionTimestamp(): Long {
         return preferences.getLong(KEY_ANALYTICS_OPT_IN_OR_OUT_TIMESTAMP, 0L)
+    }
+
+    fun setAcceptTermsTimestamp(timestamp: Long) {
+        preferences.edit().putLong(KEY_ACCEPT_TERMS_TIMESTAMP, timestamp).apply()
+    }
+
+    fun getAcceptTermsTimestamp(): Long {
+        return preferences.getLong(KEY_ACCEPT_TERMS_TIMESTAMP, 0L)
     }
 
     fun getAnalyticsEnabled(): Boolean {
@@ -370,6 +379,7 @@ class CacheService(
         val savedAnalyticsOptInOrOutTimestamp = preferences.getLong(
             KEY_ANALYTICS_OPT_IN_OR_OUT_TIMESTAMP, 0L
         )
+        val savedAcceptTermsTimestamp = preferences.getLong(KEY_ACCEPT_TERMS_TIMESTAMP, 0L)
         val widgetIds = preferences.getStringSet(KEY_CURRENT_WEATHER_WIDGET_IDS, setOf())
         val devicesOfWidgets = mutableMapOf<String, String>()
         widgetIds?.forEach {
@@ -388,6 +398,7 @@ class CacheService(
             .putString(resources.getString(KEY_PRESSURE), savedPressure)
             .putBoolean(resources.getString(KEY_ANALYTICS), savedAnalyticsEnabled)
             .putLong(KEY_ANALYTICS_OPT_IN_OR_OUT_TIMESTAMP, savedAnalyticsOptInOrOutTimestamp)
+            .putLong(KEY_ACCEPT_TERMS_TIMESTAMP, savedAcceptTermsTimestamp)
             .putStringSet(KEY_CURRENT_WEATHER_WIDGET_IDS, widgetIds)
             .apply()
 

--- a/app/src/main/java/com/weatherxm/ui/components/TermsDialogFragment.kt
+++ b/app/src/main/java/com/weatherxm/ui/components/TermsDialogFragment.kt
@@ -1,0 +1,58 @@
+package com.weatherxm.ui.components
+
+import android.app.Dialog
+import android.os.Bundle
+import androidx.fragment.app.DialogFragment
+import androidx.fragment.app.FragmentActivity
+import com.google.android.material.dialog.MaterialAlertDialogBuilder
+import com.weatherxm.R
+import com.weatherxm.databinding.ViewTermsDialogBinding
+import com.weatherxm.ui.common.setHtml
+import me.saket.bettermovementmethod.BetterLinkMovementMethod
+
+class TermsDialogFragment(
+    private val onLinkClicked: (String) -> Unit,
+    private val onClick: () -> Unit
+) : DialogFragment() {
+    private lateinit var binding: ViewTermsDialogBinding
+
+    companion object {
+        const val TAG = "TERMS_DIALOG_FRAGMENT"
+    }
+
+    override fun onCreateDialog(savedInstanceState: Bundle?): Dialog {
+        val builder = MaterialAlertDialogBuilder(requireContext())
+
+        binding = ViewTermsDialogBinding.inflate(layoutInflater)
+        builder.setView(binding.root)
+        builder.setBackgroundInsetStart(0)
+        builder.setBackgroundInsetEnd(0)
+
+        with(binding.message) {
+            movementMethod = BetterLinkMovementMethod.newInstance().apply {
+                setOnLinkClickListener { _, url ->
+                    onLinkClicked(url)
+                    return@setOnLinkClickListener true
+                }
+            }
+            setHtml(
+                R.string.terms_dialog_message,
+                getString(R.string.terms_of_use_owners_url),
+                getString(R.string.privacy_policy_owners_url)
+            )
+        }
+
+        binding.understandBtn.setOnClickListener {
+            onClick.invoke()
+            dismiss()
+        }
+
+        isCancelable = false
+
+        return builder.create()
+    }
+
+    fun show(activity: FragmentActivity) {
+        show(activity.supportFragmentManager, TAG)
+    }
+}

--- a/app/src/main/java/com/weatherxm/ui/devicedetails/DeviceDetailsActivity.kt
+++ b/app/src/main/java/com/weatherxm/ui/devicedetails/DeviceDetailsActivity.kt
@@ -40,6 +40,7 @@ import com.weatherxm.ui.common.updateRequiredChip
 import com.weatherxm.ui.common.visible
 import com.weatherxm.ui.common.warningChip
 import com.weatherxm.ui.components.BaseActivity
+import com.weatherxm.ui.components.TermsDialogFragment
 import com.weatherxm.ui.devicedetails.current.CurrentFragment
 import com.weatherxm.ui.devicedetails.forecast.ForecastFragment
 import com.weatherxm.ui.devicedetails.rewards.RewardsFragment
@@ -138,6 +139,10 @@ class DeviceDetailsActivity : BaseActivity() {
         }.attach()
 
         updateDeviceInfo()
+
+        lifecycleScope.launch {
+            handleTermsDialog()
+        }
     }
 
     override fun onResume() {
@@ -146,6 +151,15 @@ class DeviceDetailsActivity : BaseActivity() {
             analytics.trackScreen(
                 AnalyticsService.Screen.EXPLORER_DEVICE, classSimpleName(), model.device.id
             )
+        }
+    }
+
+    private fun handleTermsDialog() {
+        if (model.shouldShowTermsPrompt()) {
+            TermsDialogFragment(
+                onLinkClicked = { navigator.openWebsite(this, it) },
+                onClick = { model.setAcceptTerms() }
+            ).show(this)
         }
     }
 

--- a/app/src/main/java/com/weatherxm/ui/devicedetails/DeviceDetailsActivity.kt
+++ b/app/src/main/java/com/weatherxm/ui/devicedetails/DeviceDetailsActivity.kt
@@ -125,10 +125,12 @@ class DeviceDetailsActivity : BaseActivity() {
         }
 
         model.onShowLegalTerms().observe(this) {
-            TermsDialogFragment(
-                onLinkClicked = { navigator.openWebsite(this, it) },
-                onClick = { model.setAcceptTerms() }
-            ).show(this)
+            if (it == true) {
+                TermsDialogFragment(
+                    onLinkClicked = { navigator.openWebsite(this, it) },
+                    onClick = { model.setAcceptTerms() }
+                ).show(this)
+            }
         }
 
         val adapter = ViewPagerAdapter(this)

--- a/app/src/main/java/com/weatherxm/ui/devicedetails/DeviceDetailsActivity.kt
+++ b/app/src/main/java/com/weatherxm/ui/devicedetails/DeviceDetailsActivity.kt
@@ -124,6 +124,13 @@ class DeviceDetailsActivity : BaseActivity() {
             updateDeviceInfo(it)
         }
 
+        model.onShowLegalTerms().observe(this) {
+            TermsDialogFragment(
+                onLinkClicked = { navigator.openWebsite(this, it) },
+                onClick = { model.setAcceptTerms() }
+            ).show(this)
+        }
+
         val adapter = ViewPagerAdapter(this)
         binding.viewPager.adapter = adapter
         binding.viewPager.offscreenPageLimit = adapter.itemCount - 1
@@ -139,10 +146,6 @@ class DeviceDetailsActivity : BaseActivity() {
         }.attach()
 
         updateDeviceInfo()
-
-        lifecycleScope.launch {
-            handleTermsDialog()
-        }
     }
 
     override fun onResume() {
@@ -151,15 +154,6 @@ class DeviceDetailsActivity : BaseActivity() {
             analytics.trackScreen(
                 AnalyticsService.Screen.EXPLORER_DEVICE, classSimpleName(), model.device.id
             )
-        }
-    }
-
-    private fun handleTermsDialog() {
-        if (model.shouldShowTermsPrompt()) {
-            TermsDialogFragment(
-                onLinkClicked = { navigator.openWebsite(this, it) },
-                onClick = { model.setAcceptTerms() }
-            ).show(this)
         }
     }
 

--- a/app/src/main/java/com/weatherxm/ui/devicedetails/DeviceDetailsViewModel.kt
+++ b/app/src/main/java/com/weatherxm/ui/devicedetails/DeviceDetailsViewModel.kt
@@ -139,6 +139,9 @@ class DeviceDetailsViewModel(
         onFollowStatus.postValue(Resource.error(errorMessage))
     }
 
+    fun shouldShowTermsPrompt() = deviceDetailsUseCase.shouldShowTermsPrompt()
+    fun setAcceptTerms() = deviceDetailsUseCase.setAcceptTerms()
+
     init {
         viewModelScope.launch(dispatcher) {
             isLoggedIn = authUseCase.isLoggedIn()

--- a/app/src/main/java/com/weatherxm/ui/devicedetails/DeviceDetailsViewModel.kt
+++ b/app/src/main/java/com/weatherxm/ui/devicedetails/DeviceDetailsViewModel.kt
@@ -11,6 +11,7 @@ import com.weatherxm.data.models.ApiError
 import com.weatherxm.data.models.Failure
 import com.weatherxm.ui.common.DeviceRelation
 import com.weatherxm.ui.common.Resource
+import com.weatherxm.ui.common.SingleLiveEvent
 import com.weatherxm.ui.common.UIDevice
 import com.weatherxm.ui.common.empty
 import com.weatherxm.usecases.AuthUseCase
@@ -50,11 +51,13 @@ class DeviceDetailsViewModel(
     private val onDevicePolling = MutableLiveData<UIDevice>()
     private val onUpdatedDevice = MutableLiveData<UIDevice>()
     private val onDeviceFirstFetch = MutableLiveData<UIDevice>()
+    private val onShowLegalTerms = SingleLiveEvent<Boolean>()
 
     fun onDeviceFirstFetch(): LiveData<UIDevice> = onDeviceFirstFetch
     fun onDevicePolling(): LiveData<UIDevice> = onDevicePolling
     fun onUpdatedDevice(): LiveData<UIDevice> = onUpdatedDevice
     fun onFollowStatus(): LiveData<Resource<Unit>> = onFollowStatus
+    fun onShowLegalTerms() = onShowLegalTerms
 
     fun isLoggedIn() = isLoggedIn
 
@@ -139,12 +142,14 @@ class DeviceDetailsViewModel(
         onFollowStatus.postValue(Resource.error(errorMessage))
     }
 
-    fun shouldShowTermsPrompt() = deviceDetailsUseCase.shouldShowTermsPrompt()
     fun setAcceptTerms() = deviceDetailsUseCase.setAcceptTerms()
 
     init {
         viewModelScope.launch(dispatcher) {
             isLoggedIn = authUseCase.isLoggedIn()
+            if (isLoggedIn == true) {
+                onShowLegalTerms.postValue(deviceDetailsUseCase.shouldShowTermsPrompt())
+            }
         }
     }
 }

--- a/app/src/main/java/com/weatherxm/ui/home/HomeActivity.kt
+++ b/app/src/main/java/com/weatherxm/ui/home/HomeActivity.kt
@@ -11,14 +11,15 @@ import androidx.navigation.ui.setupWithNavController
 import com.mapbox.geojson.Point
 import com.weatherxm.R
 import com.weatherxm.data.models.Location
-import com.weatherxm.ui.common.Resource
-import com.weatherxm.ui.common.Status
 import com.weatherxm.databinding.ActivityHomeBinding
 import com.weatherxm.ui.common.Contracts
+import com.weatherxm.ui.common.Resource
+import com.weatherxm.ui.common.Status
 import com.weatherxm.ui.common.parcelable
 import com.weatherxm.ui.common.visible
 import com.weatherxm.ui.components.BaseActivity
 import com.weatherxm.ui.components.BaseMapFragment
+import com.weatherxm.ui.components.TermsDialogFragment
 import com.weatherxm.ui.explorer.ExplorerViewModel
 import com.weatherxm.ui.home.devices.DevicesViewModel
 import dev.chrisbanes.insetter.applyInsetter
@@ -126,6 +127,19 @@ class HomeActivity : BaseActivity(), BaseMapFragment.OnMapDebugInfoListener {
                 )
                 explorerModel.navigateToLocation(it)
             }
+        }
+
+        lifecycleScope.launch {
+            handleTermsDialog()
+        }
+    }
+
+    private fun handleTermsDialog() {
+        if (model.shouldShowTermsPrompt()) {
+            TermsDialogFragment(
+                onLinkClicked = { navigator.openWebsite(this, it) },
+                onClick = { model.setAcceptTerms() }
+            ).show(this)
         }
     }
 

--- a/app/src/main/java/com/weatherxm/ui/home/HomeViewModel.kt
+++ b/app/src/main/java/com/weatherxm/ui/home/HomeViewModel.kt
@@ -16,6 +16,7 @@ import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 
+@Suppress("TooManyFunctions")
 class HomeViewModel(
     private val userUseCase: UserUseCase,
     private val remoteBannersUseCase: RemoteBannersUseCase,
@@ -101,4 +102,7 @@ class HomeViewModel(
     fun dismissInfoBanner(infoBannerId: String) {
         remoteBannersUseCase.dismissInfoBanner(infoBannerId)
     }
+
+    fun shouldShowTermsPrompt() = userUseCase.shouldShowTermsPrompt()
+    fun setAcceptTerms() = userUseCase.setAcceptTerms()
 }

--- a/app/src/main/java/com/weatherxm/ui/preferences/PreferenceFragment.kt
+++ b/app/src/main/java/com/weatherxm/ui/preferences/PreferenceFragment.kt
@@ -54,6 +54,8 @@ class PreferenceFragment : PreferenceFragmentCompat() {
         val resetPassBtn: Preference? = findPreference(getString(R.string.change_password))
         val deleteAccountButton: Preference? = findPreference(getString(R.string.delete_account))
         val appVersionPref: Preference? = findPreference(getString(R.string.title_app_version))
+        val openTermsOfUse: Preference? = findPreference(getString(R.string.terms_of_use))
+        val openPrivacyPolicy: Preference? = findPreference(getString(R.string.privacy_policy))
 
         /*
          * Disable switching of notifications toggle as we prompt user to do it via the settings
@@ -86,6 +88,17 @@ class PreferenceFragment : PreferenceFragmentCompat() {
             displayModeHelper.setDisplayMode(newValue.toString())
             true
         }
+        openTermsOfUse?.onPreferenceClickListener = Preference.OnPreferenceClickListener {
+            analytics.trackEventSelectContent(AnalyticsService.ParamValue.DOCUMENTATION.paramValue)
+            navigator.openWebsite(context, getString(R.string.terms_of_use_owners_url))
+            true
+        }
+        openPrivacyPolicy?.onPreferenceClickListener = Preference.OnPreferenceClickListener {
+            analytics.trackEventSelectContent(AnalyticsService.ParamValue.DOCUMENTATION.paramValue)
+            navigator.openWebsite(context, getString(R.string.privacy_policy_owners_url))
+            true
+        }
+
         /**
          * If `installationId` is available, append it at the end of the app version
          */

--- a/app/src/main/java/com/weatherxm/ui/preferences/PreferenceFragment.kt
+++ b/app/src/main/java/com/weatherxm/ui/preferences/PreferenceFragment.kt
@@ -89,12 +89,12 @@ class PreferenceFragment : PreferenceFragmentCompat() {
             true
         }
         openTermsOfUse?.onPreferenceClickListener = Preference.OnPreferenceClickListener {
-            analytics.trackEventSelectContent(AnalyticsService.ParamValue.DOCUMENTATION.paramValue)
+            analytics.trackEventSelectContent(AnalyticsService.ParamValue.TERMS_OF_USE.paramValue)
             navigator.openWebsite(context, getString(R.string.terms_of_use_owners_url))
             true
         }
         openPrivacyPolicy?.onPreferenceClickListener = Preference.OnPreferenceClickListener {
-            analytics.trackEventSelectContent(AnalyticsService.ParamValue.DOCUMENTATION.paramValue)
+            analytics.trackEventSelectContent(AnalyticsService.ParamValue.PRIVACY_POLICY.paramValue)
             navigator.openWebsite(context, getString(R.string.privacy_policy_owners_url))
             true
         }

--- a/app/src/main/java/com/weatherxm/ui/preferences/PreferenceFragment.kt
+++ b/app/src/main/java/com/weatherxm/ui/preferences/PreferenceFragment.kt
@@ -7,6 +7,7 @@ import android.os.Bundle
 import androidx.core.app.NotificationManagerCompat
 import androidx.preference.ListPreference
 import androidx.preference.Preference
+import androidx.preference.PreferenceCategory
 import androidx.preference.PreferenceFragmentCompat
 import androidx.preference.SwitchPreferenceCompat
 import com.weatherxm.R
@@ -54,8 +55,6 @@ class PreferenceFragment : PreferenceFragmentCompat() {
         val resetPassBtn: Preference? = findPreference(getString(R.string.change_password))
         val deleteAccountButton: Preference? = findPreference(getString(R.string.delete_account))
         val appVersionPref: Preference? = findPreference(getString(R.string.title_app_version))
-        val openTermsOfUse: Preference? = findPreference(getString(R.string.terms_of_use))
-        val openPrivacyPolicy: Preference? = findPreference(getString(R.string.privacy_policy))
 
         /*
          * Disable switching of notifications toggle as we prompt user to do it via the settings
@@ -88,16 +87,6 @@ class PreferenceFragment : PreferenceFragmentCompat() {
             displayModeHelper.setDisplayMode(newValue.toString())
             true
         }
-        openTermsOfUse?.onPreferenceClickListener = Preference.OnPreferenceClickListener {
-            analytics.trackEventSelectContent(AnalyticsService.ParamValue.TERMS_OF_USE.paramValue)
-            navigator.openWebsite(context, getString(R.string.terms_of_use_owners_url))
-            true
-        }
-        openPrivacyPolicy?.onPreferenceClickListener = Preference.OnPreferenceClickListener {
-            analytics.trackEventSelectContent(AnalyticsService.ParamValue.PRIVACY_POLICY.paramValue)
-            navigator.openWebsite(context, getString(R.string.privacy_policy_owners_url))
-            true
-        }
 
         /**
          * If `installationId` is available, append it at the end of the app version
@@ -115,16 +104,12 @@ class PreferenceFragment : PreferenceFragmentCompat() {
         }
     }
 
-    private fun onLoggedOut(
-        logoutBtn: Preference?,
-        resetPassBtn: Preference?,
-        deleteAccountButton: Preference?,
-        analyticsPreference: SwitchPreferenceCompat?
-    ) {
-        logoutBtn?.isVisible = false
-        resetPassBtn?.isVisible = false
-        deleteAccountButton?.isVisible = false
-        analyticsPreference?.isVisible = false
+    private fun onLoggedOut(vararg preferences: Preference?) {
+        val legalCategory: PreferenceCategory? = findPreference(getString(R.string.legal))
+        legalCategory?.isVisible = false
+        preferences.forEach {
+            it?.isVisible = false
+        }
     }
 
     private fun onLoggedIn(
@@ -147,6 +132,19 @@ class PreferenceFragment : PreferenceFragmentCompat() {
         }
         deleteAccountButton?.onPreferenceClickListener = Preference.OnPreferenceClickListener {
             navigator.showDeleteAccount(this)
+            true
+        }
+
+        val openTermsOfUse: Preference? = findPreference(getString(R.string.terms_of_use))
+        val openPrivacyPolicy: Preference? = findPreference(getString(R.string.privacy_policy))
+        openTermsOfUse?.onPreferenceClickListener = Preference.OnPreferenceClickListener {
+            analytics.trackEventSelectContent(AnalyticsService.ParamValue.TERMS_OF_USE.paramValue)
+            navigator.openWebsite(context, getString(R.string.terms_of_use_owners_url))
+            true
+        }
+        openPrivacyPolicy?.onPreferenceClickListener = Preference.OnPreferenceClickListener {
+            analytics.trackEventSelectContent(AnalyticsService.ParamValue.PRIVACY_POLICY.paramValue)
+            navigator.openWebsite(context, getString(R.string.privacy_policy_owners_url))
             true
         }
     }

--- a/app/src/main/java/com/weatherxm/ui/signup/SignupActivity.kt
+++ b/app/src/main/java/com/weatherxm/ui/signup/SignupActivity.kt
@@ -4,16 +4,18 @@ import android.os.Bundle
 import com.google.firebase.analytics.FirebaseAnalytics
 import com.weatherxm.R
 import com.weatherxm.analytics.AnalyticsService
+import com.weatherxm.databinding.ActivitySignupBinding
 import com.weatherxm.ui.common.Resource
 import com.weatherxm.ui.common.Status
-import com.weatherxm.databinding.ActivitySignupBinding
 import com.weatherxm.ui.common.classSimpleName
 import com.weatherxm.ui.common.hideKeyboard
-import com.weatherxm.ui.common.onTextChanged
 import com.weatherxm.ui.common.invisible
+import com.weatherxm.ui.common.onTextChanged
+import com.weatherxm.ui.common.setHtml
 import com.weatherxm.ui.common.visible
 import com.weatherxm.ui.components.BaseActivity
 import com.weatherxm.util.Validator
+import me.saket.bettermovementmethod.BetterLinkMovementMethod
 import org.koin.androidx.viewmodel.ext.android.viewModel
 import timber.log.Timber
 
@@ -30,9 +32,28 @@ class SignupActivity : BaseActivity() {
             onBackPressedDispatcher.onBackPressed()
         }
 
+        with(binding.termsCheckboxDesc) {
+            movementMethod = BetterLinkMovementMethod.newInstance().apply {
+                setOnLinkClickListener { _, url ->
+                    navigator.openWebsite(this@SignupActivity, url)
+                    return@setOnLinkClickListener true
+                }
+            }
+            setHtml(
+                R.string.registration_terms_privacy_policy,
+                getString(R.string.terms_of_use_owners_url),
+                getString(R.string.privacy_policy_owners_url)
+            )
+        }
+
         binding.username.onTextChanged {
             binding.usernameContainer.error = null
-            binding.signup.isEnabled = !binding.username.text.isNullOrEmpty()
+            binding.signup.isEnabled =
+                !binding.username.text.isNullOrEmpty() && binding.termsCheckbox.isChecked
+        }
+
+        binding.termsCheckbox.setOnCheckedChangeListener { _, isChecked ->
+            binding.signup.isEnabled = !binding.username.text.isNullOrEmpty() && isChecked
         }
 
         binding.done.setOnClickListener {

--- a/app/src/main/java/com/weatherxm/usecases/DeviceDetailsUseCase.kt
+++ b/app/src/main/java/com/weatherxm/usecases/DeviceDetailsUseCase.kt
@@ -9,4 +9,6 @@ interface DeviceDetailsUseCase {
     suspend fun getDevice(device: UIDevice): Either<Failure, UIDevice>
     suspend fun getRewards(deviceId: String): Either<Failure, Rewards>
     suspend fun getUserDevice(deviceId: String): Either<Failure, UIDevice>
+    fun setAcceptTerms()
+    fun shouldShowTermsPrompt(): Boolean
 }

--- a/app/src/main/java/com/weatherxm/usecases/DeviceDetailsUseCaseImpl.kt
+++ b/app/src/main/java/com/weatherxm/usecases/DeviceDetailsUseCaseImpl.kt
@@ -7,6 +7,7 @@ import com.weatherxm.data.repository.DeviceOTARepository
 import com.weatherxm.data.repository.DeviceRepository
 import com.weatherxm.data.repository.ExplorerRepository
 import com.weatherxm.data.repository.RewardsRepository
+import com.weatherxm.data.repository.UserPreferencesRepository
 import com.weatherxm.ui.common.DeviceAlert
 import com.weatherxm.ui.common.DeviceAlertType
 import com.weatherxm.ui.common.DeviceRelation
@@ -17,7 +18,8 @@ class DeviceDetailsUseCaseImpl(
     private val deviceRepository: DeviceRepository,
     private val rewardsRepository: RewardsRepository,
     private val explorerRepository: ExplorerRepository,
-    private val deviceOTARepo: DeviceOTARepository
+    private val deviceOTARepo: DeviceOTARepository,
+    private val userPreferencesRepository: UserPreferencesRepository
 ) : DeviceDetailsUseCase {
 
     override suspend fun getDevice(device: UIDevice): Either<Failure, UIDevice> {
@@ -46,4 +48,7 @@ class DeviceDetailsUseCaseImpl(
     override suspend fun getRewards(deviceId: String): Either<Failure, Rewards> {
         return rewardsRepository.getRewards(deviceId)
     }
+
+    override fun shouldShowTermsPrompt() = userPreferencesRepository.shouldShowTermsPrompt()
+    override fun setAcceptTerms() = userPreferencesRepository.setAcceptTerms()
 }

--- a/app/src/main/java/com/weatherxm/usecases/UserUseCase.kt
+++ b/app/src/main/java/com/weatherxm/usecases/UserUseCase.kt
@@ -20,6 +20,8 @@ interface UserUseCase {
     suspend fun getWalletRewards(walletAddress: String?): Either<Failure, UIWalletRewards>
     fun getUserId(): String
     fun shouldShowAnalyticsOptIn(): Boolean
+    fun setAcceptTerms()
+    fun shouldShowTermsPrompt(): Boolean
 }
 
 class UserUseCaseImpl(
@@ -79,4 +81,7 @@ class UserUseCaseImpl(
     override fun shouldShowAnalyticsOptIn(): Boolean {
         return userPreferencesRepository.shouldShowAnalyticsOptIn()
     }
+
+    override fun shouldShowTermsPrompt() = userPreferencesRepository.shouldShowTermsPrompt()
+    override fun setAcceptTerms() = userPreferencesRepository.setAcceptTerms()
 }

--- a/app/src/main/res/layout/activity_signup.xml
+++ b/app/src/main/res/layout/activity_signup.xml
@@ -113,6 +113,28 @@
 
             </com.google.android.material.textfield.TextInputLayout>
 
+            <LinearLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginBottom="@dimen/margin_large"
+                android:gravity="center_vertical"
+                android:orientation="horizontal"
+                app:layout_constraintBottom_toTopOf="@id/signup">
+
+                <com.google.android.material.materialswitch.MaterialSwitch
+                    android:id="@+id/termsCheckbox"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content" />
+
+                <com.google.android.material.textview.MaterialTextView
+                    android:id="@+id/termsCheckboxDesc"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginStart="@dimen/margin_small"
+                    android:text="@string/registration_terms_privacy_policy" />
+
+            </LinearLayout>
+
             <com.google.android.material.button.MaterialButton
                 android:id="@+id/signup"
                 android:layout_width="match_parent"

--- a/app/src/main/res/layout/view_terms_dialog.xml
+++ b/app/src/main/res/layout/view_terms_dialog.xml
@@ -1,0 +1,40 @@
+<com.google.android.material.card.MaterialCardView xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content">
+
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content">
+
+        <com.google.android.material.textview.MaterialTextView
+            android:id="@+id/title"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:text="@string/terms_dialog_title"
+            android:textAppearance="@style/TextAppearance.WeatherXM.Default.HeadlineSmall.SansSerifMedium"
+            android:textColor="@color/darkestBlue"
+            app:layout_constraintTop_toTopOf="parent" />
+
+        <com.google.android.material.textview.MaterialTextView
+            android:id="@+id/message"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="@dimen/margin_normal"
+            android:textAppearance="@style/TextAppearance.WeatherXM.Default.BodyLarge"
+            app:layout_constraintTop_toBottomOf="@id/title"
+            tools:text="@string/terms_dialog_message" />
+
+        <com.google.android.material.button.MaterialButton
+            android:id="@+id/understandBtn"
+            style="@style/Widget.WeatherXM.Button"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="@dimen/margin_normal_to_large"
+            android:text="@string/action_i_understand"
+            app:layout_constraintTop_toBottomOf="@id/message" />
+
+    </androidx.constraintlayout.widget.ConstraintLayout>
+
+</com.google.android.material.card.MaterialCardView>

--- a/app/src/main/res/values/company_info.xml
+++ b/app/src/main/res/values/company_info.xml
@@ -27,4 +27,6 @@
     <string name="share_cell_url">https://explorer.weatherxm.com/cells/%s</string>
     <string name="share_station_url">https://explorer.weatherxm.com/stations/%s</string>
     <string name="weatherxm_claim_redirect_url">weatherxm://token-claim</string>
+    <string name="terms_of_use_owners_url">https://docs.google.com/document/d/1-Ee_5VPlVmvutISvQzc8A5Ws-o_eJv-U/edit</string>
+    <string name="privacy_policy_owners_url">https://docs.google.com/document/d/1-D80sV70S8dybsrvB0QX7np7D7n8t8-M/edit</string>
 </resources>

--- a/app/src/main/res/values/preferences.xml
+++ b/app/src/main/res/values/preferences.xml
@@ -64,6 +64,13 @@
     <string name="announcements_title">Announcements</string>
     <string name="announcements_desc">Visit our announcements portal to get up to date with WeatherXM.</string>
 
+    <!-- Legal -->
+    <string name="legal">Legal</string>
+    <string name="terms_of_use">Terms of Use</string>
+    <string name="terms_of_use_read">Read about our terms and conditions.</string>
+    <string name="privacy_policy">Privacy Policy</string>
+    <string name="privacy_policy_read">Read about our privacy standards.</string>
+
     <!-- About -->
     <string name="about">About</string>
     <string name="title_app_version">App Version</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -242,6 +242,7 @@
     <string name="signup_instructions">Signup with your email and your account will be created shortly.</string>
     <string name="success_signup_text">Thanks for joining WeatherXM! We have sent you an account activation link to %s. Please, set a password and then try to login.</string>
     <string name="info_registration_contact_support">Not receiving an activation email? Contact our support team.</string>
+    <string name="registration_terms_privacy_policy"><![CDATA[I have read and accept the <a href="%1$s">Terms of Use</a> and <a href="%2$s">Privacy Policy</a>.]]></string>
 
     <!-- Rewards -->
     <string name="title_reward_timeline">Reward Timeline</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -30,6 +30,7 @@
     <string name="action_view_all_issues">View All Issues</string>
     <string name="action_open">Open</string>
     <string name="action_done">Done</string>
+    <string name="action_i_understand">I understand</string>
     <string name="yes">Yes</string>
     <string name="no">No</string>
     <string name="action_scan_qr">Scan QR Code</string>
@@ -626,4 +627,8 @@
     <string name="station_health_data_quality_explanation"><![CDATA[The network’s effectiveness relies on meaningful, usable data, measured by the Quality-of-Data (QoD) score, which <b>updates daily</b>. This score motivates weather station owners to follow guidelines for optimal data quality. A station’s daily reward is tied to its QoD, calculated using an open-source algorithm that assesses data quality and provides a confidence level in the data received.]]></string>
     <string name="station_health_location_quality_explanation"><![CDATA[It is crucial for the Network that a station stays in the same location throughout its lifetime.<br>The Proof-of-Location algorithm, which also <b>updates daily</b>, assesses the accuracy and consistency of the station’s location data, generating a confidence score for its position.]]></string>
     <string name="station_has_started_transmitting_data">Your station has started transmitting its initial data. Sit back and relax, your rewards are on the way!</string>
+
+    <!-- Terms Dialog -->
+    <string name="terms_dialog_title">About our legal terms</string>
+    <string name="terms_dialog_message"><![CDATA[We’ve implemented the new <a href="%1$s">Terms of Use</a> and <a href="%2$s">Privacy Policy</a> to better serve you and ensure alignment with best practices and applicable laws. By continuing to use the app for the next 30 days, it is considered that you accept the new terms and privacy policy mentioned above.<br><br>By accepting these Terms of Use and Privacy Policy, you agree that they apply to all prior and future interactions with the app.]]></string>
 </resources>

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -131,6 +131,7 @@
 
     <PreferenceCategory
         app:iconSpaceReserved="false"
+        app:key="@string/legal"
         app:title="@string/legal">
         <Preference
             app:iconSpaceReserved="false"

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -131,6 +131,21 @@
 
     <PreferenceCategory
         app:iconSpaceReserved="false"
+        app:title="@string/legal">
+        <Preference
+            app:iconSpaceReserved="false"
+            app:key="@string/terms_of_use"
+            app:summary="@string/terms_of_use_read"
+            app:title="@string/terms_of_use" />
+        <Preference
+            app:iconSpaceReserved="false"
+            app:key="@string/privacy_policy"
+            app:summary="@string/privacy_policy_read"
+            app:title="@string/privacy_policy" />
+    </PreferenceCategory>
+
+    <PreferenceCategory
+        app:iconSpaceReserved="false"
         app:title="@string/about">
         <Preference
             app:enableCopying="true"

--- a/app/src/test/java/com/weatherxm/data/datasource/UserPreferenceDataSourceTest.kt
+++ b/app/src/test/java/com/weatherxm/data/datasource/UserPreferenceDataSourceTest.kt
@@ -8,6 +8,7 @@ import io.kotest.core.spec.style.BehaviorSpec
 import io.kotest.matchers.shouldBe
 import io.mockk.coJustRun
 import io.mockk.every
+import io.mockk.justRun
 import io.mockk.verify
 
 class UserPreferenceDataSourceTest : BehaviorSpec({
@@ -24,16 +25,34 @@ class UserPreferenceDataSourceTest : BehaviorSpec({
         every { cacheService.getWalletWarningDismissTimestamp() } returns timestamp
         every { cacheService.getAnalyticsDecisionTimestamp() } returns timestamp
         every { cacheService.getDevicesSortFilterOptions() } returns filters
+        every { cacheService.getAcceptTermsTimestamp() } returns timestamp
         coJustRun { cacheService.setAnalyticsEnabled(enabled) }
         coJustRun { cacheService.setAnalyticsDecisionTimestamp(any()) }
         coJustRun { cacheService.setWalletWarningDismissTimestamp(any()) }
         coJustRun { cacheService.setDevicesSortFilterOptions(sortOrder, filter, groupBy) }
+        justRun { cacheService.setAcceptTermsTimestamp(any()) }
     }
 
     context("Get analytics opt-in or opt-out timestamp") {
         When("Using the Cache Source") {
             then("return the timestamp") {
                 datasource.getAnalyticsDecisionTimestamp() shouldBe timestamp
+            }
+        }
+    }
+
+    context("GET / SET accept terms timestamp") {
+        When("Using the Cache Source") {
+            and("GET the timestamp") {
+                then("return the timestamp") {
+                    datasource.getAcceptTermsTimestamp() shouldBe timestamp
+                }
+            }
+            and("SET the timestamp") {
+                datasource.setAcceptTerms()
+                then("set the timestamp in cache") {
+                    verify(exactly = 1) { cacheService.setAcceptTermsTimestamp(any()) }
+                }
             }
         }
     }

--- a/app/src/test/java/com/weatherxm/data/repository/AuthRepositoryTest.kt
+++ b/app/src/test/java/com/weatherxm/data/repository/AuthRepositoryTest.kt
@@ -19,6 +19,7 @@ import io.mockk.coVerify
 import io.mockk.every
 import io.mockk.justRun
 import io.mockk.mockk
+import io.mockk.verify
 
 class AuthRepositoryTest : BehaviorSpec({
     lateinit var networkAuthDataSource: NetworkAuthDataSource
@@ -55,6 +56,7 @@ class AuthRepositoryTest : BehaviorSpec({
         coJustRun { databaseExplorerDataSource.deleteAll() }
         coJustRun { networkAuthDataSource.logout(authToken.access, installationId) }
         justRun { cacheService.clearAll() }
+        justRun { cacheService.setAcceptTermsTimestamp(any()) }
         coMockEitherRight({ cacheUserDataSource.getUserUsername() }, email)
     }
 
@@ -147,6 +149,9 @@ class AuthRepositoryTest : BehaviorSpec({
                 )
                 then("return that Unit indicating the success") {
                     authRepository.signup(email, firstName, lastName).isSuccess(Unit)
+                }
+                then("verify that setting the acceptance of terms has taken place") {
+                    verify(exactly = 1) { cacheService.setAcceptTermsTimestamp(any()) }
                 }
             }
             When("signup failed") {

--- a/app/src/test/java/com/weatherxm/data/repository/AuthRepositoryTest.kt
+++ b/app/src/test/java/com/weatherxm/data/repository/AuthRepositoryTest.kt
@@ -151,7 +151,7 @@ class AuthRepositoryTest : BehaviorSpec({
                     authRepository.signup(email, firstName, lastName).isSuccess(Unit)
                 }
                 then("verify that setting the acceptance of terms has taken place") {
-                    verify(exactly = 1) { cacheService.setAcceptTermsTimestamp(any()) }
+                    verify { cacheService.setAcceptTermsTimestamp(any()) }
                 }
             }
             When("signup failed") {

--- a/app/src/test/java/com/weatherxm/data/repository/UserPreferencesRepositoryTest.kt
+++ b/app/src/test/java/com/weatherxm/data/repository/UserPreferencesRepositoryTest.kt
@@ -22,6 +22,7 @@ class UserPreferencesRepositoryTest : BehaviorSpec({
         justRun { dataSource.setWalletWarningDismissTimestamp() }
         every { dataSource.getWalletWarningDismissTimestamp() } returns 0
         justRun { dataSource.setDevicesSortFilterOptions(sort, filter, group) }
+        justRun { dataSource.setAcceptTerms() }
         every { dataSource.getDevicesSortFilterOptions() } returns sortFilterGroupOptions
     }
 
@@ -79,6 +80,30 @@ class UserPreferencesRepositoryTest : BehaviorSpec({
             then("set them") {
                 repo.setDevicesSortFilterOptions(sort, filter, group)
                 verify(exactly = 1) { dataSource.setDevicesSortFilterOptions(sort, filter, group) }
+            }
+        }
+    }
+
+    context("Get if we should show the terms prompt") {
+        When("we should show it") {
+            every { dataSource.getAcceptTermsTimestamp() } returns 0
+            then("return true") {
+                repo.shouldShowTermsPrompt() shouldBe true
+            }
+        }
+        When("we should NOT show it") {
+            every { dataSource.getAcceptTermsTimestamp() } returns 1
+            then("return false") {
+                repo.shouldShowTermsPrompt() shouldBe false
+            }
+        }
+    }
+
+    context("SET accept terms timestamp") {
+        When("Using the Cache Source") {
+            repo.setAcceptTerms()
+            then("set the timestamp in cache") {
+                verify(exactly = 1) { dataSource.setAcceptTerms() }
             }
         }
     }

--- a/app/src/test/java/com/weatherxm/data/services/PrefsSingleVarTest.kt
+++ b/app/src/test/java/com/weatherxm/data/services/PrefsSingleVarTest.kt
@@ -2,6 +2,7 @@ package com.weatherxm.data.services
 
 import android.content.SharedPreferences
 import com.weatherxm.TestConfig.sharedPref
+import com.weatherxm.data.services.CacheService.Companion.KEY_ACCEPT_TERMS_TIMESTAMP
 import com.weatherxm.data.services.CacheService.Companion.KEY_ANALYTICS_OPT_IN_OR_OUT_TIMESTAMP
 import com.weatherxm.data.services.CacheService.Companion.KEY_DISMISSED_INFO_BANNER_ID
 import com.weatherxm.data.services.CacheService.Companion.KEY_DISMISSED_SURVEY_ID
@@ -64,6 +65,15 @@ class PrefsSingleVarTest(
             { prefEditor.putLong(KEY_ANALYTICS_OPT_IN_OR_OUT_TIMESTAMP, timestamp) },
             { cacheService.getAnalyticsDecisionTimestamp() },
             { cacheService.setAnalyticsDecisionTimestamp(timestamp) }
+        )
+
+        behaviorSpec.testGetSetSingleVar(
+            "Accept Terms Timestamp",
+            timestamp,
+            { sharedPref.getLong(KEY_ACCEPT_TERMS_TIMESTAMP, 0) },
+            { prefEditor.putLong(KEY_ACCEPT_TERMS_TIMESTAMP, timestamp) },
+            { cacheService.getAcceptTermsTimestamp() },
+            { cacheService.setAcceptTermsTimestamp(timestamp) }
         )
 
         behaviorSpec.testGetSetSingleVar(

--- a/app/src/test/java/com/weatherxm/ui/devicedetails/DeviceDetailsViewModelTest.kt
+++ b/app/src/test/java/com/weatherxm/ui/devicedetails/DeviceDetailsViewModelTest.kt
@@ -133,6 +133,9 @@ class DeviceDetailsViewModelTest : BehaviorSpec({
                     runTest { viewModel.isLoggedIn() }
                     viewModel.isLoggedIn() shouldBe true
                 }
+                then("get if we should show a failure or not") {
+                    viewModel.onShowLegalTerms().value shouldBe true
+                }
             }
         }
     }
@@ -379,14 +382,6 @@ class DeviceDetailsViewModelTest : BehaviorSpec({
                         }
                     }
                 }
-            }
-        }
-    }
-
-    context("Get if we should show the terms prompt or not") {
-        given("A use case returning the result") {
-            then("return that result") {
-                viewModel.shouldShowTermsPrompt() shouldBe true
             }
         }
     }

--- a/app/src/test/java/com/weatherxm/ui/devicedetails/DeviceDetailsViewModelTest.kt
+++ b/app/src/test/java/com/weatherxm/ui/devicedetails/DeviceDetailsViewModelTest.kt
@@ -111,6 +111,8 @@ class DeviceDetailsViewModelTest : BehaviorSpec({
         }
         every { authUseCase.isLoggedIn() } returns true
         every { resources.getString(R.string.error_max_followed) } returns maxFollowedMsg
+        justRun { deviceDetailsUseCase.setAcceptTerms() }
+        every { deviceDetailsUseCase.shouldShowTermsPrompt() } returns true
 
         viewModel = DeviceDetailsViewModel(
             emptyDevice,
@@ -377,6 +379,23 @@ class DeviceDetailsViewModelTest : BehaviorSpec({
                         }
                     }
                 }
+            }
+        }
+    }
+
+    context("Get if we should show the terms prompt or not") {
+        given("A use case returning the result") {
+            then("return that result") {
+                viewModel.shouldShowTermsPrompt() shouldBe true
+            }
+        }
+    }
+
+    context("Set the Accept Terms") {
+        given("the call to the respective function") {
+            viewModel.setAcceptTerms()
+            then("the respective function in the usecase should be called") {
+                verify(exactly = 1) { deviceDetailsUseCase.setAcceptTerms() }
             }
         }
     }

--- a/app/src/test/java/com/weatherxm/ui/home/HomeViewModelTest.kt
+++ b/app/src/test/java/com/weatherxm/ui/home/HomeViewModelTest.kt
@@ -40,7 +40,9 @@ class HomeViewModelTest : BehaviorSpec({
     beforeSpec {
         justRun { analytics.trackEventFailure(any()) }
         justRun { userUseCase.setWalletWarningDismissTimestamp() }
+        justRun { userUseCase.setAcceptTerms() }
         every { userUseCase.shouldShowWalletMissingWarning(emptyWalletAddress) } returns true
+        every { userUseCase.shouldShowTermsPrompt() } returns true
         every { remoteBannersUseCase.getSurvey() } returns survey
         justRun { remoteBannersUseCase.dismissSurvey(surveyId) }
         every { remoteBannersUseCase.getInfoBanner() } returns infoBanner
@@ -144,6 +146,23 @@ class HomeViewModelTest : BehaviorSpec({
                 then("the respective function in the usecase should be called") {
                     verify(exactly = 1) { remoteBannersUseCase.dismissInfoBanner(infoBannerId) }
                 }
+            }
+        }
+    }
+
+    context("Get if we should show the terms prompt or not") {
+        given("A use case returning the result") {
+            then("return that result") {
+                viewModel.shouldShowTermsPrompt() shouldBe true
+            }
+        }
+    }
+
+    context("Set the Accept Terms") {
+        given("the call to the respective function") {
+            viewModel.setAcceptTerms()
+            then("the respective function in the usecase should be called") {
+                verify(exactly = 1) { userUseCase.setAcceptTerms() }
             }
         }
     }

--- a/app/src/test/java/com/weatherxm/usecases/AuthUseCaseTest.kt
+++ b/app/src/test/java/com/weatherxm/usecases/AuthUseCaseTest.kt
@@ -8,17 +8,20 @@ import com.weatherxm.TestUtils.isSuccess
 import com.weatherxm.data.network.AuthToken
 import com.weatherxm.data.repository.AuthRepository
 import com.weatherxm.data.repository.NotificationsRepository
+import com.weatherxm.data.repository.UserPreferencesRepository
 import io.kotest.core.spec.style.BehaviorSpec
 import io.kotest.matchers.shouldBe
 import io.mockk.coJustRun
 import io.mockk.coVerify
 import io.mockk.every
 import io.mockk.mockk
+import io.mockk.verify
 
 class AuthUseCaseTest : BehaviorSpec({
     val authRepository = mockk<AuthRepository>()
     val notificationsRepository = mockk<NotificationsRepository>()
-    val usecase = AuthUseCaseImpl(authRepository, notificationsRepository)
+    val userPreferenceRepo = mockk<UserPreferencesRepository>()
+    val usecase = AuthUseCaseImpl(authRepository, userPreferenceRepo, notificationsRepository)
 
     val username = "username"
     val password = "password"
@@ -29,6 +32,7 @@ class AuthUseCaseTest : BehaviorSpec({
     beforeSpec {
         coJustRun { notificationsRepository.setFcmToken() }
         coJustRun { authRepository.logout() }
+        coJustRun { userPreferenceRepo.setAcceptTerms() }
     }
 
     context("Get if a user is logged in or not") {
@@ -60,6 +64,9 @@ class AuthUseCaseTest : BehaviorSpec({
                 coMockEitherRight({ authRepository.signup(username, firstName, lastName) }, Unit)
                 then("return the username") {
                     usecase.signup(username, firstName, lastName).isSuccess(username)
+                }
+                then("verify that the setting the acceptance of terms has taken place") {
+                    verify(exactly = 1) { userPreferenceRepo.setAcceptTerms() }
                 }
             }
         }

--- a/app/src/test/java/com/weatherxm/usecases/AuthUseCaseTest.kt
+++ b/app/src/test/java/com/weatherxm/usecases/AuthUseCaseTest.kt
@@ -8,20 +8,17 @@ import com.weatherxm.TestUtils.isSuccess
 import com.weatherxm.data.network.AuthToken
 import com.weatherxm.data.repository.AuthRepository
 import com.weatherxm.data.repository.NotificationsRepository
-import com.weatherxm.data.repository.UserPreferencesRepository
 import io.kotest.core.spec.style.BehaviorSpec
 import io.kotest.matchers.shouldBe
 import io.mockk.coJustRun
 import io.mockk.coVerify
 import io.mockk.every
 import io.mockk.mockk
-import io.mockk.verify
 
 class AuthUseCaseTest : BehaviorSpec({
     val authRepository = mockk<AuthRepository>()
     val notificationsRepository = mockk<NotificationsRepository>()
-    val userPreferenceRepo = mockk<UserPreferencesRepository>()
-    val usecase = AuthUseCaseImpl(authRepository, userPreferenceRepo, notificationsRepository)
+    val usecase = AuthUseCaseImpl(authRepository, notificationsRepository)
 
     val username = "username"
     val password = "password"
@@ -32,7 +29,6 @@ class AuthUseCaseTest : BehaviorSpec({
     beforeSpec {
         coJustRun { notificationsRepository.setFcmToken() }
         coJustRun { authRepository.logout() }
-        coJustRun { userPreferenceRepo.setAcceptTerms() }
     }
 
     context("Get if a user is logged in or not") {
@@ -64,9 +60,6 @@ class AuthUseCaseTest : BehaviorSpec({
                 coMockEitherRight({ authRepository.signup(username, firstName, lastName) }, Unit)
                 then("return the username") {
                     usecase.signup(username, firstName, lastName).isSuccess(username)
-                }
-                then("verify that the setting the acceptance of terms has taken place") {
-                    verify(exactly = 1) { userPreferenceRepo.setAcceptTerms() }
                 }
             }
         }

--- a/app/src/test/java/com/weatherxm/usecases/UserUseCaseTest.kt
+++ b/app/src/test/java/com/weatherxm/usecases/UserUseCaseTest.kt
@@ -44,7 +44,9 @@ class UserUseCaseTest : BehaviorSpec({
 
     beforeSpec {
         justRun { userPreferencesRepository.setWalletWarningDismissTimestamp() }
+        justRun { userPreferencesRepository.setAcceptTerms() }
         every { userPreferencesRepository.shouldShowAnalyticsOptIn() } returns true
+        every { userPreferencesRepository.shouldShowTermsPrompt() } returns true
     }
 
     context("Get the Wallet Address") {
@@ -200,6 +202,23 @@ class UserUseCaseTest : BehaviorSpec({
                         usecase.getWalletRewards(walletAddress).isError()
                     }
                 }
+            }
+        }
+    }
+
+    context("Get if we should show the terms prompt or not") {
+        given("The repository which returns the answer") {
+            then("return the answer") {
+                usecase.shouldShowTermsPrompt() shouldBe true
+            }
+        }
+    }
+
+    context("Set the Accept Terms") {
+        given("A repository providing the SET functionality") {
+            usecase.setAcceptTerms()
+            then("make the respective call") {
+                verify(exactly = 1) { userPreferencesRepository.setAcceptTerms() }
             }
         }
     }


### PR DESCRIPTION
### **Why?**
Integrate the new legal terms as per the spec.

### **How?**
- Created `TermsDialogFragment` which is the terms prompt that is shown in `HomeActivity` and `DeviceDetailsActivity`.
- Created the functions `shouldShowTermsPrompt` and `setAcceptTerms` which get and set the respective values from the cache to the respective activities all the way down with the correct flow.
- Fixed the unit tests to include those 2 functions in all steps.

### **Testing**
Ensure that settings, the registration screen and the 2 dialogs (home screen + device details through widget) work OK.

In order for the device details to test it:
1. Install the app
2. Login
3. Close the app without dismissing the prompt
4. Add a widget
5. Open a widget to get into the device details

### **Additional context**

Closes FE-1571 FE-1570 FE-1555
