### PR TITLE
Remove super.onReceive from our 3 widgets.

### DIFF
--- a/app/src/main/java/com/weatherxm/ui/widgets/currentweather/CurrentWeatherWidget.kt
+++ b/app/src/main/java/com/weatherxm/ui/widgets/currentweather/CurrentWeatherWidget.kt
@@ -44,8 +44,6 @@ class CurrentWeatherWidget : AppWidgetProvider(), KoinComponent {
      */
     @Suppress("MagicNumber")
     override fun onReceive(context: Context, intent: Intent?) {
-        super.onReceive(context, intent)
-
         // These variables are useful for identifying what type of update to do
         val extras = intent?.extras
         val appWidgetId =

--- a/app/src/main/java/com/weatherxm/ui/widgets/currentweather/CurrentWeatherWidgetDetailed.kt
+++ b/app/src/main/java/com/weatherxm/ui/widgets/currentweather/CurrentWeatherWidgetDetailed.kt
@@ -44,8 +44,6 @@ class CurrentWeatherWidgetDetailed : AppWidgetProvider(), KoinComponent {
      */
     @Suppress("MagicNumber")
     override fun onReceive(context: Context, intent: Intent?) {
-        super.onReceive(context, intent)
-
         // These variables are useful for identifying what type of update to do
         val extras = intent?.extras
         val appWidgetId =

--- a/app/src/main/java/com/weatherxm/ui/widgets/currentweather/CurrentWeatherWidgetTile.kt
+++ b/app/src/main/java/com/weatherxm/ui/widgets/currentweather/CurrentWeatherWidgetTile.kt
@@ -39,8 +39,6 @@ class CurrentWeatherWidgetTile : AppWidgetProvider(), KoinComponent {
 
     @Suppress("MagicNumber")
     override fun onReceive(context: Context, intent: Intent?) {
-        super.onReceive(context, intent)
-
         // These variables are useful for identifying what type of update to do
         val extras = intent?.extras
         val appWidgetId =


### PR DESCRIPTION
### **Why?**
There were some weird cases of widgets getting in an "empty"/undefined state in some cases (e.g. when clearing cache + data of the app). In this PR we are fixing this.

### **How?**
Remove `super.onReceive` from our 3 widgets so all the updates in our code take place through our custom overrides in `onReceive`.

### **Testing**
Check the states of a widget(s) and ensure everything is OK, e.g.:
1. Showing the weather
2. Logged out
3. Delete a widget
4. Add widgets and then clear the app's data & cache 
5. Add a widget of a favorite station and then unfollow it
