### PR TITLE
Pro promotional banner not visible when you go to map

### DIFF
--- a/app/src/main/java/com/weatherxm/ui/home/HomeActivity.kt
+++ b/app/src/main/java/com/weatherxm/ui/home/HomeActivity.kt
@@ -197,6 +197,7 @@ class HomeActivity : BaseActivity(), BaseMapFragment.OnMapDebugInfoListener {
         if (snackbar?.isShown == true) snackbar?.dismiss()
         when (destination.id) {
             R.id.navigation_devices -> {
+                model.getRemoteBanners()
                 checkForNoDevices()
                 binding.addDevice.show()
             }


### PR DESCRIPTION
### **How?**
Fetch banners whenever user returns to the device list

### **Testing**
Ensure that the promotional banner is visible when going to the map or the profile and return to the devices list.