### PR TITLE
Add station count labels to cells on map

### DIFF
--- a/app/src/main/java/com/weatherxm/ui/components/BaseMapFragment.kt
+++ b/app/src/main/java/com/weatherxm/ui/components/BaseMapFragment.kt
@@ -10,7 +10,9 @@ import com.mapbox.maps.MapView
 import com.mapbox.maps.MapboxMap
 import com.mapbox.maps.Style
 import com.mapbox.maps.plugin.annotation.annotations
+import com.mapbox.maps.plugin.annotation.generated.PointAnnotationManager
 import com.mapbox.maps.plugin.annotation.generated.PolygonAnnotationManager
+import com.mapbox.maps.plugin.annotation.generated.createPointAnnotationManager
 import com.mapbox.maps.plugin.annotation.generated.createPolygonAnnotationManager
 import com.mapbox.maps.plugin.gestures.gestures
 import com.mapbox.maps.plugin.scalebar.scalebar
@@ -42,6 +44,7 @@ open class BaseMapFragment : BaseFragment() {
 
     protected lateinit var binding: FragmentMapBinding
     protected lateinit var polygonManager: PolygonAnnotationManager
+    protected lateinit var pointManager: PointAnnotationManager
     protected lateinit var viewManager: ViewAnnotationManager
 
     private lateinit var debugInfoListener: OnMapDebugInfoListener
@@ -96,6 +99,9 @@ open class BaseMapFragment : BaseFragment() {
 
             with(binding.mapView.annotations) {
                 polygonManager = this.createPolygonAnnotationManager()
+                pointManager = this.createPointAnnotationManager().apply {
+                    textSize = 0.0
+                }
             }
 
             // Update camera

--- a/app/src/main/java/com/weatherxm/ui/components/BaseMapFragment.kt
+++ b/app/src/main/java/com/weatherxm/ui/components/BaseMapFragment.kt
@@ -9,6 +9,7 @@ import com.mapbox.maps.CameraOptions
 import com.mapbox.maps.MapView
 import com.mapbox.maps.MapboxMap
 import com.mapbox.maps.Style
+import com.mapbox.maps.plugin.annotation.AnnotationConfig
 import com.mapbox.maps.plugin.annotation.annotations
 import com.mapbox.maps.plugin.annotation.generated.PointAnnotationManager
 import com.mapbox.maps.plugin.annotation.generated.PolygonAnnotationManager
@@ -19,6 +20,8 @@ import com.mapbox.maps.plugin.scalebar.scalebar
 import com.mapbox.maps.viewannotation.ViewAnnotationManager
 import com.weatherxm.databinding.FragmentMapBinding
 import com.weatherxm.ui.components.BaseMapFragment.OnMapDebugInfoListener
+import com.weatherxm.ui.explorer.ExplorerMapFragment.Companion.STATION_COUNT_POINT_TEXT_SIZE
+import com.weatherxm.ui.explorer.ExplorerViewModel.Companion.POINT_LAYER
 import com.weatherxm.util.DisplayModeHelper
 import dev.chrisbanes.insetter.applyInsetter
 import org.koin.android.ext.android.inject
@@ -98,9 +101,10 @@ open class BaseMapFragment : BaseFragment() {
             binding.mapView.scalebar.enabled = false
 
             with(binding.mapView.annotations) {
-                polygonManager = this.createPolygonAnnotationManager()
-                pointManager = this.createPointAnnotationManager().apply {
-                    textSize = 0.0
+                polygonManager = createPolygonAnnotationManager()
+                val config = AnnotationConfig(layerId = POINT_LAYER)
+                pointManager = createPointAnnotationManager(config).apply {
+                    textSize = STATION_COUNT_POINT_TEXT_SIZE
                 }
             }
 

--- a/app/src/main/java/com/weatherxm/ui/explorer/ExplorerMapFragment.kt
+++ b/app/src/main/java/com/weatherxm/ui/explorer/ExplorerMapFragment.kt
@@ -51,9 +51,11 @@ import org.koin.androidx.viewmodel.ext.android.activityViewModel
 import org.koin.androidx.viewmodel.ext.android.viewModel
 import timber.log.Timber
 
+@Suppress("TooManyFunctions")
 class ExplorerMapFragment : BaseMapFragment() {
     companion object {
         const val CAMERA_ANIMATION_DURATION = 400L
+        const val STATION_COUNT_POINT_TEXT_SIZE = 16.0
     }
 
     /*
@@ -105,18 +107,7 @@ class ExplorerMapFragment : BaseMapFragment() {
             true
         }
 
-        map.subscribeCameraChanged {
-            model.setCurrentCamera(it.cameraState.zoom, it.cameraState.center)
-            lifecycleScope.launch(Dispatchers.IO) {
-                if (it.cameraState.zoom >= SHOW_STATION_COUNT_ZOOM_LEVEL && !labelsShown) {
-                    labelsShown = true
-                    pointManager.textSize = 16.0
-                } else if (it.cameraState.zoom < SHOW_STATION_COUNT_ZOOM_LEVEL && labelsShown) {
-                    labelsShown = false
-                    pointManager.textSize = 0.0
-                }
-            }
-        }
+        map.subscribeCameraChanged { onCameraChanged(it.cameraState.zoom, it.cameraState.center) }
 
         getMapView().location.updateSettings {
             enabled = true
@@ -177,6 +168,19 @@ class ExplorerMapFragment : BaseMapFragment() {
 
         // Fetch data
         model.fetch()
+    }
+
+    private fun onCameraChanged(zoom: Double, center: Point) {
+        model.setCurrentCamera(zoom, center)
+        lifecycleScope.launch(Dispatchers.IO) {
+            if (zoom >= SHOW_STATION_COUNT_ZOOM_LEVEL && !labelsShown) {
+                labelsShown = true
+                pointManager.textSize = STATION_COUNT_POINT_TEXT_SIZE
+            } else if (zoom < SHOW_STATION_COUNT_ZOOM_LEVEL && labelsShown) {
+                labelsShown = false
+                pointManager.textSize = 0.0
+            }
+        }
     }
 
     private fun handleRecentSearches(searchResults: List<SearchResult>) {

--- a/app/src/main/java/com/weatherxm/ui/explorer/ExplorerViewModel.kt
+++ b/app/src/main/java/com/weatherxm/ui/explorer/ExplorerViewModel.kt
@@ -21,6 +21,7 @@ import com.weatherxm.ui.components.BaseMapFragment.Companion.ZOOMED_IN_ZOOM_LEVE
 import com.weatherxm.usecases.ExplorerUseCase
 import com.weatherxm.util.Failure.getDefaultMessage
 import com.weatherxm.util.LocationHelper
+import com.weatherxm.util.MapboxUtils.toPointAnnotationOptions
 import com.weatherxm.util.MapboxUtils.toPolygonAnnotationOptions
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.launch
@@ -39,6 +40,7 @@ class ExplorerViewModel(
         const val HEATMAP_LAYER_ID = "heatmap-layer"
         const val HEATMAP_LAYER_SOURCE = "heatmap"
         const val HEATMAP_WEIGHT_KEY = ExplorerUseCase.DEVICE_COUNT_KEY
+        const val SHOW_STATION_COUNT_ZOOM_LEVEL: Double = 10.0
     }
 
     // Explorer Data
@@ -224,6 +226,7 @@ class ExplorerViewModel(
                      * The explorer map is empty so send all the hexes to be drawn
                      */
                     response.polygonsToDraw = response.publicHexes.toPolygonAnnotationOptions()
+                    response.pointsToDraw = response.publicHexes.toPointAnnotationOptions()
                     onExplorerData.postValue(response)
                 } else {
                     val newHexes = mutableListOf<PublicHex>()

--- a/app/src/main/java/com/weatherxm/ui/explorer/ExplorerViewModel.kt
+++ b/app/src/main/java/com/weatherxm/ui/explorer/ExplorerViewModel.kt
@@ -41,6 +41,7 @@ class ExplorerViewModel(
         const val HEATMAP_LAYER_SOURCE = "heatmap"
         const val HEATMAP_WEIGHT_KEY = ExplorerUseCase.DEVICE_COUNT_KEY
         const val SHOW_STATION_COUNT_ZOOM_LEVEL: Double = 10.0
+        const val POINT_LAYER: String = "point_layer"
     }
 
     // Explorer Data

--- a/app/src/main/java/com/weatherxm/ui/explorer/UIModels.kt
+++ b/app/src/main/java/com/weatherxm/ui/explorer/UIModels.kt
@@ -4,6 +4,7 @@ import android.os.Parcelable
 import androidx.annotation.Keep
 import com.mapbox.geojson.Point
 import com.mapbox.maps.extension.style.sources.generated.GeoJsonSource
+import com.mapbox.maps.plugin.annotation.generated.PointAnnotationOptions
 import com.mapbox.maps.plugin.annotation.generated.PolygonAnnotationOptions
 import com.squareup.moshi.JsonClass
 import com.weatherxm.data.models.Bundle
@@ -21,7 +22,8 @@ import timber.log.Timber
 data class ExplorerData(
     val geoJsonSource: GeoJsonSource,
     val publicHexes: List<PublicHex>,
-    var polygonsToDraw: List<PolygonAnnotationOptions> = listOf()
+    var polygonsToDraw: List<PolygonAnnotationOptions> = listOf(),
+    var pointsToDraw: List<PointAnnotationOptions> = listOf()
 )
 
 @Keep

--- a/app/src/main/java/com/weatherxm/util/MapboxUtils.kt
+++ b/app/src/main/java/com/weatherxm/util/MapboxUtils.kt
@@ -7,6 +7,7 @@ import com.mapbox.api.staticmap.v1.models.StaticMarkerAnnotation
 import com.mapbox.api.staticmap.v1.models.StaticPolylineAnnotation
 import com.mapbox.geojson.Point
 import com.mapbox.geojson.utils.PolylineUtils
+import com.mapbox.maps.plugin.annotation.generated.PointAnnotationOptions
 import com.mapbox.maps.plugin.annotation.generated.PolygonAnnotation
 import com.mapbox.maps.plugin.annotation.generated.PolygonAnnotationOptions
 import com.mapbox.search.result.SearchSuggestion
@@ -96,6 +97,15 @@ object MapboxUtils : KoinComponent {
                 .withFillOutlineColor(resources.getColor(R.color.white))
                 .withData(gson.toJsonTree(UICell(it.index, it.center)))
                 .withPoints(polygonPointsToLatLng(it.polygon))
+        }
+    }
+
+    fun List<PublicHex>.toPointAnnotationOptions(): List<PointAnnotationOptions> {
+        return map {
+            PointAnnotationOptions()
+                .withPoint(Point.fromLngLat(it.center.lon, it.center.lat))
+                .withTextField(it.deviceCount?.toString() ?: "")
+                .withTextColor(resources.getColor(R.color.dark_text))
         }
     }
 

--- a/app/src/test/java/com/weatherxm/ui/explorer/ExplorerViewModelTest.kt
+++ b/app/src/test/java/com/weatherxm/ui/explorer/ExplorerViewModelTest.kt
@@ -5,6 +5,7 @@ import com.mapbox.maps.extension.style.expressions.dsl.generated.interpolate
 import com.mapbox.maps.extension.style.layers.generated.HeatmapLayer
 import com.mapbox.maps.extension.style.layers.generated.heatmapLayer
 import com.mapbox.maps.extension.style.sources.generated.GeoJsonSource
+import com.mapbox.maps.plugin.annotation.generated.PointAnnotationOptions
 import com.mapbox.maps.plugin.annotation.generated.PolygonAnnotationOptions
 import com.weatherxm.TestConfig.REACH_OUT_MSG
 import com.weatherxm.TestConfig.dispatcher
@@ -27,6 +28,7 @@ import com.weatherxm.ui.explorer.ExplorerViewModel.Companion.HEATMAP_WEIGHT_KEY
 import com.weatherxm.usecases.ExplorerUseCase
 import com.weatherxm.util.LocationHelper
 import com.weatherxm.util.MapboxUtils
+import com.weatherxm.util.MapboxUtils.toPointAnnotationOptions
 import com.weatherxm.util.MapboxUtils.toPolygonAnnotationOptions
 import com.weatherxm.util.Resources
 import io.kotest.core.spec.style.BehaviorSpec
@@ -68,6 +70,7 @@ class ExplorerViewModelTest : BehaviorSpec({
     val publicHex = PublicHex("cellIndex", 1, location, listOf())
     val publicHex2 = PublicHex("cellIndex2", 1, location, listOf())
     val newPolygonAnnotationOptions = listOf(mockk<PolygonAnnotationOptions>())
+    val newPointAnnotationOptions = listOf(mockk<PointAnnotationOptions>())
     val explorerData = ExplorerData(geoJsonSource, listOf(publicHex), listOf())
     val newExplorerData =
         ExplorerData(geoJsonSource, listOf(publicHex2), newPolygonAnnotationOptions)
@@ -194,6 +197,11 @@ class ExplorerViewModelTest : BehaviorSpec({
         every {
             newExplorerData.publicHexes.toPolygonAnnotationOptions()
         } returns newPolygonAnnotationOptions
+        every { explorerData.publicHexes.toPointAnnotationOptions() } returns emptyList()
+        every { fullExplorerData.publicHexes.toPointAnnotationOptions() } returns emptyList()
+        every {
+            newExplorerData.publicHexes.toPointAnnotationOptions()
+        } returns newPointAnnotationOptions
 
         viewModel = ExplorerViewModel(usecase, analytics, locationHelper, dispatcher)
     }


### PR DESCRIPTION
### **Why?**
Add station count labels to cells on map

### **How?**
- Created `pointManager` and utilized that in order to add points to the cells at zoom level >= 10.
- Also created function `toPointAnnotationOptions` that gives back all the point annotations that should be added in the map in a correct way, and added those points at the UI Model `ExplorerData` to serve them directly.

### **Testing**
Ensure that everything looks and works OK with no lags.