### PR TITLE
Optimizations in Device Settings Activities

### DIFF
--- a/app/src/main/java/com/weatherxm/ui/devicesettings/BaseDeviceSettingsActivity.kt
+++ b/app/src/main/java/com/weatherxm/ui/devicesettings/BaseDeviceSettingsActivity.kt
@@ -1,0 +1,264 @@
+package com.weatherxm.ui.devicesettings
+
+import android.app.Activity
+import android.widget.ImageView
+import androidx.activity.result.contract.ActivityResultContracts
+import androidx.constraintlayout.widget.ConstraintLayout
+import androidx.recyclerview.widget.RecyclerView
+import androidx.swiperefreshlayout.widget.SwipeRefreshLayout
+import coil3.ImageLoader
+import com.google.android.material.button.MaterialButton
+import com.google.android.material.card.MaterialCardView
+import com.google.android.material.progressindicator.LinearProgressIndicator
+import com.google.android.material.textview.MaterialTextView
+import com.google.firebase.analytics.FirebaseAnalytics
+import com.weatherxm.R
+import com.weatherxm.analytics.AnalyticsService
+import com.weatherxm.ui.common.Contracts
+import com.weatherxm.ui.common.Contracts.ARG_DEVICE
+import com.weatherxm.ui.common.DeviceRelation
+import com.weatherxm.ui.common.RewardSplitStakeholderAdapter
+import com.weatherxm.ui.common.RewardSplitsData
+import com.weatherxm.ui.common.StationPhoto
+import com.weatherxm.ui.common.UIDevice
+import com.weatherxm.ui.common.empty
+import com.weatherxm.ui.common.invisible
+import com.weatherxm.ui.common.loadImage
+import com.weatherxm.ui.common.parcelable
+import com.weatherxm.ui.common.parcelableList
+import com.weatherxm.ui.common.setHtml
+import com.weatherxm.ui.common.visible
+import com.weatherxm.ui.components.ActionDialogFragment
+import com.weatherxm.ui.components.BaseActivity
+import com.weatherxm.util.MapboxUtils.getMinimap
+import org.koin.android.ext.android.inject
+import timber.log.Timber
+
+@Suppress("TooManyFunctions")
+abstract class BaseDeviceSettingsActivity : BaseActivity() {
+    private val imageLoader: ImageLoader by inject()
+
+    // Register the launcher for the edit location activity and wait for a possible result
+    private val editLocationLauncher =
+        registerForActivityResult(ActivityResultContracts.StartActivityForResult()) {
+            val device = it.data?.parcelable<UIDevice>(ARG_DEVICE)
+            if (it.resultCode == Activity.RESULT_OK && device != null) {
+                onEditLocation(device)
+            }
+        }
+
+    // Register the launcher for the photo gallery activity and wait for a possible result
+    private val photoGalleryLauncher =
+        registerForActivityResult(ActivityResultContracts.StartActivityForResult()) {
+            /**
+             * Some changes happened in the photos so we need to fetch them again or delete all of
+             * them if the user left the screen with <2 photos left.
+             */
+            val shouldDeleteAllPhotos =
+                it.data?.getBooleanExtra(Contracts.ARG_DELETE_ALL_PHOTOS, false)
+            val photos = it.data?.parcelableList<StationPhoto>(Contracts.ARG_PHOTOS)
+            if (it.resultCode == Activity.RESULT_OK) {
+                onPhotosChanged(shouldDeleteAllPhotos, photos)
+            }
+        }
+
+    protected fun handleLoading(
+        swipeRefreshLayout: SwipeRefreshLayout,
+        progress: LinearProgressIndicator,
+        isLoading: Boolean
+    ) {
+        if (isLoading && !swipeRefreshLayout.isRefreshing) {
+            progress.visible(true)
+        } else {
+            swipeRefreshLayout.isRefreshing = false
+            progress.invisible()
+        }
+    }
+
+    protected fun onPhotosClicked(
+        devicePhotos: List<String>,
+        hasAcceptedPhotosTerms: Boolean,
+        device: UIDevice
+    ) {
+        analytics.trackEventSelectContent(
+            contentType = AnalyticsService.ParamValue.GO_TO_PHOTO_VERIFICATION.paramValue,
+            Pair(
+                FirebaseAnalytics.Param.SOURCE,
+                AnalyticsService.ParamValue.SETTINGS.paramValue
+            )
+        )
+        val photos = arrayListOf<String>()
+        devicePhotos.forEach {
+            photos.add(it)
+        }
+        if (photos.isEmpty() || !hasAcceptedPhotosTerms) {
+            navigator.showPhotoVerificationIntro(this, device, photos)
+        } else {
+            navigator.showPhotoGallery(photoGalleryLauncher, this, device, photos, false)
+        }
+    }
+
+    protected fun onPhotosCancelPrompt(onCancel: () -> Unit) {
+        ActionDialogFragment
+            .Builder(
+                title = getString(R.string.cancel_upload),
+                message = getString(R.string.cancel_upload_message),
+                negative = getString(R.string.action_back)
+            )
+            .onPositiveClick(getString(R.string.yes_cancel)) {
+                analytics.trackEventUserAction(
+                    AnalyticsService.ParamValue.CANCEL_UPLOADING_PHOTOS.paramValue
+                )
+                onCancel()
+            }
+            .build()
+            .show(this)
+    }
+
+
+    protected fun onPhotosRetry(functionToRun: () -> Unit) {
+        functionToRun()
+        analytics.trackEventUserAction(
+            AnalyticsService.ParamValue.RETRY_UPLOADING_PHOTOS.paramValue
+        )
+    }
+
+    protected fun setupStationLocation(
+        device: UIDevice,
+        editLocationBtn: MaterialButton,
+        locationDesc: MaterialTextView
+    ) {
+        editLocationBtn.setOnClickListener {
+            navigator.showEditLocation(editLocationLauncher, this, device)
+        }
+        editLocationBtn.visible(device.isOwned())
+
+        if (device.relation == DeviceRelation.FOLLOWED) {
+            locationDesc.setHtml(
+                R.string.station_location_favorite_desc,
+                device.address ?: String.empty()
+            )
+        } else {
+            locationDesc.setHtml(R.string.station_location_desc, device.address ?: String.empty())
+        }
+    }
+
+    protected fun updateMinimap(
+        device: UIDevice,
+        locationLayout: ConstraintLayout,
+        locationMinimap: ImageView
+    ) {
+        val deviceMapLocation = if (device.isOwned()) {
+            device.location
+        } else {
+            null
+        }
+        getMinimap(locationLayout.width, deviceMapLocation, device.hex7)?.let {
+            locationMinimap.loadImage(imageLoader, it.toString())
+        } ?: locationMinimap.visible(false)
+    }
+
+    protected fun onRemoveStation(device: UIDevice, onRemoved: () -> Unit) {
+        analytics.trackEventSelectContent(
+            AnalyticsService.ParamValue.REMOVE_DEVICE.paramValue,
+            Pair(FirebaseAnalytics.Param.ITEM_ID, device.id)
+        )
+        navigator.showPasswordPrompt(this, R.string.remove_station_password_message) {
+            if (it) {
+                Timber.d("Password confirmation success!")
+                onRemoved()
+            } else {
+                Timber.d("Password confirmation prompt was cancelled or failed.")
+            }
+        }
+    }
+
+    protected fun onChangeStationName(device: UIDevice, onChanged: (String?) -> Unit) {
+        FriendlyNameDialogFragment(device.friendlyName, device.id) {
+            onChanged(it)
+        }.show(this)
+    }
+
+    protected fun setupRemoveStationDescription(view: MaterialTextView) {
+        view.movementMethod =
+            me.saket.bettermovementmethod.BetterLinkMovementMethod.newInstance().apply {
+                setOnLinkClickListener { _, url ->
+                    navigator.openWebsite(this@BaseDeviceSettingsActivity, url)
+                    return@setOnLinkClickListener true
+                }
+            }
+        view.setHtml(
+            R.string.remove_station_desc,
+            getString(R.string.docs_url)
+        )
+    }
+
+    protected fun trackLowBatteryWarning(deviceId: String) {
+        analytics.trackEventPrompt(
+            AnalyticsService.ParamValue.LOW_BATTERY.paramValue,
+            AnalyticsService.ParamValue.WARN.paramValue,
+            AnalyticsService.ParamValue.VIEW.paramValue,
+            Pair(FirebaseAnalytics.Param.ITEM_ID, deviceId)
+        )
+    }
+
+    protected fun onShare(textToShare: String, deviceId: String) {
+        navigator.openShare(this, textToShare)
+
+        analytics.trackEventUserAction(
+            actionName = AnalyticsService.ParamValue.SHARE_STATION_INFO.paramValue,
+            contentType = AnalyticsService.ParamValue.STATION_INFO.paramValue,
+            Pair(FirebaseAnalytics.Param.ITEM_ID, deviceId)
+        )
+    }
+
+    @Suppress("LongParameterList")
+    protected fun handleRewardSplits(
+        rewardSplitCard: MaterialCardView,
+        rewardSplitDesc: MaterialTextView,
+        recyclerRewardSplit: RecyclerView,
+        data: RewardSplitsData?,
+        isStakeholder: Boolean,
+        isDeviceOwned: Boolean,
+    ) {
+        if (data?.hasSplitRewards() == true) {
+            rewardSplitCard.visible(true)
+            rewardSplitDesc.text = getString(R.string.reward_split_desc, data.splits.size)
+            val rewardSplitAdapter = RewardSplitStakeholderAdapter(data.wallet, true)
+            recyclerRewardSplit.adapter = rewardSplitAdapter
+            rewardSplitAdapter.submitList(data.splits)
+
+            val stakeHolderValue = if (isStakeholder) {
+                AnalyticsService.ParamValue.STAKEHOLDER_LOWERCASE.paramValue
+            } else {
+                AnalyticsService.ParamValue.NON_STAKEHOLDER.paramValue
+            }
+            trackRewardSplitViewContent(
+                AnalyticsService.ParamValue.REWARD_SPLITTING.paramValue,
+                stakeHolderValue
+            )
+        } else {
+            val stakeHolderValue = if (isDeviceOwned) {
+                AnalyticsService.ParamValue.STAKEHOLDER_LOWERCASE.paramValue
+            } else {
+                AnalyticsService.ParamValue.NON_STAKEHOLDER.paramValue
+            }
+            trackRewardSplitViewContent(
+                AnalyticsService.ParamValue.NO_REWARD_SPLITTING.paramValue,
+                stakeHolderValue
+            )
+        }
+    }
+
+    protected fun trackRewardSplitViewContent(deviceState: String, userState: String) {
+        analytics.trackEventViewContent(
+            AnalyticsService.ParamValue.REWARD_SPLITTING_DEVICE_SETTINGS.paramValue,
+            contentId = null,
+            Pair(AnalyticsService.CustomParam.DEVICE_STATE.paramName, deviceState),
+            Pair(AnalyticsService.CustomParam.USER_STATE.paramName, userState)
+        )
+    }
+
+    abstract fun onEditLocation(device: UIDevice)
+    abstract fun onPhotosChanged(shouldDeleteAllPhotos: Boolean?, photos: ArrayList<StationPhoto>?)
+}

