### PR TITLE
Reset widget to 'Select Station' when clear app data takes place

### DIFF
--- a/app/src/main/java/com/weatherxm/ui/widgets/currentweather/CurrentWeatherWidget.kt
+++ b/app/src/main/java/com/weatherxm/ui/widgets/currentweather/CurrentWeatherWidget.kt
@@ -8,7 +8,9 @@ import android.appwidget.AppWidgetProvider
 import android.content.Context
 import android.content.Intent
 import android.widget.RemoteViews
+import androidx.preference.PreferenceManager
 import com.weatherxm.R
+import com.weatherxm.data.services.CacheService.Companion.KEY_CURRENT_WEATHER_WIDGET_IDS
 import com.weatherxm.ui.common.Contracts.ARG_DEVICE
 import com.weatherxm.ui.common.Contracts.ARG_IS_CUSTOM_APPWIDGET_UPDATE
 import com.weatherxm.ui.common.Contracts.ARG_WIDGET_ON_LOGGED_IN
@@ -57,11 +59,11 @@ class CurrentWeatherWidget : AppWidgetProvider(), KoinComponent {
         val validWidgetTypeForUpdate =
             extras?.parcelable<WidgetType>(ARG_WIDGET_TYPE) == WidgetType.CURRENT_WEATHER
 
-        /*
-        * Only update widget on actions we have triggered:
-        * a. Creation of widget
-        * b. Login/Logout
-        * c. Work Manager Update
+        /**
+         * Only update widget on actions we have triggered:
+         * a. Creation of widget
+         * b. Login/Logout
+         * c. Work Manager Update
          */
         val shouldUpdate = intent?.action == ACTION_APPWIDGET_UPDATE
             && extras?.getBoolean(ARG_IS_CUSTOM_APPWIDGET_UPDATE) ?: false
@@ -69,7 +71,18 @@ class CurrentWeatherWidget : AppWidgetProvider(), KoinComponent {
         if (!shouldUpdate && (widgetIdsFromIntent == null || widgetIdsFromIntent.isEmpty())) {
             return
         } else if (!shouldUpdate) {
-            CurrentWeatherWidgetWorkerUpdate.restartAllWorkers(context)
+            val prefs = PreferenceManager.getDefaultSharedPreferences(context)
+            val ids = prefs.getStringSet(KEY_CURRENT_WEATHER_WIDGET_IDS, setOf())
+
+            /**
+             * The first line covers the case of a user clearing app storage & cache so we reset
+             * the widget to the "Select Station" state
+             */
+            if (ids.isNullOrEmpty()) {
+                CurrentWeatherWidgetWorkerUpdate.clearAllWidgets(context, widgetHelper)
+            } else {
+                CurrentWeatherWidgetWorkerUpdate.restartAllWorkers(context)
+            }
             return
         }
 

--- a/app/src/main/java/com/weatherxm/ui/widgets/currentweather/CurrentWeatherWidgetTile.kt
+++ b/app/src/main/java/com/weatherxm/ui/widgets/currentweather/CurrentWeatherWidgetTile.kt
@@ -8,7 +8,9 @@ import android.appwidget.AppWidgetProvider
 import android.content.Context
 import android.content.Intent
 import android.widget.RemoteViews
+import androidx.preference.PreferenceManager
 import com.weatherxm.R
+import com.weatherxm.data.services.CacheService.Companion.KEY_CURRENT_WEATHER_WIDGET_IDS
 import com.weatherxm.ui.common.Contracts
 import com.weatherxm.ui.common.Contracts.ARG_DEVICE
 import com.weatherxm.ui.common.Contracts.ARG_IS_CUSTOM_APPWIDGET_UPDATE
@@ -53,20 +55,30 @@ class CurrentWeatherWidgetTile : AppWidgetProvider(), KoinComponent {
         val validWidgetTypeForUpdate =
             extras?.parcelable<WidgetType>(ARG_WIDGET_TYPE) == WidgetType.CURRENT_WEATHER_TILE
 
-        /*
-        * Only update widget on actions we have triggered:
-        * a. Creation of widget
-        * b. Login/Logout
-        * c. Work Manager Update
+        /**
+         * Only update widget on actions we have triggered:
+         * a. Creation of widget
+         * b. Login/Logout
+         * c. Work Manager Update
          */
         val shouldUpdate = intent?.action == ACTION_APPWIDGET_UPDATE
             && extras?.getBoolean(ARG_IS_CUSTOM_APPWIDGET_UPDATE) ?: false
 
-
         if (!shouldUpdate && (widgetIdsFromIntent == null || widgetIdsFromIntent.isEmpty())) {
             return
         } else if (!shouldUpdate) {
-            CurrentWeatherWidgetWorkerUpdate.restartAllWorkers(context)
+            val prefs = PreferenceManager.getDefaultSharedPreferences(context)
+            val ids = prefs.getStringSet(KEY_CURRENT_WEATHER_WIDGET_IDS, setOf())
+
+            /**
+             * The first line covers the case of a user clearing app storage & cache so we reset
+             * the widget to the "Select Station" state
+             */
+            if (ids.isNullOrEmpty()) {
+                CurrentWeatherWidgetWorkerUpdate.clearAllWidgets(context, widgetHelper)
+            } else {
+                CurrentWeatherWidgetWorkerUpdate.restartAllWorkers(context)
+            }
             return
         }
 

--- a/app/src/main/java/com/weatherxm/ui/widgets/currentweather/CurrentWeatherWidgetWorkerUpdate.kt
+++ b/app/src/main/java/com/weatherxm/ui/widgets/currentweather/CurrentWeatherWidgetWorkerUpdate.kt
@@ -2,6 +2,7 @@ package com.weatherxm.ui.widgets.currentweather
 
 import android.appwidget.AppWidgetManager
 import android.appwidget.AppWidgetManager.INVALID_APPWIDGET_ID
+import android.content.ComponentName
 import android.content.Context
 import android.content.Intent
 import android.os.Parcelable
@@ -41,6 +42,34 @@ class CurrentWeatherWidgetWorkerUpdate(
 ) : CoroutineWorker(context, workerParams), KoinComponent {
     companion object {
         private const val UPDATE_INTERVAL_IN_MINS = 15L
+
+        fun clearAllWidgets(context: Context, widgetHelper: WidgetHelper) {
+            val weatherWidgets = AppWidgetManager.getInstance(context).getAppWidgetIds(
+                ComponentName(context, CurrentWeatherWidget::class.java)
+            ).toList()
+            val weatherTilesWidgets = AppWidgetManager.getInstance(context).getAppWidgetIds(
+                ComponentName(context, CurrentWeatherWidgetTile::class.java)
+            ).toList()
+            val weatherDetailedWidgets = AppWidgetManager.getInstance(context).getAppWidgetIds(
+                ComponentName(context, CurrentWeatherWidgetDetailed::class.java)
+            ).toList()
+            val allWidgets = buildList {
+                addAll(weatherWidgets)
+                addAll(weatherTilesWidgets)
+                addAll(weatherDetailedWidgets)
+            }
+
+            allWidgets.forEach {
+                val widgetType =
+                    widgetHelper.getWidgetTypeById(AppWidgetManager.getInstance(context), it)
+                val intent = Intent(AppWidgetManager.ACTION_APPWIDGET_UPDATE)
+                intent.putExtra(AppWidgetManager.EXTRA_APPWIDGET_ID, it)
+                intent.putExtra(ARG_IS_CUSTOM_APPWIDGET_UPDATE, true)
+                intent.putExtra(ARG_WIDGET_SHOULD_SELECT_STATION, true)
+                intent.putExtra(ARG_WIDGET_TYPE, widgetType as Parcelable)
+                context.sendBroadcast(intent)
+            }
+        }
 
         fun restartAllWorkers(context: Context) {
             val prefs = PreferenceManager.getDefaultSharedPreferences(context)


### PR DESCRIPTION
### **Why?**
Widgets fails to load after clearing app data on Android

### **How?**
Created `clearAllWidgets` in the Worker which is responsible for getting the widget IDs and sending "Should Select Station" events to them.

### **Testing**
1. Add a widget
2. Close the app and clear its cache & data
3. Open the app
4. Ensure the widget is at the "Select Station" state
5. Login through the app
6. Select a station through the widget
7. Ensure everything looks OK.

### **Additional context**
Current limitations: Works only for 1 widget currently.
