### PR TITLE
FE-1608 Hotfix/fix crashes

### DIFF
--- a/app/src/main/java/com/weatherxm/ui/components/LoginPromptDialogFragment.kt
+++ b/app/src/main/java/com/weatherxm/ui/components/LoginPromptDialogFragment.kt
@@ -8,18 +8,34 @@ import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import com.weatherxm.databinding.ViewLoginPromptDialogBinding
 import com.weatherxm.ui.common.setHtml
 
-class LoginPromptDialogFragment(
-    private val title: String?,
-    private val message: String?,
-    private val htmlMessage: String?,
-    private val onLogin: () -> Unit,
-    private val onSignup: () -> Unit
-) : DialogFragment() {
+class LoginPromptDialogFragment() : DialogFragment() {
     private lateinit var binding: ViewLoginPromptDialogBinding
+
+    private var title: String? = null
+    private var message: String? = null
+    private var htmlMessage: String? = null
+    private var onLogin: (() -> Unit)? = null
+    private var onSignup: (() -> Unit)? = null
 
     companion object {
         const val TAG = "LOGIN_PROMPT_DIALOG_FRAGMENT"
+        const val AUTO_DISMISS_DIALOG = "AUTO_DISMISS_DIALOG"
     }
+
+    constructor(
+        title: String,
+        message: String? = null,
+        htmlMessage: String? = null,
+        onLogin: () -> Unit,
+        onSignup: () -> Unit
+    ) : this() {
+        this.title = title
+        this.message = message
+        this.htmlMessage = htmlMessage
+        this.onLogin = onLogin
+        this.onSignup = onSignup
+    }
+
 
     override fun onCreateDialog(savedInstanceState: Bundle?): Dialog {
         val builder = MaterialAlertDialogBuilder(requireContext())
@@ -42,16 +58,32 @@ class LoginPromptDialogFragment(
         }
 
         binding.loginBtn.setOnClickListener {
-            onLogin.invoke()
+            onLogin?.invoke()
             dismiss()
         }
 
         binding.signupBtn.setOnClickListener {
-            onSignup.invoke()
+            onSignup?.invoke()
             dismiss()
         }
 
+        /**
+         * Enabling "Don't keep activities" causes a crash, and we cannot save the listeners
+         * in the savedInstanceState to restore the dialog so we dismiss it automatically
+         * and it's the caller's responsibility to re-instantiate it.
+         */
+        savedInstanceState?.let {
+            if (it.getBoolean(AUTO_DISMISS_DIALOG, false)) {
+                dismiss()
+            }
+        }
+
         return builder.create()
+    }
+
+    override fun onSaveInstanceState(outState: Bundle) {
+        outState.putBoolean(AUTO_DISMISS_DIALOG, true)
+        super.onSaveInstanceState(outState)
     }
 
     fun show(activity: FragmentActivity) {


### PR DESCRIPTION
### **Why?**
Fix crashes on dialogs (e.g. Terms dialog).

### **How?**
Auto-dismiss the dialog when it's restored from saved instance (e.g. when the activity is destroyed and restarted) and let it be the caller's responsibility to re-instantiate it.

### **Testing**
- On the device go to "Developer Options" -> "Don't keep activities"
- Open a fresh install so the terms can be shown
- Click the home button to let the app go to the background or any link in the dialog
- Re-open the app
- Make sure it does **not** crash.
