### PR TITLE
Add backPressedDispatcher callback in Photo Verification Intro Activity

### DIFF
--- a/app/src/main/java/com/weatherxm/ui/photoverification/intro/PhotoVerificationIntroActivity.kt
+++ b/app/src/main/java/com/weatherxm/ui/photoverification/intro/PhotoVerificationIntroActivity.kt
@@ -2,6 +2,7 @@ package com.weatherxm.ui.photoverification.intro
 
 import android.annotation.SuppressLint
 import android.os.Bundle
+import androidx.activity.addCallback
 import com.weatherxm.R
 import com.weatherxm.analytics.AnalyticsService
 import com.weatherxm.databinding.ActivityPhotoVerificationIntroBinding
@@ -63,6 +64,12 @@ class PhotoVerificationIntroActivity : BaseActivity() {
                     finish()
                 }
             } else {
+                onBackPressedDispatcher.addCallback {
+                    analytics.trackEventUserAction(
+                        AnalyticsService.ParamValue.EXIT_PHOTO_VERIFICATION.paramValue
+                    )
+                    finish()
+                }
                 onIntroScreen(
                     onClose = {
                         ActionDialogFragment


### PR DESCRIPTION
### **Why?**
Capture system's back press on Photo Verification Intro to track the respective event

### **How?**
Added a handler when back button is pressed.

### **Testing**
Opening the photo verification intro and clicking the system's back button should trigger the new code and track the event in analytics.