--- a/app/src/main/java/com/weatherxm/ui/devicesettings/BaseDeviceSettingsViewModel.kt
+++ b/app/src/main/java/com/weatherxm/ui/devicesettings/BaseDeviceSettingsViewModel.kt
@@ -143,8 +143,8 @@ abstract class BaseDeviceSettingsViewModel(
         })
     }
 
-    fun isStakeholder(rewardSplitsData: RewardSplitsData): Boolean {
-        return rewardSplitsData.splits.firstOrNull { split ->
+    fun isStakeholder(rewardSplitsData: RewardSplitsData?): Boolean {
+        return rewardSplitsData?.splits?.firstOrNull { split ->
             rewardSplitsData.wallet == split.wallet
         } != null
     }

--- a/app/src/main/java/com/weatherxm/ui/devicesettings/helium/DeviceSettingsHeliumActivity.kt
+++ b/app/src/main/java/com/weatherxm/ui/devicesettings/helium/DeviceSettingsHeliumActivity.kt
@@ -1,75 +1,35 @@
 package com.weatherxm.ui.devicesettings.helium
 
-import android.app.Activity
 import android.os.Bundle
-import androidx.activity.result.contract.ActivityResultContracts
-import coil3.ImageLoader
-import com.google.firebase.analytics.FirebaseAnalytics
 import com.weatherxm.R
 import com.weatherxm.analytics.AnalyticsService
 import com.weatherxm.databinding.ActivityDeviceSettingsHeliumBinding
 import com.weatherxm.service.workers.UploadPhotoWorker
-import com.weatherxm.ui.common.Contracts
 import com.weatherxm.ui.common.Contracts.ARG_DEVICE
 import com.weatherxm.ui.common.DeviceAlertType
 import com.weatherxm.ui.common.DeviceRelation
-import com.weatherxm.ui.common.RewardSplitStakeholderAdapter
-import com.weatherxm.ui.common.RewardSplitsData
 import com.weatherxm.ui.common.StationPhoto
 import com.weatherxm.ui.common.UIDevice
 import com.weatherxm.ui.common.applyOnGlobalLayout
 import com.weatherxm.ui.common.classSimpleName
-import com.weatherxm.ui.common.empty
 import com.weatherxm.ui.common.invisible
-import com.weatherxm.ui.common.loadImage
 import com.weatherxm.ui.common.parcelable
-import com.weatherxm.ui.common.parcelableList
 import com.weatherxm.ui.common.setHtml
 import com.weatherxm.ui.common.toast
 import com.weatherxm.ui.common.visible
-import com.weatherxm.ui.components.ActionDialogFragment
-import com.weatherxm.ui.components.BaseActivity
+import com.weatherxm.ui.devicesettings.BaseDeviceSettingsActivity
 import com.weatherxm.ui.devicesettings.DeviceInfoItemAdapter
-import com.weatherxm.ui.devicesettings.FriendlyNameDialogFragment
-import com.weatherxm.util.MapboxUtils.getMinimap
 import net.gotev.uploadservice.extensions.getCancelUploadIntent
-import org.koin.android.ext.android.inject
 import org.koin.androidx.viewmodel.ext.android.viewModel
 import org.koin.core.parameter.parametersOf
 import timber.log.Timber
 
-class DeviceSettingsHeliumActivity : BaseActivity() {
+class DeviceSettingsHeliumActivity : BaseDeviceSettingsActivity() {
     private val model: DeviceSettingsHeliumViewModel by viewModel {
         parametersOf(intent.parcelable<UIDevice>(ARG_DEVICE))
     }
     private lateinit var binding: ActivityDeviceSettingsHeliumBinding
-    private val imageLoader: ImageLoader by inject()
     private lateinit var adapter: DeviceInfoItemAdapter
-
-    // Register the launcher for the edit location activity and wait for a possible result
-    private val editLocationLauncher =
-        registerForActivityResult(ActivityResultContracts.StartActivityForResult()) {
-            val device = it.data?.parcelable<UIDevice>(ARG_DEVICE)
-            if (it.resultCode == Activity.RESULT_OK && device != null) {
-                model.device = device
-                setupStationLocation(true)
-            }
-        }
-
-    // Register the launcher for the photo gallery activity and wait for a possible result
-    private val photoGalleryLauncher =
-        registerForActivityResult(ActivityResultContracts.StartActivityForResult()) {
-            /**
-             * Some changes happened in the photos so we need to fetch them again or delete all of
-             * them if the user left the screen with <2 photos left.
-             */
-            val shouldDeleteAllPhotos =
-                it.data?.getBooleanExtra(Contracts.ARG_DELETE_ALL_PHOTOS, false)
-            val photos = it.data?.parcelableList<StationPhoto>(Contracts.ARG_PHOTOS)
-            if (it.resultCode == Activity.RESULT_OK) {
-                model.onPhotosChanged(shouldDeleteAllPhotos, photos)
-            }
-        }
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -96,12 +56,7 @@ class DeviceSettingsHeliumActivity : BaseActivity() {
         }
 
         model.onLoading().observe(this) {
-            if (it && !binding.swiperefresh.isRefreshing) {
-                binding.progress.visible(true)
-            } else {
-                binding.swiperefresh.isRefreshing = false
-                binding.progress.invisible()
-            }
+            handleLoading(binding.swiperefresh, binding.progress, it)
         }
 
         model.onEditNameChange().observe(this) {
@@ -123,11 +78,15 @@ class DeviceSettingsHeliumActivity : BaseActivity() {
         }
 
         binding.changeStationNameBtn.setOnClickListener {
-            onChangeStationName()
+            onChangeStationName(model.device) {
+                model.setOrClearFriendlyName(it)
+            }
         }
 
         binding.removeStationBtn.setOnClickListener {
-            onRemoveStation()
+            onRemoveStation(model.device) {
+                model.removeDevice()
+            }
         }
 
         binding.changeFrequencyBtn.setOnClickListener {
@@ -154,7 +113,7 @@ class DeviceSettingsHeliumActivity : BaseActivity() {
             }
         )
 
-        setupStationLocation(false)
+        updateStationLocation(false)
     }
 
     override fun onResume() {
@@ -167,55 +126,20 @@ class DeviceSettingsHeliumActivity : BaseActivity() {
         binding.devicePhotosCard.updateUI(devicePhotos)
         binding.devicePhotosCard.setOnClickListener(
             onClick = {
-                analytics.trackEventSelectContent(
-                    contentType = AnalyticsService.ParamValue.GO_TO_PHOTO_VERIFICATION.paramValue,
-                    Pair(
-                        FirebaseAnalytics.Param.SOURCE,
-                        AnalyticsService.ParamValue.SETTINGS.paramValue
-                    )
-                )
-                val photos = arrayListOf<String>()
-                devicePhotos.forEach {
-                    photos.add(it)
-                }
-                if (photos.isEmpty() || !model.getAcceptedPhotoTerms()) {
-                    navigator.showPhotoVerificationIntro(this, model.device, photos)
-                } else {
-                    navigator.showPhotoGallery(
-                        photoGalleryLauncher,
-                        this,
-                        model.device,
-                        photos,
-                        false
-                    )
-                }
+                onPhotosClicked(devicePhotos, model.getAcceptedPhotoTerms(), model.device)
             },
             onCancelUpload = {
-                ActionDialogFragment
-                    .Builder(
-                        title = getString(R.string.cancel_upload),
-                        message = getString(R.string.cancel_upload_message),
-                        negative = getString(R.string.action_back)
-                    )
-                    .onPositiveClick(getString(R.string.yes_cancel)) {
-                        analytics.trackEventUserAction(
-                            AnalyticsService.ParamValue.CANCEL_UPLOADING_PHOTOS.paramValue
-                        )
-                        // Trigger a refresh on the photos through the API
-                        UploadPhotoWorker.cancelWorkers(this, model.device.id)
-                        model.getDevicePhotoUploadIds().onEach {
-                            getCancelUploadIntent(it).send()
-                        }
-                        model.onPhotosChanged(false, null)
+                onPhotosCancelPrompt {
+                    // Trigger a refresh on the photos through the API
+                    UploadPhotoWorker.cancelWorkers(this, model.device.id)
+                    model.getDevicePhotoUploadIds().onEach {
+                        getCancelUploadIntent(it).send()
                     }
-                    .build()
-                    .show(this)
+                    model.onPhotosChanged(false, null)
+                }
             },
             onRetry = {
-                model.retryPhotoUpload()
-                analytics.trackEventUserAction(
-                    AnalyticsService.ParamValue.RETRY_UPLOADING_PHOTOS.paramValue
-                )
+                onPhotosRetry { model.retryPhotoUpload() }
             }
         )
 
@@ -237,88 +161,30 @@ class DeviceSettingsHeliumActivity : BaseActivity() {
         binding.recyclerInfo.adapter = adapter
     }
 
-    private fun setupStationLocation(forceUpdateMinimap: Boolean) {
-        binding.editLocationBtn.setOnClickListener {
-            navigator.showEditLocation(editLocationLauncher, this, model.device)
-        }
-        binding.editLocationBtn.visible(model.device.isOwned())
-
-        if (model.device.relation == DeviceRelation.FOLLOWED) {
-            binding.locationDesc.setHtml(
-                R.string.station_location_favorite_desc, model.device.address ?: String.empty()
-            )
-        } else {
-            binding.locationDesc.setHtml(
-                R.string.station_location_desc,
-                model.device.address ?: String.empty()
-            )
-        }
+    private fun updateStationLocation(forceUpdateMinimap: Boolean) {
+        setupStationLocation(model.device, binding.editLocationBtn, binding.locationDesc)
 
         if (forceUpdateMinimap) {
-            updateMinimap()
+            updateMinimap(model.device, binding.locationLayout, binding.locationMinimap)
         } else {
             binding.locationLayout.applyOnGlobalLayout {
-                updateMinimap()
+                updateMinimap(model.device, binding.locationLayout, binding.locationMinimap)
             }
         }
-    }
-
-    private fun updateMinimap() {
-        val deviceMapLocation = if (model.device.isOwned()) {
-            model.device.location
-        } else {
-            null
-        }
-        getMinimap(binding.locationLayout.width, deviceMapLocation, model.device.hex7)?.let {
-            binding.locationMinimap.loadImage(imageLoader, it.toString())
-        } ?: binding.locationMinimap.visible(false)
-    }
-
-    private fun onRemoveStation() {
-        analytics.trackEventSelectContent(
-            AnalyticsService.ParamValue.REMOVE_DEVICE.paramValue,
-            Pair(FirebaseAnalytics.Param.ITEM_ID, model.device.id)
-        )
-        navigator.showPasswordPrompt(this, R.string.remove_station_password_message) {
-            if (it) {
-                Timber.d("Password confirmation success!")
-                model.removeDevice()
-            } else {
-                Timber.d("Password confirmation prompt was cancelled or failed.")
-            }
-        }
-    }
-
-    private fun onChangeStationName() {
-        FriendlyNameDialogFragment(model.device.friendlyName, model.device.id) {
-            model.setOrClearFriendlyName(it)
-        }.show(this)
     }
 
     private fun setupInfo() {
         binding.stationName.text = model.device.getDefaultOrFriendlyName()
-        binding.deleteStationCard.visible(model.device.isOwned())
-        if (!model.device.isOwned()) {
+        if (model.device.isOwned()) {
+            setupRemoveStationDescription(binding.removeStationDesc)
+        } else {
             binding.frequencyTitle.visible(false)
             binding.frequencyDesc.visible(false)
             binding.changeFrequencyBtn.visible(false)
             binding.rebootStationContainer.visible(false)
             binding.dividerBelowFrequency.visible(false)
             binding.dividerBelowStationName.visible(false)
-        } else {
-            with(binding.removeStationDesc) {
-                movementMethod =
-                    me.saket.bettermovementmethod.BetterLinkMovementMethod.newInstance().apply {
-                        setOnLinkClickListener { _, url ->
-                            navigator.openWebsite(context, url)
-                            return@setOnLinkClickListener true
-                        }
-                    }
-                setHtml(
-                    R.string.remove_station_desc,
-                    getString(R.string.docs_url)
-                )
-            }
+            binding.deleteStationCard.visible(false)
         }
 
         with(binding.frequencyDesc) {
@@ -337,12 +203,7 @@ class DeviceSettingsHeliumActivity : BaseActivity() {
 
         model.onDeviceInfo().observe(this) { deviceInfo ->
             if (deviceInfo.default.any { it.deviceAlert?.alert == DeviceAlertType.LOW_BATTERY }) {
-                analytics.trackEventPrompt(
-                    AnalyticsService.ParamValue.LOW_BATTERY.paramValue,
-                    AnalyticsService.ParamValue.WARN.paramValue,
-                    AnalyticsService.ParamValue.VIEW.paramValue,
-                    Pair(FirebaseAnalytics.Param.ITEM_ID, model.device.id)
-                )
+                trackLowBatteryWarning(model.device.id)
             }
             if (deviceInfo.default.any { it.deviceAlert?.alert == DeviceAlertType.NEEDS_UPDATE }) {
                 analytics.trackEventPrompt(
@@ -352,58 +213,32 @@ class DeviceSettingsHeliumActivity : BaseActivity() {
                 )
             }
 
-            handleSplitRewards(deviceInfo.rewardSplit)
+            handleRewardSplits(
+                binding.rewardSplitCard,
+                binding.rewardSplitDesc,
+                binding.recyclerRewardSplit,
+                deviceInfo.rewardSplit,
+                model.isStakeholder(deviceInfo.rewardSplit),
+                model.device.isOwned()
+            )
 
             adapter.submitList(deviceInfo.default)
 
             binding.shareBtn.setOnClickListener {
-                navigator.openShare(this, model.parseDeviceInfoToShare(deviceInfo))
-
-                analytics.trackEventUserAction(
-                    actionName = AnalyticsService.ParamValue.SHARE_STATION_INFO.paramValue,
-                    contentType = AnalyticsService.ParamValue.STATION_INFO.paramValue,
-                    Pair(FirebaseAnalytics.Param.ITEM_ID, model.device.id)
-                )
+                onShare(model.parseDeviceInfoToShare(deviceInfo), model.device.id)
             }
         }
     }
 
-    private fun handleSplitRewards(data: RewardSplitsData?) {
-        if (data?.hasSplitRewards() == true) {
-            binding.rewardSplitCard.visible(true)
-            binding.rewardSplitDesc.text = getString(R.string.reward_split_desc, data.splits.size)
-            val rewardSplitAdapter = RewardSplitStakeholderAdapter(data.wallet, true)
-            binding.recyclerRewardSplit.adapter = rewardSplitAdapter
-            rewardSplitAdapter.submitList(data.splits)
-
-            val stakeHolderValue = if (model.isStakeholder(data)) {
-                AnalyticsService.ParamValue.STAKEHOLDER_LOWERCASE.paramValue
-            } else {
-                AnalyticsService.ParamValue.NON_STAKEHOLDER.paramValue
-            }
-            trackRewardSplitViewContent(
-                AnalyticsService.ParamValue.REWARD_SPLITTING.paramValue,
-                stakeHolderValue
-            )
-        } else {
-            val stakeHolderValue = if (model.device.isOwned()) {
-                AnalyticsService.ParamValue.STAKEHOLDER_LOWERCASE.paramValue
-            } else {
-                AnalyticsService.ParamValue.NON_STAKEHOLDER.paramValue
-            }
-            trackRewardSplitViewContent(
-                AnalyticsService.ParamValue.NO_REWARD_SPLITTING.paramValue,
-                stakeHolderValue
-            )
-        }
+    override fun onEditLocation(device: UIDevice) {
+        model.device = device
+        updateStationLocation(true)
     }
 
-    private fun trackRewardSplitViewContent(deviceState: String, userState: String) {
-        analytics.trackEventViewContent(
-            AnalyticsService.ParamValue.REWARD_SPLITTING_DEVICE_SETTINGS.paramValue,
-            contentId = null,
-            Pair(AnalyticsService.CustomParam.DEVICE_STATE.paramName, deviceState),
-            Pair(AnalyticsService.CustomParam.USER_STATE.paramName, userState)
-        )
+    override fun onPhotosChanged(
+        shouldDeleteAllPhotos: Boolean?,
+        photos: ArrayList<StationPhoto>?
+    ) {
+        model.onPhotosChanged(shouldDeleteAllPhotos, photos)
     }
 }

--- a/app/src/main/java/com/weatherxm/ui/devicesettings/wifi/DeviceSettingsWifiActivity.kt
+++ b/app/src/main/java/com/weatherxm/ui/devicesettings/wifi/DeviceSettingsWifiActivity.kt
@@ -1,79 +1,38 @@
 package com.weatherxm.ui.devicesettings.wifi
 
-import android.app.Activity
 import android.os.Bundle
-import android.view.View
-import androidx.activity.result.contract.ActivityResultContracts
-import coil3.ImageLoader
-import com.google.firebase.analytics.FirebaseAnalytics
 import com.weatherxm.R
 import com.weatherxm.analytics.AnalyticsService
 import com.weatherxm.databinding.ActivityDeviceSettingsWifiBinding
 import com.weatherxm.service.workers.UploadPhotoWorker
 import com.weatherxm.ui.common.BundleName
-import com.weatherxm.ui.common.Contracts
 import com.weatherxm.ui.common.Contracts.ARG_DEVICE
 import com.weatherxm.ui.common.DeviceAlertType
 import com.weatherxm.ui.common.DeviceRelation
-import com.weatherxm.ui.common.RewardSplitStakeholderAdapter
-import com.weatherxm.ui.common.RewardSplitsData
 import com.weatherxm.ui.common.StationPhoto
 import com.weatherxm.ui.common.UIDevice
 import com.weatherxm.ui.common.applyOnGlobalLayout
 import com.weatherxm.ui.common.classSimpleName
 import com.weatherxm.ui.common.empty
 import com.weatherxm.ui.common.invisible
-import com.weatherxm.ui.common.loadImage
 import com.weatherxm.ui.common.parcelable
-import com.weatherxm.ui.common.parcelableList
-import com.weatherxm.ui.common.setHtml
 import com.weatherxm.ui.common.toast
 import com.weatherxm.ui.common.visible
-import com.weatherxm.ui.components.ActionDialogFragment
-import com.weatherxm.ui.components.BaseActivity
+import com.weatherxm.ui.devicesettings.BaseDeviceSettingsActivity
 import com.weatherxm.ui.devicesettings.DeviceInfoItemAdapter
-import com.weatherxm.ui.devicesettings.FriendlyNameDialogFragment
-import com.weatherxm.util.MapboxUtils.getMinimap
 import net.gotev.uploadservice.extensions.getCancelUploadIntent
-import org.koin.android.ext.android.inject
 import org.koin.androidx.viewmodel.ext.android.viewModel
 import org.koin.core.parameter.parametersOf
 import timber.log.Timber
 
-class DeviceSettingsWifiActivity : BaseActivity() {
+class DeviceSettingsWifiActivity : BaseDeviceSettingsActivity() {
     private val model: DeviceSettingsWifiViewModel by viewModel {
         parametersOf(intent.parcelable<UIDevice>(ARG_DEVICE))
     }
     private lateinit var binding: ActivityDeviceSettingsWifiBinding
-    private val imageLoader: ImageLoader by inject()
     private lateinit var defaultAdapter: DeviceInfoItemAdapter
     private lateinit var gatewayAdapter: DeviceInfoItemAdapter
     private lateinit var stationAdapter: DeviceInfoItemAdapter
-
-    // Register the launcher for the edit location activity and wait for a possible result
-    private val editLocationLauncher =
-        registerForActivityResult(ActivityResultContracts.StartActivityForResult()) {
-            val device = it.data?.parcelable<UIDevice>(ARG_DEVICE)
-            if (it.resultCode == Activity.RESULT_OK && device != null) {
-                model.device = device
-                setupStationLocation(true)
-            }
-        }
-
-    // Register the launcher for the photo gallery activity and wait for a possible result
-    private val photoGalleryLauncher =
-        registerForActivityResult(ActivityResultContracts.StartActivityForResult()) {
-            /**
-             * Some changes happened in the photos so we need to fetch them again or delete all of
-             * them if the user left the screen with <2 photos left.
-             */
-            val shouldDeleteAllPhotos =
-                it.data?.getBooleanExtra(Contracts.ARG_DELETE_ALL_PHOTOS, false)
-            val photos = it.data?.parcelableList<StationPhoto>(Contracts.ARG_PHOTOS)
-            if (it.resultCode == Activity.RESULT_OK) {
-                model.onPhotosChanged(shouldDeleteAllPhotos, photos)
-            }
-        }
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -100,12 +59,7 @@ class DeviceSettingsWifiActivity : BaseActivity() {
         }
 
         model.onLoading().observe(this) {
-            if (it && !binding.swiperefresh.isRefreshing) {
-                binding.progress.visible(true)
-            } else {
-                binding.swiperefresh.isRefreshing = false
-                binding.progress.invisible()
-            }
+            handleLoading(binding.swiperefresh, binding.progress, it)
         }
 
         model.onEditNameChange().observe(this) {
@@ -113,7 +67,7 @@ class DeviceSettingsWifiActivity : BaseActivity() {
         }
 
         model.onError().observe(this) {
-            binding.progress.visibility = View.INVISIBLE
+            binding.progress.invisible()
             showSnackbarMessage(binding.root, it.errorMessage, it.retryFunction)
         }
 
@@ -127,11 +81,15 @@ class DeviceSettingsWifiActivity : BaseActivity() {
         }
 
         binding.changeStationNameBtn.setOnClickListener {
-            onChangeStationName()
+            onChangeStationName(model.device) {
+                model.setOrClearFriendlyName(it)
+            }
         }
 
         binding.removeStationBtn.setOnClickListener {
-            onRemoveStation()
+            onRemoveStation(model.device) {
+                model.removeDevice()
+            }
         }
 
         binding.contactSupportBtn.setOnClickListener {
@@ -150,7 +108,7 @@ class DeviceSettingsWifiActivity : BaseActivity() {
             }
         )
 
-        setupStationLocation(false)
+        updateStationLocation(false)
     }
 
     override fun onResume() {
@@ -163,55 +121,20 @@ class DeviceSettingsWifiActivity : BaseActivity() {
         binding.devicePhotosCard.updateUI(devicePhotos)
         binding.devicePhotosCard.setOnClickListener(
             onClick = {
-                analytics.trackEventSelectContent(
-                    contentType = AnalyticsService.ParamValue.GO_TO_PHOTO_VERIFICATION.paramValue,
-                    Pair(
-                        FirebaseAnalytics.Param.SOURCE,
-                        AnalyticsService.ParamValue.SETTINGS.paramValue
-                    )
-                )
-                val photos = arrayListOf<String>()
-                devicePhotos.forEach {
-                    photos.add(it)
-                }
-                if (photos.isEmpty() || !model.getAcceptedPhotoTerms()) {
-                    navigator.showPhotoVerificationIntro(this, model.device, photos)
-                } else {
-                    navigator.showPhotoGallery(
-                        photoGalleryLauncher,
-                        this,
-                        model.device,
-                        photos,
-                        false
-                    )
-                }
+                onPhotosClicked(devicePhotos, model.getAcceptedPhotoTerms(), model.device)
             },
             onCancelUpload = {
-                analytics.trackEventUserAction(
-                    AnalyticsService.ParamValue.CANCEL_UPLOADING_PHOTOS.paramValue
-                )
-                ActionDialogFragment
-                    .Builder(
-                        title = getString(R.string.cancel_upload),
-                        message = getString(R.string.cancel_upload_message),
-                        negative = getString(R.string.action_back)
-                    )
-                    .onPositiveClick(getString(R.string.yes_cancel)) {
-                        // Trigger a refresh on the photos through the API
-                        UploadPhotoWorker.cancelWorkers(this, model.device.id)
-                        model.getDevicePhotoUploadIds().onEach {
-                            getCancelUploadIntent(it).send()
-                        }
-                        model.onPhotosChanged(false, null)
+                onPhotosCancelPrompt {
+                    // Trigger a refresh on the photos through the API
+                    UploadPhotoWorker.cancelWorkers(this, model.device.id)
+                    model.getDevicePhotoUploadIds().onEach {
+                        getCancelUploadIntent(it).send()
                     }
-                    .build()
-                    .show(this)
+                    model.onPhotosChanged(false, null)
+                }
             },
             onRetry = {
-                model.retryPhotoUpload()
-                analytics.trackEventUserAction(
-                    AnalyticsService.ParamValue.RETRY_UPLOADING_PHOTOS.paramValue
-                )
+                onPhotosRetry { model.retryPhotoUpload() }
             }
         )
         binding.devicePhotosCard.visible(true)
@@ -236,148 +159,59 @@ class DeviceSettingsWifiActivity : BaseActivity() {
         binding.recyclerStationInfo.adapter = stationAdapter
     }
 
-    private fun setupStationLocation(forceUpdateMinimap: Boolean) {
-        binding.editLocationBtn.setOnClickListener {
-            navigator.showEditLocation(editLocationLauncher, this, model.device)
-        }
-        binding.editLocationBtn.visible(model.device.isOwned())
-
-        if (model.device.relation == DeviceRelation.FOLLOWED) {
-            binding.locationDesc.setHtml(
-                R.string.station_location_favorite_desc, model.device.address ?: String.empty()
-            )
-        } else {
-            binding.locationDesc.setHtml(
-                R.string.station_location_desc,
-                model.device.address ?: String.empty()
-            )
-        }
+    private fun updateStationLocation(forceUpdateMinimap: Boolean) {
+        setupStationLocation(model.device, binding.editLocationBtn, binding.locationDesc)
 
         if (forceUpdateMinimap) {
-            updateMinimap()
+            updateMinimap(model.device, binding.locationLayout, binding.locationMinimap)
         } else {
             binding.locationLayout.applyOnGlobalLayout {
-                updateMinimap()
+                updateMinimap(model.device, binding.locationLayout, binding.locationMinimap)
             }
         }
-    }
-
-    private fun updateMinimap() {
-        val deviceMapLocation = if (model.device.isOwned()) {
-            model.device.location
-        } else {
-            null
-        }
-        getMinimap(binding.locationLayout.width, deviceMapLocation, model.device.hex7)?.let {
-            binding.locationMinimap.loadImage(imageLoader, it.toString())
-        } ?: binding.locationMinimap.visible(false)
-    }
-
-    private fun onRemoveStation() {
-        analytics.trackEventSelectContent(
-            AnalyticsService.ParamValue.REMOVE_DEVICE.paramValue,
-            Pair(FirebaseAnalytics.Param.ITEM_ID, model.device.id)
-        )
-        navigator.showPasswordPrompt(this, R.string.remove_station_password_message) {
-            if (it) {
-                Timber.d("Password confirmation success!")
-                model.removeDevice()
-            } else {
-                Timber.d("Password confirmation prompt was cancelled or failed.")
-            }
-        }
-    }
-
-    private fun onChangeStationName() {
-        FriendlyNameDialogFragment(model.device.friendlyName, model.device.id) {
-            model.setOrClearFriendlyName(it)
-        }.show(this)
     }
 
     private fun setupInfo() {
         binding.stationName.text = model.device.getDefaultOrFriendlyName()
         if (model.device.isOwned()) {
-            with(binding.removeStationDesc) {
-                movementMethod =
-                    me.saket.bettermovementmethod.BetterLinkMovementMethod.newInstance().apply {
-                        setOnLinkClickListener { _, url ->
-                            navigator.openWebsite(context, url)
-                            return@setOnLinkClickListener true
-                        }
-                    }
-                setHtml(
-                    R.string.remove_station_desc,
-                    getString(R.string.docs_url)
-                )
-            }
+            setupRemoveStationDescription(binding.removeStationDesc)
         } else {
             binding.deleteStationCard.visible(false)
         }
 
         model.onDeviceInfo().observe(this) { deviceInfo ->
             if (deviceInfo.station.any { it.deviceAlert?.alert == DeviceAlertType.LOW_BATTERY }) {
-                analytics.trackEventPrompt(
-                    AnalyticsService.ParamValue.LOW_BATTERY.paramValue,
-                    AnalyticsService.ParamValue.WARN.paramValue,
-                    AnalyticsService.ParamValue.VIEW.paramValue,
-                    Pair(FirebaseAnalytics.Param.ITEM_ID, model.device.id)
-                )
+                trackLowBatteryWarning(model.device.id)
             }
 
-            handleSplitRewards(deviceInfo.rewardSplit)
+            handleRewardSplits(
+                binding.rewardSplitCard,
+                binding.rewardSplitDesc,
+                binding.recyclerRewardSplit,
+                deviceInfo.rewardSplit,
+                model.isStakeholder(deviceInfo.rewardSplit),
+                model.device.isOwned()
+            )
 
             defaultAdapter.submitList(deviceInfo.default)
             gatewayAdapter.submitList(deviceInfo.gateway)
             stationAdapter.submitList(deviceInfo.station)
 
             binding.shareBtn.setOnClickListener {
-                navigator.openShare(this, model.parseDeviceInfoToShare(deviceInfo))
-
-                analytics.trackEventUserAction(
-                    actionName = AnalyticsService.ParamValue.SHARE_STATION_INFO.paramValue,
-                    contentType = AnalyticsService.ParamValue.STATION_INFO.paramValue,
-                    Pair(FirebaseAnalytics.Param.ITEM_ID, model.device.id)
-                )
+                onShare(model.parseDeviceInfoToShare(deviceInfo), model.device.id)
             }
         }
     }
 
-    private fun handleSplitRewards(data: RewardSplitsData?) {
-        if (data?.hasSplitRewards() == true) {
-            binding.rewardSplitCard.visible(true)
-            binding.rewardSplitDesc.text = getString(R.string.reward_split_desc, data.splits.size)
-            val rewardSplitAdapter = RewardSplitStakeholderAdapter(data.wallet, true)
-            binding.recyclerRewardSplit.adapter = rewardSplitAdapter
-            rewardSplitAdapter.submitList(data.splits)
-
-            val stakeHolderValue = if (model.isStakeholder(data)) {
-                AnalyticsService.ParamValue.STAKEHOLDER_LOWERCASE.paramValue
-            } else {
-                AnalyticsService.ParamValue.NON_STAKEHOLDER.paramValue
-            }
-            trackRewardSplitViewContent(
-                AnalyticsService.ParamValue.REWARD_SPLITTING.paramValue,
-                stakeHolderValue
-            )
-        } else {
-            val stakeHolderValue = if (model.device.isOwned()) {
-                AnalyticsService.ParamValue.STAKEHOLDER_LOWERCASE.paramValue
-            } else {
-                AnalyticsService.ParamValue.NON_STAKEHOLDER.paramValue
-            }
-            trackRewardSplitViewContent(
-                AnalyticsService.ParamValue.NO_REWARD_SPLITTING.paramValue,
-                stakeHolderValue
-            )
-        }
+    override fun onEditLocation(device: UIDevice) {
+        model.device = device
+        updateStationLocation(true)
     }
 
-    private fun trackRewardSplitViewContent(deviceState: String, userState: String) {
-        analytics.trackEventViewContent(
-            AnalyticsService.ParamValue.REWARD_SPLITTING_DEVICE_SETTINGS.paramValue,
-            contentId = null,
-            Pair(AnalyticsService.CustomParam.DEVICE_STATE.paramName, deviceState),
-            Pair(AnalyticsService.CustomParam.USER_STATE.paramName, userState)
-        )
+    override fun onPhotosChanged(
+        shouldDeleteAllPhotos: Boolean?,
+        photos: ArrayList<StationPhoto>?
+    ) {
+        model.onPhotosChanged(shouldDeleteAllPhotos, photos)
     }
 }


### PR DESCRIPTION
### **Why?**
Multiple code duplicates, try having a parent activity that will encapsulate most of the UI-related code in order to centralize it.

### **How?**
Create `BaseDeviceSettingsActivity` in order to capture most of the code that can be reused between the WiFi and Helium activities. Those two activities (`DeviceSettingsWifiActivity` and `DeviceSettingsHeliumActivity`) extend the `BaseDeviceSettingsActivity`.

### **Testing**
Play around with both WiFi and Helium station settings and make sure everything is working properly and nothings has broken.