### PR TITLE
Add screen view events in station photo verification

### DIFF
--- a/app/src/main/java/com/weatherxm/analytics/AnalyticsService.kt
+++ b/app/src/main/java/com/weatherxm/analytics/AnalyticsService.kt
@@ -65,7 +65,10 @@ interface AnalyticsService {
         DEVICE_FORECAST_DETAILS("Device Forecast Details"),
         CLAIM_DAPP("Claim Dapp"),
         TEMPERATURE_BARS_EXPLANATION("Temperature Bars Explanation"),
-        REWARD_ANALYTICS("Reward Analytics")
+        REWARD_ANALYTICS("Reward Analytics"),
+        STATION_PHOTOS_INSTRUCTIONS("Station Photos Instructions"),
+        STATION_PHOTOS_INTRO("Station Photos Intro"),
+        STATION_PHOTOS_GALLERY("Station Photos Gallery")
     }
 
     // Custom Event Names

--- a/app/src/main/java/com/weatherxm/ui/photoverification/gallery/PhotoGalleryActivity.kt
+++ b/app/src/main/java/com/weatherxm/ui/photoverification/gallery/PhotoGalleryActivity.kt
@@ -36,6 +36,7 @@ import com.weatherxm.ui.common.Contracts.ARG_NEW_PHOTO_VERIFICATION
 import com.weatherxm.ui.common.StationPhoto
 import com.weatherxm.ui.common.Status
 import com.weatherxm.ui.common.UIDevice
+import com.weatherxm.ui.common.classSimpleName
 import com.weatherxm.ui.common.disable
 import com.weatherxm.ui.common.empty
 import com.weatherxm.ui.common.enable
@@ -150,6 +151,7 @@ class PhotoGalleryActivity : BaseActivity() {
         if (model.photos.isEmpty()) {
             binding.addPhotoBtn.performClick()
         }
+        analytics.trackScreen(AnalyticsService.Screen.STATION_PHOTOS_GALLERY, classSimpleName())
     }
 
     override fun onResume() {

--- a/app/src/main/java/com/weatherxm/ui/photoverification/intro/PhotoVerificationIntroActivity.kt
+++ b/app/src/main/java/com/weatherxm/ui/photoverification/intro/PhotoVerificationIntroActivity.kt
@@ -9,6 +9,7 @@ import com.weatherxm.ui.common.Contracts
 import com.weatherxm.ui.common.Contracts.ARG_DEVICE
 import com.weatherxm.ui.common.Contracts.ARG_INSTRUCTIONS_ONLY
 import com.weatherxm.ui.common.UIDevice
+import com.weatherxm.ui.common.classSimpleName
 import com.weatherxm.ui.common.parcelable
 import com.weatherxm.ui.components.ActionDialogFragment
 import com.weatherxm.ui.components.BaseActivity
@@ -41,6 +42,15 @@ class PhotoVerificationIntroActivity : BaseActivity() {
         if (viewModel.getAcceptedTerms() && !instructionsOnly) {
             navigator.showPhotoGallery(null, this, device, stationPhotoUrls, true)
             finish()
+        }
+        if (instructionsOnly) {
+            analytics.trackScreen(
+                AnalyticsService.Screen.STATION_PHOTOS_INSTRUCTIONS, classSimpleName()
+            )
+        } else {
+            analytics.trackScreen(
+                AnalyticsService.Screen.STATION_PHOTOS_INTRO, classSimpleName()
+            )
         }
     }
 


### PR DESCRIPTION
### **Why?**
Add screen view events in station photo verification

### **How?**
1. "Station Photos Instructions"  - For the instructions screen when terms are NOT visible.
2. "Station Photos Intro"  - For the instructions screen when terms are visible, e.g. on the first time we open this screen.
3. "Station Photos Gallery" - For the gallery screen

### **Testing**
Ensure that events are logged properly.