### PR TITLE
Added no active stations chip in cell details

### DIFF
--- a/app/src/main/java/com/weatherxm/ui/cellinfo/CellInfoActivity.kt
+++ b/app/src/main/java/com/weatherxm/ui/cellinfo/CellInfoActivity.kt
@@ -178,7 +178,8 @@ class CellInfoActivity : BaseActivity(), DeviceListener {
                 binding.activeChip.text =
                     resources.getQuantityString(R.plurals.cell_active_station, this, this)
             } else {
-                binding.activeChip.visible(false)
+                binding.activeChip.text = getString(R.string.no_active_stations)
+                binding.activeChip.setChipBackgroundColorResource(R.color.errorTint)
             }
         }
         binding.capacityChip.text = getString(R.string.cell_stations_present, data.size)

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -612,6 +612,7 @@
     <string name="cell_stations_present">%d/10 stations present</string>
     <string name="cell_capacity">Cell Capacity</string>
     <string name="cell_capacity_explanation">Cell capacity is a parameter that is used to define the maximum number of stations that are eligible for rewards in a specific cell. Every cell has a predefined capacity that depends on its geospatial characteristics*.\n\nEvery station is ranked in its cell daily, based on its reward score and its seniority. As long as the station’s ranking is above the capacity threshold, it will be rewarded, whereas getting below it will lead to zero rewards. For example, in a cell with a max capacity of 5 stations, if a station is ranked 3rd it will get rewarded, but if it is ranked 7th, it won’t receive any rewards.\n\nRead more about how our Cell Capacity algorithm works.\n\n* The cell capacity is currently set to the fixed value of 10 rewardable stations, for every cell.</string>
+    <string name="no_active_stations">No active stations</string>
 
     <!-- Temperature Bars Explanation -->
     <string name="understanding_temperature_bars">Understanding the Temperature Bars</string>


### PR DESCRIPTION
### **Why?**
Added no active stations chip in cell details when there aren't any.

### **How?**
Just use the existing code and instead of hiding the chip when there aren't any active stations, edit its text and background color.

### **Testing**
Check some cells with and without active stations and ensure everything looks OK.