### PR TITLE
Only emit the success events once in photo uploading

### DIFF
--- a/app/src/main/java/com/weatherxm/service/GlobalUploadObserverService.kt
+++ b/app/src/main/java/com/weatherxm/service/GlobalUploadObserverService.kt
@@ -24,6 +24,7 @@ class GlobalUploadObserverService(
 ) : RequestObserverDelegate {
     private var device = UIDevice.empty()
     private var numberOfPhotosToUpload = 0
+    private var currentUploadedPhotos = 0
     private var photosProgress = mutableMapOf<String, Int>()
     private val onUploadPhotosState = MutableSharedFlow<UploadPhotosState>(
         replay = 1,
@@ -57,8 +58,9 @@ class GlobalUploadObserverService(
     ) {
         Timber.d("[UPLOAD SERVICE] Success: $serverResponse | $uploadInfo")
         photosProgress[uploadInfo.uploadId] = uploadInfo.progressPercent
+        currentUploadedPhotos += 1
 
-        if (getAverageProgress() == 100 && photosProgress.size == numberOfPhotosToUpload) {
+        if (getAverageProgress() == 100 && currentUploadedPhotos == numberOfPhotosToUpload) {
             Timber.d("[UPLOAD SERVICE] All photos uploaded successfully.")
             analytics.trackEventViewContent(
                 contentName = AnalyticsService.ParamValue.UPLOADING_PHOTOS_SUCCESS.paramValue,
@@ -130,6 +132,7 @@ class GlobalUploadObserverService(
     fun setData(device: UIDevice, numberOfPhotosToUpload: Int) {
         this.device = device
         this.numberOfPhotosToUpload = numberOfPhotosToUpload
+        this.currentUploadedPhotos = 0
         photosProgress = mutableMapOf()
     }
 


### PR DESCRIPTION
### **Why?**
`UPLOADING_PHOTOS_SUCCESS` gets tracked as many as the photos uploaded are

### **How?**
Created a new variable `currentUploadedPhotos` where we track how many photos have been uploaded and emit the success event (and its tracking analytics) only once at the end of the uploading flow.

### **Testing**
Make some uploads and ensure:
1. Everything is OK
2. The respective code, the success event and the `UPLOADING_PHOTOS_SUCCESS` runs only once at the end.
