### PR TITLE
Use the correct source param for analytics

### DIFF
--- a/app/src/main/java/com/weatherxm/analytics/AnalyticsService.kt
+++ b/app/src/main/java/com/weatherxm/analytics/AnalyticsService.kt
@@ -93,8 +93,7 @@ interface AnalyticsService {
         STATE("STATE"),
         APP_ID("APP_ID"),
         DEVICE_STATE("DEVICE_STATE"),
-        USER_STATE("USER_STATE"),
-        SOURCE("SOURCE")
+        USER_STATE("USER_STATE")
     }
 
     // Custom Param Names

--- a/app/src/main/java/com/weatherxm/ui/photoverification/gallery/PhotoGalleryActivity.kt
+++ b/app/src/main/java/com/weatherxm/ui/photoverification/gallery/PhotoGalleryActivity.kt
@@ -85,7 +85,7 @@ class PhotoGalleryActivity : BaseActivity() {
                             AnalyticsService.ParamValue.COMPLETED.paramValue
                         ),
                         Pair(
-                            AnalyticsService.CustomParam.SOURCE.paramName,
+                            FirebaseAnalytics.Param.SOURCE,
                             AnalyticsService.ParamValue.CAMERA.paramValue
                         )
                     )
@@ -108,7 +108,7 @@ class PhotoGalleryActivity : BaseActivity() {
                             AnalyticsService.ParamValue.COMPLETED.paramValue
                         ),
                         Pair(
-                            AnalyticsService.CustomParam.SOURCE.paramName,
+                            FirebaseAnalytics.Param.SOURCE,
                             AnalyticsService.ParamValue.GALLERY.paramValue
                         )
                     )
@@ -286,7 +286,7 @@ class PhotoGalleryActivity : BaseActivity() {
                             AnalyticsService.ParamValue.STARTED.paramValue
                         ),
                         Pair(
-                            AnalyticsService.CustomParam.SOURCE.paramName,
+                            FirebaseAnalytics.Param.SOURCE,
                             AnalyticsService.ParamValue.CAMERA.paramValue
                         )
                     )
@@ -304,7 +304,7 @@ class PhotoGalleryActivity : BaseActivity() {
                             AnalyticsService.ParamValue.STARTED.paramValue
                         ),
                         Pair(
-                            AnalyticsService.CustomParam.SOURCE.paramName,
+                            FirebaseAnalytics.Param.SOURCE,
                             AnalyticsService.ParamValue.GALLERY.paramValue
                         )
                     )


### PR DESCRIPTION
### **Why?** 
Use the correct source param for analytics. 

 ### **Testing** 
Should have the param in lowercase as `source`