### PR TITLE
Update the relation in the UI when following a station from a cell's list

### DIFF
--- a/app/src/main/java/com/weatherxm/ui/common/DevicesAdapter.kt
+++ b/app/src/main/java/com/weatherxm/ui/common/DevicesAdapter.kt
@@ -146,7 +146,7 @@ class DeviceAdapter(private val deviceListener: DeviceListener) :
             return oldItem.id == newItem.id
         }
 
-        @Suppress("MaxLineLength", "CyclomaticComplexMethod")
+        @Suppress("CyclomaticComplexMethod")
         override fun areContentsTheSame(oldItem: UIDevice, newItem: UIDevice): Boolean {
             return oldItem.name == newItem.name &&
                 oldItem.currentWeather?.icon == newItem.currentWeather?.icon &&
@@ -167,6 +167,7 @@ class DeviceAdapter(private val deviceListener: DeviceListener) :
                 oldItem.currentFirmware == newItem.currentFirmware &&
                 oldItem.assignedFirmware == newItem.assignedFirmware &&
                 oldItem.friendlyName == newItem.friendlyName &&
+                oldItem.relation == newItem.relation &&
                 oldItem.lastWeatherStationActivity == newItem.lastWeatherStationActivity &&
                 oldItem.isActive == newItem.isActive
         }


### PR DESCRIPTION
### **Why?**
A **UI** bug that didn't update the relation of a device when clicking "follow" or "unfollow".

### **How?**
In the `DeviceAdapter` also consider `device.relation` to reflect changes in the UI or not.

### **Testing**
Follow & unfollow stations from a cell's list and make sure the UI updates correctly.