### PR TITLE
Fixes on analytics initialization

### DIFF
--- a/app/src/main/java/com/weatherxm/analytics/AnalyticsWrapper.kt
+++ b/app/src/main/java/com/weatherxm/analytics/AnalyticsWrapper.kt
@@ -2,6 +2,7 @@ package com.weatherxm.analytics
 
 import android.content.Context
 import com.google.firebase.analytics.FirebaseAnalytics
+import com.weatherxm.data.services.CacheService
 import com.weatherxm.ui.common.DevicesFilterType
 import com.weatherxm.ui.common.DevicesGroupBy
 import com.weatherxm.ui.common.DevicesSortFilterOptions
@@ -21,6 +22,17 @@ class AnalyticsWrapper(
     private var devicesSortFilterOptions: List<String> = mutableListOf()
     private var devicesOwn: Int = 0
     private var hasWallet: Boolean = false
+
+    fun bindCacheService(cacheService: CacheService) {
+        cacheService.setUserPropertiesChangeListener { key, value ->
+            when (key) {
+                CacheService.KEY_DEVICES_OWN -> setDevicesOwn(value as Int)
+                CacheService.KEY_HAS_WALLET -> setHasWallet(value as Boolean)
+                CacheService.KEY_USER_ID -> setUserId(value as String)
+            }
+            setUserProperties()
+        }
+    }
 
     fun setDevicesOwn(devicesOwn: Int) {
         this.devicesOwn = devicesOwn

--- a/app/src/main/java/com/weatherxm/app/AnalyticsInitializer.kt
+++ b/app/src/main/java/com/weatherxm/app/AnalyticsInitializer.kt
@@ -16,6 +16,7 @@ class AnalyticsInitializer : Initializer<Unit>, KoinComponent {
         Timber.d("Basic configuration for Analytics Wrapper")
         val enabled = cacheService.getAnalyticsEnabled()
         Timber.d("Initializing Analytics [enabled=$enabled]")
+        analyticsWrapper.bindCacheService(cacheService)
         analyticsWrapper.setAnalyticsEnabled(enabled)
         analyticsWrapper.setUserId(cacheService.getUserId())
         analyticsWrapper.setDevicesSortFilterOptions(cacheService.getDevicesSortFilterOptions())

--- a/app/src/main/java/com/weatherxm/data/Modules.kt
+++ b/app/src/main/java/com/weatherxm/data/Modules.kt
@@ -601,20 +601,20 @@ val database = module {
 }
 
 val analytics = module {
-    single<FirebaseAnalytics> {
+    single<FirebaseAnalytics>(createdAtStart = true) {
         Firebase.analytics
     }
 
-    single<MixpanelAPI> {
+    single<MixpanelAPI>(createdAtStart = true) {
         MixpanelAPI.getInstance(androidContext(), BuildConfig.MIXPANEL_TOKEN, false).apply {
             setEnableLogging(true)
         }
     }
 
-    factoryOf(::FirebaseAnalyticsService) { bind<AnalyticsService>() }
-    factoryOf(::MixpanelAnalyticsService) { bind<AnalyticsService>() }
+    singleOf(::FirebaseAnalyticsService) { bind<AnalyticsService>() }
+    singleOf(::MixpanelAnalyticsService) { bind<AnalyticsService>() }
 
-    single<AnalyticsWrapper> {
+    single<AnalyticsWrapper>(createdAtStart = true) {
         AnalyticsWrapper(getAll<AnalyticsService>(), androidContext())
     }
 }

--- a/app/src/main/java/com/weatherxm/data/services/CacheService.kt
+++ b/app/src/main/java/com/weatherxm/data/services/CacheService.kt
@@ -79,6 +79,12 @@ class CacheService(
     private var userStationsIds = listOf<String>()
     private var countriesInfo = listOf<CountryInfo>()
 
+    private var onUserPropertiesChangeListener: ((String, Any) -> Unit)? = null
+
+    fun setUserPropertiesChangeListener(listener: (String, Any) -> Unit) {
+        onUserPropertiesChangeListener = listener
+    }
+
     fun getAuthToken(): Either<Failure, AuthToken> {
         val access = encryptedPreferences.getString(KEY_ACCESS, null)
         val refresh = encryptedPreferences.getString(KEY_REFRESH, null)
@@ -163,6 +169,7 @@ class CacheService(
     fun setWalletAddress(address: String) {
         this.walletAddress = address
         preferences.edit().putBoolean(KEY_HAS_WALLET, true).apply()
+        onUserPropertiesChangeListener?.invoke(KEY_HAS_WALLET, true)
     }
 
     fun hasWallet(): Boolean {
@@ -175,6 +182,7 @@ class CacheService(
 
     fun setUser(user: User) {
         preferences.edit().putString(KEY_USER_ID, user.id).apply()
+        onUserPropertiesChangeListener?.invoke(KEY_USER_ID, user.id)
         this.user = user
     }
 
@@ -333,6 +341,7 @@ class CacheService(
     fun setUserDevicesIds(ids: List<String>) {
         userStationsIds = ids
         preferences.edit().putInt(KEY_DEVICES_OWN, ids.size).apply()
+        onUserPropertiesChangeListener?.invoke(KEY_DEVICES_OWN, ids.size)
     }
 
     fun getDevicesOwn(): Int {


### PR DESCRIPTION
### **Why?**
Events and user parameters were not being sent correctly (or not sent at all).

### **How?**
1. Create all components related to Analytics at start-up, as `createdAtStart = true` indicates.
2. Add a listener in `CacheService` and bind it to `AnalyticsWrapper` whenever a user-property-related param changes, to change it in the analytics as well.

### **Testing**
Been tested already with John and Giannis, so it's a PR to merge it and hopefully everything will work in production as well. Just make sure the code looks OK.