### PR TITLE
Fix background color of terms dialog in dark mode

### DIFF
--- a/app/src/main/java/com/weatherxm/ui/components/compose/TermsDialog.kt
+++ b/app/src/main/java/com/weatherxm/ui/components/compose/TermsDialog.kt
@@ -32,8 +32,7 @@ fun TermsDialog(shouldShow: Boolean, onUnderstand: () -> Unit) {
     if (shouldShow) {
         AlertDialog(
             modifier = Modifier.padding(horizontal = dimensionResource(R.dimen.padding_normal)),
-            containerColor = MaterialTheme.colorScheme.surface,
-            titleContentColor = MaterialTheme.colorScheme.onSurface,
+            containerColor = colorResource(R.color.colorSurface),
             onDismissRequest = { },
             title = {
                 Text(


### PR DESCRIPTION
### **Why?**
Fix background color of terms dialog in dark mode

### **How?**
`MaterialTheme.colorScheme.surface` ---> `colorResource(R.color.colorSurface)`

### **Testing**
Check that it looks OK in both themes.