### PR TITLE
FE-1708 FE-1707 Fixes on "Add Photo" button

### DIFF
--- a/app/src/main/java/com/weatherxm/analytics/AnalyticsService.kt
+++ b/app/src/main/java/com/weatherxm/analytics/AnalyticsService.kt
@@ -270,7 +270,9 @@ interface AnalyticsService {
         UPLOADING_PHOTOS_SUCCESS("Uploading Photos Success"),
         GO_TO_PHOTO_VERIFICATION("Go To Photo Verification"),
         CLAIMING_ID("claiming"),
-        ANNOUNCEMENT_BUTTON("Announcement Button")
+        ANNOUNCEMENT_BUTTON("Announcement Button"),
+        STARTED("started"),
+        COMPLETED("completed")
     }
 
     // Custom Param Names

--- a/app/src/main/java/com/weatherxm/ui/photoverification/gallery/PhotoGalleryActivity.kt
+++ b/app/src/main/java/com/weatherxm/ui/photoverification/gallery/PhotoGalleryActivity.kt
@@ -72,6 +72,14 @@ class PhotoGalleryActivity : BaseActivity() {
     private val cameraLauncher =
         registerForActivityResult(ActivityResultContracts.StartActivityForResult()) {
             if (it.resultCode == RESULT_OK) {
+                analytics.trackEventUserAction(
+                    AnalyticsService.ParamValue.ADD_STATION_PHOTO.paramValue,
+                    null,
+                    Pair(
+                        AnalyticsService.CustomParam.ACTION.paramName,
+                        AnalyticsService.ParamValue.COMPLETED.paramValue
+                    )
+                )
                 model.addPhoto(latestPhotoTakenPath)
             }
         }
@@ -149,7 +157,7 @@ class PhotoGalleryActivity : BaseActivity() {
         }
 
         if (model.photos.isEmpty()) {
-            binding.addPhotoBtn.performClick()
+            getCameraPermissions()
         }
         analytics.trackScreen(AnalyticsService.Screen.STATION_PHOTOS_GALLERY, classSimpleName())
     }
@@ -217,7 +225,12 @@ class PhotoGalleryActivity : BaseActivity() {
         } else {
             binding.addPhotoBtn.setOnClickListener {
                 analytics.trackEventUserAction(
-                    AnalyticsService.ParamValue.ADD_STATION_PHOTO.paramValue
+                    AnalyticsService.ParamValue.ADD_STATION_PHOTO.paramValue,
+                    null,
+                    Pair(
+                        AnalyticsService.CustomParam.ACTION.paramName,
+                        AnalyticsService.ParamValue.STARTED.paramValue
+                    )
                 )
                 getCameraPermissions()
             }


### PR DESCRIPTION
### **Why?**
1. Needs to split "Add Photo event to two events.
2. Add Photo doesn't seem to be clicked automatically 100% when gallery is empty

### **How?**
1. Added the `ACTION` param with values `STARTED` and `COMPLETED` for each different action (before and after photo is taken).
2. Fixed the listener when photos are empty at `onCreate`

### **Testing**
1. Ensure both events are logged properly
2. Ensure that camera opens automatically when the gallery is empty and user has already accepted the permissons.