### PR TITLE
Android new user registration returns API error when first or last name are empty

### DIFF
--- a/app/src/main/java/com/weatherxm/data/repository/AuthRepositoryImpl.kt
+++ b/app/src/main/java/com/weatherxm/data/repository/AuthRepositoryImpl.kt
@@ -56,7 +56,9 @@ class AuthRepositoryImpl(
         firstName: String?,
         lastName: String?
     ): Either<Failure, Unit> {
-        return networkAuthDataSource.signup(username, firstName, lastName).onRight {
+        val first = if (firstName.isNullOrEmpty()) null else firstName
+        val last = if (lastName.isNullOrEmpty()) null else lastName
+        return networkAuthDataSource.signup(username, first, last).onRight {
             // The user has signed-up successfully so the terms should be marked as accepted
             cacheService.setAcceptTermsTimestamp(System.currentTimeMillis())
             Timber.d("Signup success. Email sent to user: $username")

--- a/app/src/test/java/com/weatherxm/data/repository/AuthRepositoryTest.kt
+++ b/app/src/test/java/com/weatherxm/data/repository/AuthRepositoryTest.kt
@@ -142,6 +142,31 @@ class AuthRepositoryTest : BehaviorSpec({
             }
         }
         given("A Signup action") {
+            and("first name and last name are not null") {
+                When("signup is successful") {
+                    coMockEitherRight(
+                        { networkAuthDataSource.signup(email, firstName, lastName) },
+                        Unit
+                    )
+                    then("return that Unit indicating the success") {
+                        authRepository.signup(email, firstName, lastName).isSuccess(Unit)
+                    }
+                    then("verify that setting the acceptance of terms has taken place") {
+                        verify { cacheService.setAcceptTermsTimestamp(any()) }
+                    }
+                }
+            }
+            and("first name and last name are empty") {
+                When("signup is successful") {
+                    coMockEitherRight({ networkAuthDataSource.signup(email, null, null) }, Unit)
+                    then("return that Unit indicating the success") {
+                        authRepository.signup(email, "", "").isSuccess(Unit)
+                    }
+                    then("verify that setting the acceptance of terms has taken place") {
+                        verify { cacheService.setAcceptTermsTimestamp(any()) }
+                    }
+                }
+            }
             When("signup is successful") {
                 coMockEitherRight(
                     { networkAuthDataSource.signup(email, firstName, lastName) },


### PR DESCRIPTION
### **Why?**
When first name and last names are empty, replace them with null in sign up.

### **How?**
```
        val first = if (firstName.isNullOrEmpty()) null else firstName
        val last = if (lastName.isNullOrEmpty()) null else lastName
```

### **Testing**
Make two test sign-ups and make sure everything is OK:
1. With first and last name empty
2. With first and last name filled