### PR TITLE
Fix bug on scrolling & bottom navigation in profile hiding elements

### DIFF
--- a/app/src/main/java/com/weatherxm/ui/home/HomeActivity.kt
+++ b/app/src/main/java/com/weatherxm/ui/home/HomeActivity.kt
@@ -69,7 +69,7 @@ class HomeActivity : BaseActivity(), BaseMapFragment.OnMapDebugInfoListener {
             }
         }
 
-        devicesViewModel.showOverlayViews().observe(this) { shouldShow ->
+        model.showOverlayViews().observe(this) { shouldShow ->
             if (shouldShow) {
                 binding.addDevice.show()
                 binding.navView.show()

--- a/app/src/main/java/com/weatherxm/ui/home/HomeViewModel.kt
+++ b/app/src/main/java/com/weatherxm/ui/home/HomeViewModel.kt
@@ -32,10 +32,14 @@ class HomeViewModel(
     private val onInfoBanner = SingleLiveEvent<InfoBanner?>()
     private val onOpenExplorer = SingleLiveEvent<Boolean>()
 
+    // Needed for passing info to the activity to show/hide elements when scrolling on the list
+    private val showOverlayViews = MutableLiveData(true)
+
     fun onWalletWarnings(): LiveData<WalletWarnings> = onWalletWarnings
     fun onSurvey(): LiveData<Survey> = onSurvey
     fun onInfoBanner(): LiveData<InfoBanner?> = onInfoBanner
     fun onOpenExplorer() = onOpenExplorer
+    fun showOverlayViews() = showOverlayViews
 
     fun openExplorer() {
         onOpenExplorer.postValue(true)
@@ -45,6 +49,10 @@ class HomeViewModel(
 
     fun setHasDevices(devices: List<UIDevice>?) {
         hasDevices = devices?.firstOrNull { it.isOwned() } != null
+    }
+
+    fun onScroll(dy: Int) {
+        showOverlayViews.postValue(dy <= 0)
     }
 
     fun getWalletWarnings() {

--- a/app/src/main/java/com/weatherxm/ui/home/devices/DevicesFragment.kt
+++ b/app/src/main/java/com/weatherxm/ui/home/devices/DevicesFragment.kt
@@ -68,7 +68,7 @@ class DevicesFragment : BaseFragment(), DeviceListener {
         }
 
         binding.nestedScrollView.setOnScrollChangeListener { _, _, scrollY, _, oldScrollY ->
-            model.onScroll(scrollY - oldScrollY)
+            parentModel.onScroll(scrollY - oldScrollY)
         }
 
         binding.sortFilterBtn.setOnClickListener {

--- a/app/src/main/java/com/weatherxm/ui/home/devices/DevicesViewModel.kt
+++ b/app/src/main/java/com/weatherxm/ui/home/devices/DevicesViewModel.kt
@@ -38,13 +38,9 @@ class DevicesViewModel(
     private val onUnFollowStatus = MutableLiveData<Resource<Unit>>()
     private val onDevicesRewards = MutableLiveData<DevicesRewards>()
 
-    // Needed for passing info to the activity to show/hide elements when scrolling on the list
-    private val showOverlayViews = MutableLiveData(true)
-
     fun devices(): LiveData<Resource<List<UIDevice>>> = devices
     fun onDevicesRewards(): LiveData<DevicesRewards> = onDevicesRewards
     fun onUnFollowStatus(): LiveData<Resource<Unit>> = onUnFollowStatus
-    fun showOverlayViews() = showOverlayViews
 
     fun fetch() {
         this@DevicesViewModel.devices.postValue(Resource.loading())
@@ -79,10 +75,6 @@ class DevicesViewModel(
             }
         }
         onDevicesRewards.postValue(DevicesRewards(totalRewards, latestRewards, devicesWithRewards))
-    }
-
-    fun onScroll(dy: Int) {
-        showOverlayViews.postValue(dy <= 0)
     }
 
     fun unFollowStation(deviceId: String) {

--- a/app/src/main/java/com/weatherxm/ui/home/profile/ProfileFragment.kt
+++ b/app/src/main/java/com/weatherxm/ui/home/profile/ProfileFragment.kt
@@ -164,6 +164,10 @@ class ProfileFragment : BaseFragment() {
                 .visible(true)
         }
 
+        binding.nestedScrollView.setOnScrollChangeListener { _, _, scrollY, _, oldScrollY ->
+            parentModel.onScroll(scrollY - oldScrollY)
+        }
+
         model.fetchUser()
         parentModel.getSurvey()
     }

--- a/app/src/main/res/layout/fragment_profile.xml
+++ b/app/src/main/res/layout/fragment_profile.xml
@@ -149,6 +149,7 @@
         app:layout_behavior="com.google.android.material.appbar.AppBarLayout$ScrollingViewBehavior">
 
         <androidx.core.widget.NestedScrollView
+            android:id="@+id/nestedScrollView"
             android:layout_width="match_parent"
             android:layout_height="match_parent"
             android:clipChildren="false"

--- a/app/src/test/java/com/weatherxm/ui/home/HomeViewModelTest.kt
+++ b/app/src/test/java/com/weatherxm/ui/home/HomeViewModelTest.kt
@@ -76,6 +76,29 @@ class HomeViewModelTest : BehaviorSpec({
         }
     }
 
+    context("Flow to be called when scrolling takes place") {
+        given("a dy value") {
+            When("it's > 0") {
+                viewModel.onScroll(1)
+                then("LiveData showOverlayViews posts false") {
+                    viewModel.showOverlayViews().value shouldBe false
+                }
+            }
+            When("it's < 0") {
+                viewModel.onScroll(-1)
+                then("LiveData showOverlayViews posts true") {
+                    viewModel.showOverlayViews().value shouldBe true
+                }
+            }
+            When("it's = 0") {
+                viewModel.onScroll(0)
+                then("LiveData showOverlayViews posts true") {
+                    viewModel.showOverlayViews().value shouldBe true
+                }
+            }
+        }
+    }
+
     context("Get Wallet Warnings") {
         given("a usecase returning the wallet address in order to create the WalletWarnings") {
             When("it's a failure") {

--- a/app/src/test/java/com/weatherxm/ui/home/devices/DevicesViewModelTest.kt
+++ b/app/src/test/java/com/weatherxm/ui/home/devices/DevicesViewModelTest.kt
@@ -138,29 +138,6 @@ class DevicesViewModelTest : BehaviorSpec({
         }
     }
 
-    context("Flow to be called when scrolling takes place") {
-        given("a dy value") {
-            When("it's > 0") {
-                viewModel.onScroll(1)
-                then("LiveData showOverlayViews posts false") {
-                    viewModel.showOverlayViews().value shouldBe false
-                }
-            }
-            When("it's < 0") {
-                viewModel.onScroll(-1)
-                then("LiveData showOverlayViews posts true") {
-                    viewModel.showOverlayViews().value shouldBe true
-                }
-            }
-            When("it's = 0") {
-                viewModel.onScroll(0)
-                then("LiveData showOverlayViews posts true") {
-                    viewModel.showOverlayViews().value shouldBe true
-                }
-            }
-        }
-    }
-
     context("Unfollow a station") {
         given("a usecase returning the response of the unfollow request") {
             When("it's failure") {


### PR DESCRIPTION
### **Why?**
When Info banner is displayed not able to press Preferences and settings.

### **How?**
Scrolling on profile shows/hides the bottom navigation just like we do in devices. Moved the respective functions in `HomeViewModel` instead of the `DevicesViewModel` it was before.

### **Testing**
Ensure that everything looks OK. You can retirn in `HomeViewModel` on `getSurvey` a new `Survey` with multiple `\n` (line breaks) in the "message" argument so that this screen captures more than the available height and scrolling will be needed.
