### PR TITLE
On Delete photo -> wait for API response before deleting it from Gallery

### DIFF
--- a/app/src/main/java/com/weatherxm/ui/photoverification/gallery/PhotoGalleryActivity.kt
+++ b/app/src/main/java/com/weatherxm/ui/photoverification/gallery/PhotoGalleryActivity.kt
@@ -34,6 +34,7 @@ import com.weatherxm.ui.common.Contracts
 import com.weatherxm.ui.common.Contracts.ARG_DEVICE
 import com.weatherxm.ui.common.Contracts.ARG_NEW_PHOTO_VERIFICATION
 import com.weatherxm.ui.common.StationPhoto
+import com.weatherxm.ui.common.Status
 import com.weatherxm.ui.common.UIDevice
 import com.weatherxm.ui.common.disable
 import com.weatherxm.ui.common.empty
@@ -139,6 +140,13 @@ class PhotoGalleryActivity : BaseActivity() {
             Thumbnails()
         }
 
+        model.onDeletingPhotoStatus().observe(this) {
+            binding.loading.visible(it.status == Status.LOADING)
+            if (it.status == Status.ERROR && it.message != null) {
+                showSnackbarMessage(binding.root, it.message)
+            }
+        }
+
         if (model.photos.isEmpty()) {
             binding.addPhotoBtn.performClick()
         }
@@ -241,13 +249,11 @@ class PhotoGalleryActivity : BaseActivity() {
                     .onPositiveClick(getString(R.string.action_delete)) {
                         setResult(false)
                         model.deletePhoto(it)
-                        selectedPhoto.value = null
                     }
                     .build()
                     .show(this)
             } else {
                 model.deletePhoto(it)
-                selectedPhoto.value = null
             }
         }
     }

--- a/app/src/main/res/layout/activity_photo_gallery.xml
+++ b/app/src/main/res/layout/activity_photo_gallery.xml
@@ -38,6 +38,14 @@
 
     </com.google.android.material.appbar.AppBarLayout>
 
+    <com.google.android.material.progressindicator.LinearProgressIndicator
+        android:id="@+id/loading"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:visibility="gone"
+        app:layout_behavior="com.google.android.material.appbar.AppBarLayout$ScrollingViewBehavior"
+        tools:visibility="visible" />
+
     <androidx.constraintlayout.widget.ConstraintLayout
         android:layout_width="match_parent"
         android:layout_height="match_parent"


### PR DESCRIPTION
### **Why?**
On Delete photo -> wait for API response before deleting it from Gallery

### **How?**
Wait for API before deleting a remote photo. also add linear loader and snackbar in case of error.

### **Testing**
Perform photo deletions and ensure everything looks OK with/without error (e.g. with error = no connection or replace an argument in `usecase.deleteDevicePhoto` in the ViewModel's call place with an invalid one).