### PR TITLE
Track "Click on Chips" select content event only on chip click

### DIFF
--- a/app/src/main/java/com/weatherxm/ui/devicedetails/DeviceDetailsActivity.kt
+++ b/app/src/main/java/com/weatherxm/ui/devicedetails/DeviceDetailsActivity.kt
@@ -290,19 +290,19 @@ class DeviceDetailsActivity : BaseActivity() {
     }
 
     private fun setupAlertChipClickListener(analyticsItemId: String?) {
-        analyticsItemId?.let {
-            analytics.trackEventSelectContent(
-                AnalyticsService.ParamValue.WARNINGS.paramValue,
-                customParams = arrayOf(
-                    Pair(
-                        AnalyticsService.CustomParam.CONTENT_NAME.paramName,
-                        AnalyticsService.ParamValue.STATION_DETAILS_CHIP.paramValue
-                    ),
-                    Pair(FirebaseAnalytics.Param.ITEM_ID, it)
-                )
-            )
-        }
         binding.alertChip.setOnClickListener {
+            analyticsItemId?.let {
+                analytics.trackEventSelectContent(
+                    AnalyticsService.ParamValue.WARNINGS.paramValue,
+                    customParams = arrayOf(
+                        Pair(
+                            AnalyticsService.CustomParam.CONTENT_NAME.paramName,
+                            AnalyticsService.ParamValue.STATION_DETAILS_CHIP.paramValue
+                        ),
+                        Pair(FirebaseAnalytics.Param.ITEM_ID, it)
+                    )
+                )
+            }
             navigator.showDeviceAlerts(this, model.device)
         }
     }


### PR DESCRIPTION
### **Why?**
Select content event on `Click on Chips` is tracked always instead of only when a click happens in the chips.

### **How?**
Moved the respective code inside the click listener.

### **Testing**
Ensure the event is tracked ONLY on click on the chips.