### PR TITLE
Catch two obvious crashes in OTA and Change Frequency

### DIFF
--- a/app/src/main/java/com/weatherxm/data/models/Failure.kt
+++ b/app/src/main/java/com/weatherxm/data/models/Failure.kt
@@ -39,6 +39,7 @@ sealed class Failure(val code: String? = null) {
     object CountryNotFound : Failure()
     object InvalidRefreshTokenError : Failure()
     object InstallationIdNotFound : Failure()
+    object FirmwareBytesParsingError : Failure()
 }
 
 @Keep

--- a/app/src/main/java/com/weatherxm/ui/claimdevice/helium/frequency/ClaimHeliumFrequencyFragment.kt
+++ b/app/src/main/java/com/weatherxm/ui/claimdevice/helium/frequency/ClaimHeliumFrequencyFragment.kt
@@ -35,7 +35,7 @@ class ClaimHeliumFrequencyFragment : BaseFragment() {
                 navigator.openWebsite(context, it)
             },
             onBack = {
-               // parentModel.backToLocation()
+                // Do nothing. Not applicable.
             },
             onSet = {
                 parentModel.setFrequency(

--- a/app/src/main/java/com/weatherxm/ui/components/HeliumSetFrequencyView.kt
+++ b/app/src/main/java/com/weatherxm/ui/components/HeliumSetFrequencyView.kt
@@ -99,11 +99,15 @@ class HeliumSetFrequencyView : LinearLayout {
         }
 
         binding.setButton.setOnClickListener {
-            onSet(binding.frequenciesSelector.selectedItemPosition)
+            binding.frequenciesSelector.selectedItemPosition.also {
+                if (it >= 0) onSet(it)
+            }
         }
 
         binding.changeButton.setOnClickListener {
-            onSet(binding.frequenciesSelector.selectedItemPosition)
+            binding.frequenciesSelector.selectedItemPosition.also {
+                if (it >= 0) onSet(it)
+            }
         }
     }
 }


### PR DESCRIPTION
### **Why?**
Catch two obvious crashes in OTA and Change Frequency

### **How?**
1. Catch `IOException` that the `bytes()` function might throw.
2. Do not fire the `onSet` listener when the selected item position is `INVALID_POSITION == -1` (i.e. a frequency NOT selected yet)

### **Testing**
Not sure, I didn't manage to reproduce either of them. You can try to reproduce the second one by commenting out the line 77 in `ChangeFrequencyViewModel`, no idea how a user has actually reproduced it though. I fixed the end result of it.
