### PR TITLE
Analytics labels for audience Implementation

### DIFF
--- a/app/src/main/java/com/weatherxm/analytics/AnalyticsService.kt
+++ b/app/src/main/java/com/weatherxm/analytics/AnalyticsService.kt
@@ -304,7 +304,8 @@ interface AnalyticsService {
         HPA("hpa"),
         INHG("inhg"),
         STATIONS_OWN("STATIONS_OWN"),
-        HAS_WALLET("HAS_WALLET")
+        HAS_WALLET("HAS_WALLET"),
+        STATIONS_FAVORITE("STATIONS_FAVORITE"),
     }
 
     fun setUserId(userId: String)

--- a/app/src/main/java/com/weatherxm/analytics/AnalyticsWrapper.kt
+++ b/app/src/main/java/com/weatherxm/analytics/AnalyticsWrapper.kt
@@ -22,6 +22,7 @@ class AnalyticsWrapper(
     private var devicesSortFilterOptions: List<String> = mutableListOf()
     private var devicesOwn: Int = 0
     private var devicesFavorite: Int = 0
+    private var deviceBundlesOwn: MutableMap<String, Int> = mutableMapOf()
     private var hasWallet: Boolean = false
 
     fun bindCacheService(cacheService: CacheService) {
@@ -31,6 +32,11 @@ class AnalyticsWrapper(
                 CacheService.KEY_DEVICES_FAVORITE -> setDevicesFavorite(value as Int)
                 CacheService.KEY_HAS_WALLET -> setHasWallet(value as Boolean)
                 CacheService.KEY_USER_ID -> setUserId(value as String)
+                else -> {
+                    if (key.startsWith(CacheService.KEY_DEVICES_OWN)) {
+                        setDeviceBundlesOwn(key.substringAfterLast("_"), value as Int)
+                    }
+                }
             }
             setUserProperties()
         }
@@ -38,6 +44,10 @@ class AnalyticsWrapper(
 
     fun setDevicesOwn(devicesOwn: Int) {
         this.devicesOwn = devicesOwn
+    }
+
+    fun setDeviceBundlesOwn(key: String, value: Int) {
+        deviceBundlesOwn[key] = value
     }
 
     fun setDevicesFavorite(devicesFavorite: Int) {
@@ -167,6 +177,15 @@ class AnalyticsWrapper(
         userParams.add(
             Pair(AnalyticsService.UserProperty.STATIONS_OWN.propertyName, devicesOwn.toString())
         )
+
+        deviceBundlesOwn.forEach { (key, value) ->
+            userParams.add(
+                Pair(
+                    "${AnalyticsService.UserProperty.STATIONS_OWN.propertyName}_${key.uppercase()}",
+                    value.toString()
+                )
+            )
+        }
 
         userParams.add(
             Pair(

--- a/app/src/main/java/com/weatherxm/analytics/AnalyticsWrapper.kt
+++ b/app/src/main/java/com/weatherxm/analytics/AnalyticsWrapper.kt
@@ -21,12 +21,14 @@ class AnalyticsWrapper(
     private var displayMode: String = AnalyticsService.UserProperty.SYSTEM.propertyName
     private var devicesSortFilterOptions: List<String> = mutableListOf()
     private var devicesOwn: Int = 0
+    private var devicesFavorite: Int = 0
     private var hasWallet: Boolean = false
 
     fun bindCacheService(cacheService: CacheService) {
         cacheService.setUserPropertiesChangeListener { key, value ->
             when (key) {
                 CacheService.KEY_DEVICES_OWN -> setDevicesOwn(value as Int)
+                CacheService.KEY_DEVICES_FAVORITE -> setDevicesFavorite(value as Int)
                 CacheService.KEY_HAS_WALLET -> setHasWallet(value as Boolean)
                 CacheService.KEY_USER_ID -> setUserId(value as String)
             }
@@ -36,6 +38,10 @@ class AnalyticsWrapper(
 
     fun setDevicesOwn(devicesOwn: Int) {
         this.devicesOwn = devicesOwn
+    }
+
+    fun setDevicesFavorite(devicesFavorite: Int) {
+        this.devicesFavorite = devicesFavorite
     }
 
     fun setHasWallet(hasWallet: Boolean) {
@@ -160,6 +166,13 @@ class AnalyticsWrapper(
 
         userParams.add(
             Pair(AnalyticsService.UserProperty.STATIONS_OWN.propertyName, devicesOwn.toString())
+        )
+
+        userParams.add(
+            Pair(
+                AnalyticsService.UserProperty.STATIONS_FAVORITE.propertyName,
+                devicesFavorite.toString()
+            )
         )
 
         userParams.add(

--- a/app/src/main/java/com/weatherxm/app/AnalyticsInitializer.kt
+++ b/app/src/main/java/com/weatherxm/app/AnalyticsInitializer.kt
@@ -21,6 +21,9 @@ class AnalyticsInitializer : Initializer<Unit>, KoinComponent {
         analyticsWrapper.setUserId(cacheService.getUserId())
         analyticsWrapper.setDevicesSortFilterOptions(cacheService.getDevicesSortFilterOptions())
         analyticsWrapper.setDevicesOwn(cacheService.getDevicesOwn())
+        cacheService.getUserDevicesOfBundles().forEach { (bundleId, devices) ->
+            analyticsWrapper.setDeviceBundlesOwn(bundleId, devices)
+        }
         analyticsWrapper.setDevicesFavorite(cacheService.getDevicesFavorite())
         analyticsWrapper.setHasWallet(cacheService.hasWallet())
         analyticsWrapper.setUserProperties()

--- a/app/src/main/java/com/weatherxm/app/AnalyticsInitializer.kt
+++ b/app/src/main/java/com/weatherxm/app/AnalyticsInitializer.kt
@@ -21,6 +21,7 @@ class AnalyticsInitializer : Initializer<Unit>, KoinComponent {
         analyticsWrapper.setUserId(cacheService.getUserId())
         analyticsWrapper.setDevicesSortFilterOptions(cacheService.getDevicesSortFilterOptions())
         analyticsWrapper.setDevicesOwn(cacheService.getDevicesOwn())
+        analyticsWrapper.setDevicesFavorite(cacheService.getDevicesFavorite())
         analyticsWrapper.setHasWallet(cacheService.hasWallet())
         analyticsWrapper.setUserProperties()
         return

--- a/app/src/main/java/com/weatherxm/data/datasource/CacheDeviceDataSource.kt
+++ b/app/src/main/java/com/weatherxm/data/datasource/CacheDeviceDataSource.kt
@@ -44,12 +44,20 @@ class CacheDeviceDataSource(private val cacheService: CacheService) : DeviceData
         throw NotImplementedError("Won't be implemented. Ignore this.")
     }
 
-    override suspend fun getUserDevicesIds(): List<String> {
-        return cacheService.getUserDevicesIds()
+    override suspend fun getUserDevicesFromCache(): List<Device> {
+        return cacheService.getUserDevices()
     }
 
-    override suspend fun setUserDevicesIds(ids: List<String>) {
-        cacheService.setUserDevicesIds(ids)
+    override suspend fun setUserDevices(devices: List<Device>) {
+        cacheService.setUserDevices(devices)
+        devices.groupBy { it.bundle }.forEach {
+            it.key?.name?.let { name ->
+                cacheService.setUserDevicesOfBundle(
+                    CacheService.getUserDeviceOwnFormattedKey(name),
+                    it.value.size
+                )
+            }
+        }
     }
 
     override suspend fun setLocation(

--- a/app/src/main/java/com/weatherxm/data/datasource/DeviceDataSource.kt
+++ b/app/src/main/java/com/weatherxm/data/datasource/DeviceDataSource.kt
@@ -20,8 +20,8 @@ interface DeviceDataSource {
     suspend fun clearFriendlyName(deviceId: String): Either<Failure, Unit>
     suspend fun removeDevice(serialNumber: String): Either<Failure, Unit>
     suspend fun getDeviceInfo(deviceId: String): Either<Failure, DeviceInfo>
-    suspend fun getUserDevicesIds(): List<String>
-    suspend fun setUserDevicesIds(ids: List<String>)
+    suspend fun getUserDevicesFromCache(): List<Device>
+    suspend fun setUserDevices(devices: List<Device>)
     suspend fun setLocation(
         deviceId: String,
         lat: Double,

--- a/app/src/main/java/com/weatherxm/data/datasource/NetworkDeviceDataSource.kt
+++ b/app/src/main/java/com/weatherxm/data/datasource/NetworkDeviceDataSource.kt
@@ -70,11 +70,11 @@ class NetworkDeviceDataSource(private val apiService: ApiService) : DeviceDataSo
         return apiService.getUserDeviceInfo(deviceId).mapResponse()
     }
 
-    override suspend fun getUserDevicesIds(): List<String> {
+    override suspend fun getUserDevicesFromCache(): List<Device> {
         throw NotImplementedError("Won't be implemented. Ignore this.")
     }
 
-    override suspend fun setUserDevicesIds(ids: List<String>) {
+    override suspend fun setUserDevices(devices: List<Device>) {
         throw NotImplementedError("Won't be implemented. Ignore this.")
     }
 

--- a/app/src/main/java/com/weatherxm/data/repository/FollowRepository.kt
+++ b/app/src/main/java/com/weatherxm/data/repository/FollowRepository.kt
@@ -1,15 +1,14 @@
 package com.weatherxm.data.repository
 
 import arrow.core.Either
-import com.weatherxm.data.models.Failure
 import com.weatherxm.data.datasource.CacheFollowDataSource
 import com.weatherxm.data.datasource.NetworkFollowDataSource
+import com.weatherxm.data.models.Failure
 
 interface FollowRepository {
     suspend fun followStation(deviceId: String): Either<Failure, Unit>
     suspend fun unfollowStation(deviceId: String): Either<Failure, Unit>
     suspend fun getFollowedDevicesIds(): List<String>
-    suspend fun setFollowedDevicesIds(ids: List<String>)
 }
 
 class FollowRepositoryImpl(
@@ -33,9 +32,5 @@ class FollowRepositoryImpl(
 
     override suspend fun getFollowedDevicesIds(): List<String> {
         return cacheFollowDataSource.getFollowedDevicesIds()
-    }
-
-    override suspend fun setFollowedDevicesIds(ids: List<String>) {
-        cacheFollowDataSource.setFollowedDevicesIds(ids)
     }
 }

--- a/app/src/main/java/com/weatherxm/data/services/CacheService.kt
+++ b/app/src/main/java/com/weatherxm/data/services/CacheService.kt
@@ -43,6 +43,7 @@ class CacheService(
         const val KEY_DEVICES_FILTER = "devices_filter"
         const val KEY_DEVICES_GROUP_BY = "devices_group_by"
         const val KEY_DEVICES_OWN = "devices_own"
+        const val KEY_DEVICES_FAVORITE = "devices_favorite"
         const val KEY_HAS_WALLET = "has_wallet"
         const val WIDGET_ID = "widget_id"
         const val KEY_USER_ID = "user_id"
@@ -335,6 +336,12 @@ class CacheService(
 
     fun setFollowedDevicesIds(ids: List<String>) {
         followedStationsIds = ids
+        preferences.edit { putInt(KEY_DEVICES_FAVORITE, ids.size) }
+        onUserPropertiesChangeListener?.invoke(KEY_DEVICES_FAVORITE, ids.size)
+    }
+
+    fun getDevicesFavorite(): Int {
+        return preferences.getInt(KEY_DEVICES_FAVORITE, 0)
     }
 
     fun getUserDevicesIds(): List<String> {

--- a/app/src/test/java/com/weatherxm/analytics/AnalyticsWrapperTest.kt
+++ b/app/src/test/java/com/weatherxm/analytics/AnalyticsWrapperTest.kt
@@ -24,6 +24,7 @@ class AnalyticsWrapperTest : KoinTest, BehaviorSpec({
     val testUserID = "test123"
     val testDisplayMode = "dark"
     val testDevicesOwn = 6
+    val testDevicesFavorite = 5
     val testHasWallet = true
 
     fun AnalyticsService.mockResponses() {
@@ -64,6 +65,7 @@ class AnalyticsWrapperTest : KoinTest, BehaviorSpec({
 
                 analyticsWrapper.setUserId(testUserID)
                 analyticsWrapper.setDevicesOwn(testDevicesOwn)
+                analyticsWrapper.setDevicesFavorite(testDevicesFavorite)
                 analyticsWrapper.setHasWallet(testHasWallet)
                 analyticsWrapper.setDisplayMode(testDisplayMode)
                 analyticsWrapper.setDevicesSortFilterOptions(
@@ -71,7 +73,7 @@ class AnalyticsWrapperTest : KoinTest, BehaviorSpec({
                 )
 
                 with(analyticsWrapper.setUserProperties()) {
-                    size shouldBe 11
+                    size shouldBe 12
                     this[0] shouldBe ("theme" to testDisplayMode)
                     this[1] shouldBe ("UNIT_TEMPERATURE" to "c")
                     this[2] shouldBe ("UNIT_WIND" to "mps")
@@ -82,7 +84,8 @@ class AnalyticsWrapperTest : KoinTest, BehaviorSpec({
                     this[7] shouldBe ("FILTER" to "all")
                     this[8] shouldBe ("GROUP_BY" to "no_grouping")
                     this[9] shouldBe ("STATIONS_OWN" to "$testDevicesOwn")
-                    this[10] shouldBe ("HAS_WALLET" to "$testHasWallet")
+                    this[10] shouldBe ("STATIONS_FAVORITE" to "$testDevicesFavorite")
+                    this[11] shouldBe ("HAS_WALLET" to "$testHasWallet")
                 }
                 verifier.verifyUserIdSet(testUserID)
                 verifier.verifyUserPropertiesSet()

--- a/app/src/test/java/com/weatherxm/analytics/AnalyticsWrapperTest.kt
+++ b/app/src/test/java/com/weatherxm/analytics/AnalyticsWrapperTest.kt
@@ -25,7 +25,9 @@ class AnalyticsWrapperTest : KoinTest, BehaviorSpec({
     val testDisplayMode = "dark"
     val testDevicesOwn = 6
     val testDevicesFavorite = 5
+    val testDevicesOfBundle = 2
     val testHasWallet = true
+    val bundleKey = "KEY"
 
     fun AnalyticsService.mockResponses() {
         justRun { setAnalyticsEnabled(any() as Boolean) }
@@ -66,6 +68,7 @@ class AnalyticsWrapperTest : KoinTest, BehaviorSpec({
                 analyticsWrapper.setUserId(testUserID)
                 analyticsWrapper.setDevicesOwn(testDevicesOwn)
                 analyticsWrapper.setDevicesFavorite(testDevicesFavorite)
+                analyticsWrapper.setDeviceBundlesOwn(bundleKey, testDevicesOfBundle)
                 analyticsWrapper.setHasWallet(testHasWallet)
                 analyticsWrapper.setDisplayMode(testDisplayMode)
                 analyticsWrapper.setDevicesSortFilterOptions(
@@ -73,7 +76,7 @@ class AnalyticsWrapperTest : KoinTest, BehaviorSpec({
                 )
 
                 with(analyticsWrapper.setUserProperties()) {
-                    size shouldBe 12
+                    size shouldBe 13
                     this[0] shouldBe ("theme" to testDisplayMode)
                     this[1] shouldBe ("UNIT_TEMPERATURE" to "c")
                     this[2] shouldBe ("UNIT_WIND" to "mps")
@@ -84,8 +87,9 @@ class AnalyticsWrapperTest : KoinTest, BehaviorSpec({
                     this[7] shouldBe ("FILTER" to "all")
                     this[8] shouldBe ("GROUP_BY" to "no_grouping")
                     this[9] shouldBe ("STATIONS_OWN" to "$testDevicesOwn")
-                    this[10] shouldBe ("STATIONS_FAVORITE" to "$testDevicesFavorite")
-                    this[11] shouldBe ("HAS_WALLET" to "$testHasWallet")
+                    this[10] shouldBe ("STATIONS_OWN_KEY" to "$testDevicesOfBundle")
+                    this[11] shouldBe ("STATIONS_FAVORITE" to "$testDevicesFavorite")
+                    this[12] shouldBe ("HAS_WALLET" to "$testHasWallet")
                 }
                 verifier.verifyUserIdSet(testUserID)
                 verifier.verifyUserPropertiesSet()

--- a/app/src/test/java/com/weatherxm/data/datasource/DeviceDataSourceTest.kt
+++ b/app/src/test/java/com/weatherxm/data/datasource/DeviceDataSourceTest.kt
@@ -40,7 +40,7 @@ class DeviceDataSourceTest : BehaviorSpec({
 
     val device = Device.empty()
     val deviceInfo = mockk<DeviceInfo>()
-    val devicesIds = listOf(deviceId)
+    val devices = listOf(device)
 
     val deviceResponse = NetworkResponse.Success<Device, ErrorResponse>(
         device, retrofitResponse(device)
@@ -60,8 +60,8 @@ class DeviceDataSourceTest : BehaviorSpec({
     )
 
     beforeSpec {
-        every { cacheService.getUserDevicesIds() } returns devicesIds
-        justRun { cacheService.setUserDevicesIds(devicesIds) }
+        every { cacheService.getUserDevices() } returns devices
+        justRun { cacheService.setUserDevices(devices) }
     }
 
     context("Get user devices") {
@@ -158,23 +158,23 @@ class DeviceDataSourceTest : BehaviorSpec({
 
     context("Get the IDs of user devices") {
         When("Using the Network Source") {
-            testThrowNotImplemented { networkSource.getUserDevicesIds() }
+            testThrowNotImplemented { networkSource.getUserDevicesFromCache() }
         }
         When("Using the Cache Source") {
             then("return the list of IDs") {
-                cacheSource.getUserDevicesIds() shouldBe devicesIds
+                cacheSource.getUserDevicesFromCache() shouldBe devices
             }
         }
     }
 
     context("Set the IDs of user devices") {
         When("Using the Network Source") {
-            testThrowNotImplemented { networkSource.setUserDevicesIds(devicesIds) }
+            testThrowNotImplemented { networkSource.setUserDevices(devices) }
         }
         When("Using the Cache Source") {
             then("set the list of IDs in cache") {
-                cacheSource.setUserDevicesIds(devicesIds)
-                verify(exactly = 1) { cacheService.setUserDevicesIds(devicesIds) }
+                cacheSource.setUserDevices(devices)
+                verify(exactly = 1) { cacheService.setUserDevices(devices) }
             }
         }
     }

--- a/app/src/test/java/com/weatherxm/data/repository/DeviceRepositoryTest.kt
+++ b/app/src/test/java/com/weatherxm/data/repository/DeviceRepositoryTest.kt
@@ -8,6 +8,7 @@ import com.weatherxm.TestUtils.isSuccess
 import com.weatherxm.data.datasource.CacheDeviceDataSource
 import com.weatherxm.data.datasource.CacheFollowDataSource
 import com.weatherxm.data.datasource.NetworkDeviceDataSource
+import com.weatherxm.data.models.Bundle
 import com.weatherxm.data.models.Device
 import com.weatherxm.data.models.DeviceInfo
 import com.weatherxm.data.models.Location
@@ -33,7 +34,14 @@ class DeviceRepositoryTest : BehaviorSpec({
         null,
         null,
         null,
-        null,
+        Bundle(
+            name = "m5",
+            null,
+            null,
+            null,
+            null,
+            null
+        ),
         null,
         null,
         null,
@@ -72,9 +80,9 @@ class DeviceRepositoryTest : BehaviorSpec({
             cacheDeviceSource,
             cacheFollowSource
         )
-        coJustRun { cacheDeviceSource.setUserDevicesIds(any()) }
+        coJustRun { cacheDeviceSource.setUserDevices(any()) }
         coJustRun { cacheFollowSource.setFollowedDevicesIds(any()) }
-        coEvery { cacheDeviceSource.getUserDevicesIds() } returns emptyList()
+        coEvery { cacheDeviceSource.getUserDevicesFromCache() } returns emptyList()
     }
 
     context("Get user devices") {
@@ -96,7 +104,9 @@ class DeviceRepositoryTest : BehaviorSpec({
                     }
                 }
                 then("save owned devices in cache") {
-                    coVerify(exactly = 1) { cacheDeviceSource.setUserDevicesIds(listOf(ownedId)) }
+                    coVerify(exactly = 1) {
+                        cacheDeviceSource.setUserDevices(listOf(ownedDevice))
+                    }
                 }
                 then("save followed devices in cache") {
                     coVerify(exactly = 1) {
@@ -154,11 +164,10 @@ class DeviceRepositoryTest : BehaviorSpec({
                     repo.claimDevice(serialNumber, location).isSuccess(ownedDevice)
                 }
                 then("save this device along with the rest owned devices in cache") {
-                    coVerify(exactly = 1) { cacheDeviceSource.getUserDevicesIds() }
-                    coVerify(exactly = 1) { cacheDeviceSource.setUserDevicesIds(listOf(ownedId)) }
+                    coVerify(exactly = 1) { cacheDeviceSource.getUserDevicesFromCache() }
+                    coVerify(exactly = 1) { cacheDeviceSource.setUserDevices(listOf(ownedDevice)) }
                 }
             }
-
         }
     }
 
@@ -176,9 +185,11 @@ class DeviceRepositoryTest : BehaviorSpec({
                     repo.removeDevice(serialNumber, ownedId).isSuccess(Unit)
                 }
                 then("remove this device from the rest owned devices in cache") {
-                    coEvery { cacheDeviceSource.getUserDevicesIds() } returns listOf(ownedId)
-                    coVerify(exactly = 1) { cacheDeviceSource.getUserDevicesIds() }
-                    coVerify(exactly = 1) { cacheDeviceSource.setUserDevicesIds(listOf()) }
+                    coEvery {
+                        cacheDeviceSource.getUserDevicesFromCache()
+                    } returns listOf(ownedDevice)
+                    coVerify(exactly = 1) { cacheDeviceSource.getUserDevicesFromCache() }
+                    coVerify(exactly = 1) { cacheDeviceSource.setUserDevices(listOf()) }
                 }
             }
 
@@ -220,7 +231,10 @@ class DeviceRepositoryTest : BehaviorSpec({
                     }
                 }
                 When("the response is a success") {
-                    coMockEitherRight({ networkDeviceSource.clearFriendlyName(serialNumber) }, Unit)
+                    coMockEitherRight(
+                        { networkDeviceSource.clearFriendlyName(serialNumber) },
+                        Unit
+                    )
                     then("return that success") {
                         repo.clearFriendlyName(serialNumber).isSuccess(Unit)
                     }

--- a/app/src/test/java/com/weatherxm/data/repository/FollowRepositoryTest.kt
+++ b/app/src/test/java/com/weatherxm/data/repository/FollowRepositoryTest.kt
@@ -79,13 +79,7 @@ class FollowRepositoryTest : BehaviorSpec({
         }
     }
 
-    context("Get/set followed devices IDs") {
-        given("a list of device IDs") {
-            then("Set them in cache") {
-                repo.setFollowedDevicesIds(ids)
-                coVerify(exactly = 1) { cacheSource.setFollowedDevicesIds(ids) }
-            }
-        }
+    context("Get followed devices IDs") {
         given("a request to get the device IDs of followed stations") {
             then("Get them from cache") {
                 repo.getFollowedDevicesIds() shouldBe ids

--- a/app/src/test/java/com/weatherxm/data/services/CacheServiceTest.kt
+++ b/app/src/test/java/com/weatherxm/data/services/CacheServiceTest.kt
@@ -13,6 +13,7 @@ import com.weatherxm.data.services.CacheService.Companion.KEY_ACCESS
 import com.weatherxm.data.services.CacheService.Companion.KEY_CURRENT_WEATHER_WIDGET_IDS
 import com.weatherxm.data.services.CacheService.Companion.KEY_DEVICES_FILTER
 import com.weatherxm.data.services.CacheService.Companion.KEY_DEVICES_GROUP_BY
+import com.weatherxm.data.services.CacheService.Companion.KEY_DEVICES_OWN
 import com.weatherxm.data.services.CacheService.Companion.KEY_DEVICES_SORT
 import com.weatherxm.data.services.CacheService.Companion.KEY_REFRESH
 import com.weatherxm.data.services.CacheService.Companion.KEY_TEMPERATURE
@@ -39,6 +40,7 @@ class CacheServiceTest : KoinTest, BehaviorSpec({
     val groupByOption = "groupByOption"
     val deviceId = "deviceId"
     val celsiusUnit = "°C"
+    val bundleKey = "bundleKey"
     val weatherData = listOf<WeatherData>(mockk())
 
     beforeSpec {
@@ -52,6 +54,10 @@ class CacheServiceTest : KoinTest, BehaviorSpec({
         every { prefEditor.remove(any()) } returns prefEditor
         every { prefEditor.clear() } returns prefEditor
         every { sharedPref.getStringSet("current_weather_widget_ids", setOf()) } returns setOf()
+        every { sharedPref.all } returns mapOf(
+            KEY_DEVICES_OWN to 5,
+            KEY_DEVICES_OWN + "_" + bundleKey to 1
+        )
         justRun { okHttpCache.evictAll() }
         justRun { prefEditor.apply() }
     }
@@ -249,6 +255,21 @@ class CacheServiceTest : KoinTest, BehaviorSpec({
             then("call the respective clearAll function") {
                 cacheService.clearAll()
                 cacheService.isCacheEmpty() shouldBe true
+            }
+        }
+    }
+
+    context("GET / SET User Devices Of Bundle") {
+        When("We want to GET all the user devices of each bundle") {
+            then("return the respective map of elements") {
+                val k = cacheService.getUserDevicesOfBundles()
+                k shouldBe mapOf(bundleKey to 1)
+            }
+        }
+        When("We have a bundle and its size") {
+            cacheService.setUserDevicesOfBundle(bundleKey, 1)
+            then("set the respective size in the Shared Preferences") {
+                verify(exactly = 1) { prefEditor.putInt(bundleKey, 1) }
             }
         }
     }

--- a/app/src/test/java/com/weatherxm/data/services/InMemoryTest.kt
+++ b/app/src/test/java/com/weatherxm/data/services/InMemoryTest.kt
@@ -9,6 +9,7 @@ import com.weatherxm.data.models.DataError
 import com.weatherxm.data.models.Failure
 import com.weatherxm.data.models.Location
 import com.weatherxm.data.models.User
+import com.weatherxm.data.services.CacheService.Companion.KEY_DEVICES_FAVORITE
 import com.weatherxm.data.services.CacheService.Companion.KEY_DEVICES_OWN
 import com.weatherxm.data.services.CacheService.Companion.KEY_HAS_WALLET
 import com.weatherxm.data.services.CacheService.Companion.KEY_USER_ID
@@ -125,7 +126,14 @@ class InMemoryTest(private val cacheService: CacheService) {
             deviceIds,
             { cacheService.getFollowedDevicesIds() },
             { cacheService.setFollowedDevicesIds(deviceIds) }
-        )
+        ).apply {
+            given("that the user has some favorite devices") {
+                every { sharedPref.getInt(KEY_DEVICES_FAVORITE, 0) } returns deviceIds.size
+                then("return the number of owned devices") {
+                    cacheService.getDevicesFavorite() shouldBe deviceIds.size
+                }
+            }
+        }
 
         behaviorSpec.testInMemorySingleVar(
             "Device's photo upload IDs",

--- a/app/src/test/java/com/weatherxm/data/services/InMemoryTest.kt
+++ b/app/src/test/java/com/weatherxm/data/services/InMemoryTest.kt
@@ -6,6 +6,7 @@ import com.weatherxm.TestConfig.sharedPref
 import com.weatherxm.TestUtils.isSuccess
 import com.weatherxm.data.models.CountryInfo
 import com.weatherxm.data.models.DataError
+import com.weatherxm.data.models.Device
 import com.weatherxm.data.models.Failure
 import com.weatherxm.data.models.Location
 import com.weatherxm.data.models.User
@@ -31,6 +32,7 @@ class InMemoryTest(private val cacheService: CacheService) {
     private val query = "query"
     private val deviceId = "deviceId"
     private val uploadId = "uploadId"
+    private val devices= listOf(Device.empty())
     private val deviceIds = listOf(deviceId)
     private val countriesInfo = listOf<CountryInfo>(mockk())
     private val uploadIds = listOf(uploadId)
@@ -170,14 +172,14 @@ class InMemoryTest(private val cacheService: CacheService) {
 
         behaviorSpec.testInMemorySingleVar(
             "IDs of the user devices",
-            deviceIds,
-            { cacheService.getUserDevicesIds() },
-            { cacheService.setUserDevicesIds(deviceIds) }
+            devices,
+            { cacheService.getUserDevices() },
+            { cacheService.setUserDevices(devices) }
         ).apply {
             given("that the user has some owned devices") {
-                every { sharedPref.getInt(KEY_DEVICES_OWN, 0) } returns deviceIds.size
+                every { sharedPref.getInt(KEY_DEVICES_OWN, 0) } returns devices.size
                 then("return the number of owned devices") {
-                    cacheService.getDevicesOwn() shouldBe deviceIds.size
+                    cacheService.getDevicesOwn() shouldBe devices.size
                 }
             }
         }


### PR DESCRIPTION
### **Why?**
- Add a label for the user's favorite stations (count)
- Add a label for user stations owned with the corresponding station type (count)

### **How?**
- Save favorite stations size in cache with key `KEY_DEVICES_FAVORITE` and add `fun setDevicesFavorite(devicesFavorite)` to set the respective variable in `AnalyticsWrapper` in order to use it afterwards to set user params.
- Refactor `userDevicesIds` in Cache in-memory variable and save `userDevices` in order to be able to use simplify things in `getUserDevices`, `claimDevice` and `removeDevice` in the `DeviceRepository` to add/remove devices and the respective values in cache such as `KEY_DEVICES_OWN` and `KEY_DEVICES_OWN_{BUNDLE_NAME}`. Also create `fun setUserDevicesOfBundle(bundleKey: String, size: Int)` and `fun getUserDevicesOfBundles()` in `CacheService` in order to get/set the respective values in cache.

### **Testing**
Ensure that all audiences are shown correctly on either Firebase or Mixpanel.