### PR TITLE
Hide info annotation banner on rewards when reward score is >=99%

### DIFF
--- a/app/src/local/assets/mock_files/get_device_rewards.json
+++ b/app/src/local/assets/mock_files/get_device_rewards.json
@@ -5,7 +5,7 @@
         "base_reward": 2.34,
         "total_business_boost_reward": 1.23,
         "total_reward": 3.57,
-        "base_reward_score": 95,
+        "base_reward_score": 99,
         "annotation_summary": [
             {
                 "severity_level": "INFO",

--- a/app/src/main/java/com/weatherxm/data/models/ApiModels.kt
+++ b/app/src/main/java/com/weatherxm/data/models/ApiModels.kt
@@ -10,6 +10,7 @@ import com.weatherxm.ui.common.DeviceRelation
 import com.weatherxm.ui.common.DeviceTotalRewardsBoost
 import com.weatherxm.ui.common.UIDevice
 import com.weatherxm.ui.common.empty
+import com.weatherxm.util.Rewards.THRESHOLD_SCORE_TO_SHOW_ISSUES
 import kotlinx.parcelize.Parcelize
 import timber.log.Timber
 import java.time.LocalDate
@@ -576,6 +577,10 @@ data class Reward(
     companion object {
         fun initWithTimestamp(ts: ZonedDateTime?) = Reward(ts, null, null, null, null, null)
     }
+
+    fun shouldShowAnnotations() = !annotationSummary.isNullOrEmpty()
+        && baseRewardScore != null
+        && baseRewardScore < THRESHOLD_SCORE_TO_SHOW_ISSUES
 }
 
 @Keep
@@ -639,6 +644,10 @@ data class RewardDetails(
 
     fun isEmpty() = timestamp == null && totalDailyReward == null && base == null
         && boost == null && annotationSummary == null && rewardSplit == null
+
+    fun shouldShowAnnotations() = !annotationSummary.isNullOrEmpty()
+        && base?.rewardScore != null
+        && base.rewardScore < THRESHOLD_SCORE_TO_SHOW_ISSUES
 }
 
 @Keep

--- a/app/src/main/java/com/weatherxm/ui/components/compose/DailyRewardsView.kt
+++ b/app/src/main/java/com/weatherxm/ui/components/compose/DailyRewardsView.kt
@@ -52,14 +52,17 @@ fun DailyRewardsView(
     val sortedSeverities = data.annotationSummary?.map {
         it.severityLevel
     }?.sortedByDescending { it }?.filterNotNull()
-    val topSeverity = sortedSeverities?.getOrNull(0)
 
-    val border = topSeverity?.let {
-        when (it) {
-            SeverityLevel.ERROR -> BorderStroke(1.dp, colorResource(R.color.error))
-            SeverityLevel.WARNING -> BorderStroke(1.dp, colorResource(R.color.warning))
-            SeverityLevel.INFO -> BorderStroke(1.dp, colorResource(R.color.infoStrokeColor))
+    val border = if (data.shouldShowAnnotations()) {
+        sortedSeverities?.getOrNull(0)?.let {
+            when (it) {
+                SeverityLevel.ERROR -> BorderStroke(1.dp, colorResource(R.color.error))
+                SeverityLevel.WARNING -> BorderStroke(1.dp, colorResource(R.color.warning))
+                SeverityLevel.INFO -> BorderStroke(1.dp, colorResource(R.color.infoStrokeColor))
+            }
         }
+    } else {
+        null
     }
 
     if (onCardClick != null) {
@@ -156,7 +159,7 @@ private fun DailyRewardsContents(
                     }
                 }
 
-                if (onViewDetails != null && data.annotationSummary.isNullOrEmpty()) {
+                if (onViewDetails != null && !data.shouldShowAnnotations()) {
                     Button(
                         onClick = { onViewDetails() },
                         colors = ButtonDefaults.buttonColors(
@@ -178,11 +181,11 @@ private fun DailyRewardsContents(
             }
         }
 
-        if (!sortedSeverities.isNullOrEmpty() && data.annotationSummary != null) {
+        if (!sortedSeverities.isNullOrEmpty() && data.shouldShowAnnotations()) {
             val annotationMessage = getAnnotationMessage(
                 useShortAnnotationText,
                 sortedSeverities,
-                data.annotationSummary.size
+                data.annotationSummary?.size!!
             )
 
             MessageCardView(

--- a/app/src/main/java/com/weatherxm/ui/rewarddetails/RewardDetailsActivity.kt
+++ b/app/src/main/java/com/weatherxm/ui/rewarddetails/RewardDetailsActivity.kt
@@ -123,7 +123,7 @@ class RewardDetailsActivity : BaseActivity(), RewardBoostListener {
 
         handleSplitRewards(data)
 
-        updateIssues(sortedIssues)
+        updateIssues(data, sortedIssues)
 
         data.base?.qodScore?.let {
             updateDataQualityCard(it)
@@ -194,8 +194,8 @@ class RewardDetailsActivity : BaseActivity(), RewardBoostListener {
         )
     }
 
-    private fun updateIssues(sortedIssues: List<RewardsAnnotationGroup>?) {
-        if (sortedIssues.isNullOrEmpty()) {
+    private fun updateIssues(data: RewardDetails, sortedIssues: List<RewardsAnnotationGroup>?) {
+        if (sortedIssues.isNullOrEmpty() || !data.shouldShowAnnotations()) {
             binding.issuesTitle.visible(false)
             binding.issuesDesc.visible(false)
             binding.issueCard.visible(false)

--- a/app/src/main/java/com/weatherxm/util/Rewards.kt
+++ b/app/src/main/java/com/weatherxm/util/Rewards.kt
@@ -6,6 +6,7 @@ import com.weatherxm.ui.common.AnnotationGroupCode
 import com.weatherxm.ui.common.ErrorType
 
 object Rewards {
+    const val THRESHOLD_SCORE_TO_SHOW_ISSUES = 99
 
     @Suppress("MagicNumber")
     fun metricsErrorType(score: Int?, polReason: AnnotationGroupCode?): ErrorType? {


### PR DESCRIPTION
### **Why?**
Hide warning banner when stations has 99% score

### **How?**
Created `shouldShowAnnotations` functions in the respective models and call them before showing any annotations.

### **Testing**
Play with mock `get_device_rewards.json` and `get_device_reward_details.json` and ensure the annotations are not shown when reward or QoD score is 99% or 100%.
