### PR TITLE
Create TokenMetricsActivity and its respective layout

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -332,6 +332,10 @@
             android:screenOrientation="portrait"
             android:theme="@style/Theme.WeatherXM" />
         <activity
+            android:name="com.weatherxm.ui.networkstats.tokenmetrics.TokenMetricsActivity"
+            android:screenOrientation="portrait"
+            android:theme="@style/Theme.WeatherXM" />
+        <activity
             android:name="com.journeyapps.barcodescanner.CaptureActivity"
             android:screenOrientation="portrait"
             tools:replace="screenOrientation" />

--- a/app/src/main/java/com/weatherxm/analytics/AnalyticsService.kt
+++ b/app/src/main/java/com/weatherxm/analytics/AnalyticsService.kt
@@ -67,7 +67,8 @@ interface AnalyticsService {
         REWARD_ANALYTICS("Reward Analytics"),
         STATION_PHOTOS_INSTRUCTIONS("Station Photos Instructions"),
         STATION_PHOTOS_INTRO("Station Photos Intro"),
-        STATION_PHOTOS_GALLERY("Station Photos Gallery")
+        STATION_PHOTOS_GALLERY("Station Photos Gallery"),
+        TOKEN_METRICS("Token Metrics")
     }
 
     // Custom Event Names

--- a/app/src/main/java/com/weatherxm/ui/Navigator.kt
+++ b/app/src/main/java/com/weatherxm/ui/Navigator.kt
@@ -45,6 +45,7 @@ import com.weatherxm.ui.common.Contracts.ARG_EXPLORER_CELL
 import com.weatherxm.ui.common.Contracts.ARG_FORECAST_SELECTED_DAY
 import com.weatherxm.ui.common.Contracts.ARG_INSTRUCTIONS_ONLY
 import com.weatherxm.ui.common.Contracts.ARG_NEEDS_PHOTO_VERIFICATION
+import com.weatherxm.ui.common.Contracts.ARG_NETWORK_STATS
 import com.weatherxm.ui.common.Contracts.ARG_NEW_PHOTO_VERIFICATION
 import com.weatherxm.ui.common.Contracts.ARG_OPEN_EXPLORER_ON_BACK
 import com.weatherxm.ui.common.Contracts.ARG_PHOTOS
@@ -83,7 +84,9 @@ import com.weatherxm.ui.explorer.ExplorerActivity
 import com.weatherxm.ui.explorer.UICell
 import com.weatherxm.ui.home.HomeActivity
 import com.weatherxm.ui.login.LoginActivity
+import com.weatherxm.ui.networkstats.NetworkStats
 import com.weatherxm.ui.networkstats.NetworkStatsActivity
+import com.weatherxm.ui.networkstats.tokenmetrics.TokenMetricsActivity
 import com.weatherxm.ui.passwordprompt.PasswordPromptFragment
 import com.weatherxm.ui.photoverification.gallery.PhotoGalleryActivity
 import com.weatherxm.ui.photoverification.intro.PhotoVerificationIntroActivity
@@ -541,6 +544,14 @@ class Navigator(private val analytics: AnalyticsWrapper) {
         }
     }
 
+    fun showTokenMetrics(context: Context, networkStats: NetworkStats) {
+        context.startActivity(
+            Intent(context, TokenMetricsActivity::class.java)
+                .addFlags(Intent.FLAG_ACTIVITY_SINGLE_TOP or Intent.FLAG_ACTIVITY_CLEAR_TOP)
+                .putExtra(ARG_NETWORK_STATS, networkStats)
+        )
+    }
+
     @Suppress("LongParameterList")
     fun showMessageDialog(
         fragmentManager: FragmentManager,
@@ -588,7 +599,8 @@ class Navigator(private val analytics: AnalyticsWrapper) {
         htmlMessage: String? = null,
     ) {
         fragmentActivity?.let {
-            LoginPromptDialogFragment(title,
+            LoginPromptDialogFragment(
+                title,
                 message,
                 htmlMessage,
                 onLogin = {

--- a/app/src/main/java/com/weatherxm/ui/common/Contracts.kt
+++ b/app/src/main/java/com/weatherxm/ui/common/Contracts.kt
@@ -39,4 +39,5 @@ object Contracts {
     const val ARG_NEW_PHOTO_VERIFICATION = "new_photo_verification"
     const val FILE_PROVIDER_AUTHORITY = "${BuildConfig.APPLICATION_ID}.fileprovider"
     const val ARG_DELETE_ALL_PHOTOS = "delete_all_photos"
+    const val ARG_NETWORK_STATS = "network_stats"
 }

--- a/app/src/main/java/com/weatherxm/ui/networkstats/NetworkStatsActivity.kt
+++ b/app/src/main/java/com/weatherxm/ui/networkstats/NetworkStatsActivity.kt
@@ -15,7 +15,6 @@ import com.weatherxm.ui.common.visible
 import com.weatherxm.ui.components.BaseActivity
 import com.weatherxm.ui.components.ProPromotionDialogFragment
 import com.weatherxm.ui.components.compose.ProPromotionCard
-import com.weatherxm.util.NumberUtils.compactNumber
 import com.weatherxm.util.initializeNetworkStatsChart
 import me.saket.bettermovementmethod.BetterLinkMovementMethod
 import org.koin.androidx.viewmodel.ext.android.viewModel
@@ -64,6 +63,12 @@ class NetworkStatsActivity : BaseActivity() {
         binding.contactUsBtn.setOnClickListener {
             navigator.openWebsite(this, getString(R.string.website_contact))
             analytics.trackEventSelectContent(AnalyticsService.ParamValue.MANUFACTURER.paramValue)
+        }
+
+        binding.rewardsCard.setOnClickListener {
+            model.onNetworkStats().value?.data?.let {
+                navigator.showTokenMetrics(this, it)
+            }
         }
 
         setInfoButtonListeners()
@@ -144,22 +149,6 @@ class NetworkStatsActivity : BaseActivity() {
             )
         }
 
-        binding.totalSupplyBtn.setOnClickListener {
-            openMessageDialog(
-                R.string.total_supply,
-                R.string.total_supply_explanation,
-                AnalyticsService.ParamValue.TOTAL_SUPPLY.paramValue
-            )
-        }
-
-        binding.circSupplyBtn.setOnClickListener {
-            openMessageDialog(
-                R.string.circulating_supply,
-                R.string.circulating_supply_explanation,
-                AnalyticsService.ParamValue.CIRCULATING_SUPPLY.paramValue
-            )
-        }
-
         binding.totalInfoBtn.setOnClickListener {
             openMessageDialog(
                 R.string.total_weather_stations,
@@ -226,17 +215,6 @@ class NetworkStatsActivity : BaseActivity() {
 
             earnWxmPerMonth.text = getString(R.string.earn_wxm, data.rewardsAvgMonthly)
 
-            totalSupply.text = compactNumber(data.totalSupply)
-            binding.circSupply.text = compactNumber(data.circulatingSupply)
-            if (data.totalSupply != null && data.circulatingSupply != null
-                && data.totalSupply >= data.circulatingSupply
-            ) {
-                binding.circSupplyBar.valueTo = data.totalSupply.toFloat()
-                binding.circSupplyBar.values = listOf(data.circulatingSupply.toFloat())
-            } else {
-                binding.circSupplyBar.visible(false)
-            }
-
             totals.text = data.totalStations
             claimed.text = data.claimedStations
             active.text = data.activeStations
@@ -281,27 +259,6 @@ class NetworkStatsActivity : BaseActivity() {
                 navigator.openWebsite(this@NetworkStatsActivity, txUrl)
             }
             binding.lastRunOpenInNew.visible(true)
-        }
-
-        data.tokenUrl?.let {
-            with(binding.viewTokenContractBtn) {
-                movementMethod = BetterLinkMovementMethod.newInstance().apply {
-                    setOnLinkClickListener { _, url ->
-                        analytics.trackEventSelectContent(
-                            AnalyticsService.ParamValue.NETWORK_STATS.paramValue,
-                            Pair(
-                                FirebaseAnalytics.Param.SOURCE,
-                                AnalyticsService.ParamValue.REWARD_CONTRACT.paramValue
-                            )
-                        )
-                        navigator.openWebsite(this@NetworkStatsActivity, url)
-                        return@setOnLinkClickListener true
-                    }
-                }
-                setHtml(R.string.view_token_contract, it)
-                removeLinksUnderline()
-                visible(true)
-            }
         }
     }
 }

--- a/app/src/main/java/com/weatherxm/ui/networkstats/UIModels.kt
+++ b/app/src/main/java/com/weatherxm/ui/networkstats/UIModels.kt
@@ -1,11 +1,14 @@
 package com.weatherxm.ui.networkstats
 
+import android.os.Parcelable
 import androidx.annotation.Keep
 import com.github.mikephil.charting.data.Entry
 import com.squareup.moshi.JsonClass
+import kotlinx.parcelize.Parcelize
 
 @Keep
 @JsonClass(generateAdapter = true)
+@Parcelize
 data class NetworkStats(
     val totalDataDays: String,
     val totalDataDays30D: String,
@@ -32,13 +35,14 @@ data class NetworkStats(
     val activeStations: String,
     val activeStationStats: List<NetworkStationStats>,
     val lastUpdated: String
-)
+) : Parcelable
 
 @Keep
 @JsonClass(generateAdapter = true)
+@Parcelize
 data class NetworkStationStats(
     val name: String,
     val url: String,
     val percentage: Double,
     val amount: String
-)
+) : Parcelable

--- a/app/src/main/java/com/weatherxm/ui/networkstats/tokenmetrics/TokenMetricsActivity.kt
+++ b/app/src/main/java/com/weatherxm/ui/networkstats/tokenmetrics/TokenMetricsActivity.kt
@@ -1,0 +1,119 @@
+package com.weatherxm.ui.networkstats.tokenmetrics
+
+import android.os.Bundle
+import androidx.annotation.StringRes
+import com.google.firebase.analytics.FirebaseAnalytics
+import com.weatherxm.R
+import com.weatherxm.analytics.AnalyticsService
+import com.weatherxm.databinding.ActivityTokenMetricsBinding
+import com.weatherxm.ui.common.Contracts.ARG_NETWORK_STATS
+import com.weatherxm.ui.common.classSimpleName
+import com.weatherxm.ui.common.parcelable
+import com.weatherxm.ui.common.removeLinksUnderline
+import com.weatherxm.ui.common.setHtml
+import com.weatherxm.ui.common.toast
+import com.weatherxm.ui.common.visible
+import com.weatherxm.ui.components.BaseActivity
+import com.weatherxm.ui.networkstats.NetworkStats
+import com.weatherxm.util.NumberUtils.compactNumber
+import me.saket.bettermovementmethod.BetterLinkMovementMethod
+import timber.log.Timber
+
+class TokenMetricsActivity : BaseActivity() {
+    private lateinit var binding: ActivityTokenMetricsBinding
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        binding = ActivityTokenMetricsBinding.inflate(layoutInflater)
+        setContentView(binding.root)
+
+        val networkStats = intent.parcelable<NetworkStats>(ARG_NETWORK_STATS)
+        if (networkStats == null) {
+            Timber.d("Could not start TokenMetricsActivity. Network Stats are null.")
+            toast(R.string.error_generic_message)
+            finish()
+            return
+        }
+
+        binding.toolbar.setNavigationOnClickListener {
+            finish()
+        }
+
+        binding.totalSupplyBtn.setOnClickListener {
+            openMessageDialog(
+                R.string.total_supply,
+                R.string.total_supply_explanation,
+                AnalyticsService.ParamValue.TOTAL_SUPPLY.paramValue
+            )
+        }
+
+        binding.circSupplyBtn.setOnClickListener {
+            openMessageDialog(
+                R.string.circulating_supply,
+                R.string.circulating_supply_explanation,
+                AnalyticsService.ParamValue.CIRCULATING_SUPPLY.paramValue
+            )
+        }
+
+        updateUI(networkStats)
+    }
+
+    private fun openMessageDialog(
+        @StringRes titleResId: Int?,
+        @StringRes messageResId: Int,
+        messageSource: String
+    ) {
+        navigator.showMessageDialog(
+            supportFragmentManager,
+            title = titleResId?.let { getString(it) },
+            message = getString(messageResId)
+        )
+        analytics.trackEventSelectContent(
+            AnalyticsService.ParamValue.LEARN_MORE.paramValue,
+            Pair(FirebaseAnalytics.Param.ITEM_ID, messageSource)
+        )
+    }
+
+    override fun onResume() {
+        super.onResume()
+        analytics.trackScreen(AnalyticsService.Screen.TOKEN_METRICS, classSimpleName())
+    }
+
+    private fun updateUI(data: NetworkStats) {
+        with(binding) {
+            totalSupply.text = compactNumber(data.totalSupply)
+            binding.circSupply.text = compactNumber(data.circulatingSupply)
+            if (data.totalSupply != null && data.circulatingSupply != null
+                && data.totalSupply >= data.circulatingSupply
+            ) {
+                binding.circSupplyBar.valueTo = data.totalSupply.toFloat()
+                binding.circSupplyBar.values = listOf(data.circulatingSupply.toFloat())
+            } else {
+                binding.circSupplyBar.visible(false)
+            }
+
+            data.tokenUrl?.let {
+                binding.viewTokenContractBtn.movementMethod =
+                    BetterLinkMovementMethod.newInstance().apply {
+                        setOnLinkClickListener { _, url ->
+                            analytics.trackEventSelectContent(
+                                AnalyticsService.ParamValue.NETWORK_STATS.paramValue,
+                                Pair(
+                                    FirebaseAnalytics.Param.SOURCE,
+                                    AnalyticsService.ParamValue.REWARD_CONTRACT.paramValue
+                                )
+                            )
+                            navigator.openWebsite(this@TokenMetricsActivity, url)
+                            return@setOnLinkClickListener true
+                        }
+                    }
+                binding.viewTokenContractBtn.setHtml(R.string.view_token_contract, it)
+                binding.viewTokenContractBtn.removeLinksUnderline()
+                binding.viewTokenContractBtn.visible(true)
+            }
+
+            lastUpdated.text = getString(R.string.last_updated, data.lastUpdated)
+        }
+    }
+}
+

--- a/app/src/main/res/layout/activity_network_stats.xml
+++ b/app/src/main/res/layout/activity_network_stats.xml
@@ -238,6 +238,80 @@
             </com.google.android.material.card.MaterialCardView>
 
             <com.google.android.material.card.MaterialCardView
+                android:id="@+id/buyCard"
+                style="@style/Widget.WeatherXM.MaterialCard"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginHorizontal="@dimen/margin_normal_to_large"
+                android:layout_marginTop="@dimen/margin_small_to_normal"
+                app:cardBackgroundColor="@color/blueTint"
+                app:cardElevation="@dimen/elevation_small"
+                app:contentPadding="@dimen/padding_small_to_normal"
+                app:contentPaddingLeft="@dimen/padding_large"
+                app:layout_constraintTop_toBottomOf="@id/dataCard">
+
+                <androidx.constraintlayout.widget.ConstraintLayout
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content">
+
+                    <androidx.constraintlayout.widget.ConstraintLayout
+                        android:layout_width="0dp"
+                        android:layout_height="match_parent"
+                        app:layout_constraintBottom_toBottomOf="parent"
+                        app:layout_constraintEnd_toStartOf="@id/buyStationBtn"
+                        app:layout_constraintStart_toStartOf="parent"
+                        app:layout_constraintTop_toTopOf="parent">
+
+                        <com.google.android.material.textview.MaterialTextView
+                            android:id="@+id/earnWxm"
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:text="@string/earn_prompt"
+                            android:textAppearance="@style/TextAppearance.WeatherXM.Default.BodySmall"
+                            app:layout_constraintStart_toStartOf="parent"
+                            app:layout_constraintTop_toTopOf="parent" />
+
+                        <com.google.android.material.textview.MaterialTextView
+                            android:id="@+id/earnWxmPerMonth"
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:layout_marginEnd="@dimen/margin_small"
+                            android:text="@string/earn_wxm"
+                            android:textAppearance="@style/TextAppearance.WeatherXM.Default.PrimaryColor"
+                            android:textSize="16sp"
+                            app:layout_constraintBottom_toBottomOf="parent"
+                            app:layout_constraintStart_toStartOf="parent"
+                            app:layout_constraintTop_toBottomOf="@id/earnWxm" />
+
+                        <ImageButton
+                            android:id="@+id/earnWxmInfoBtn"
+                            style="@style/Widget.WeatherXM.ImageButton"
+                            android:layout_width="30dp"
+                            android:layout_height="30dp"
+                            android:contentDescription="@string/read_more"
+                            android:src="@drawable/ic_learn_more_info"
+                            app:layout_constraintBottom_toBottomOf="@id/earnWxmPerMonth"
+                            app:layout_constraintStart_toEndOf="@id/earnWxmPerMonth"
+                            app:layout_constraintTop_toTopOf="@id/earnWxmPerMonth" />
+
+                    </androidx.constraintlayout.widget.ConstraintLayout>
+
+                    <com.google.android.material.button.MaterialButton
+                        android:id="@+id/buyStationBtn"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:paddingStart="@dimen/padding_normal"
+                        android:paddingEnd="@dimen/padding_normal"
+                        android:text="@string/action_buy_station"
+                        app:layout_constraintBottom_toBottomOf="parent"
+                        app:layout_constraintEnd_toEndOf="parent"
+                        app:layout_constraintTop_toTopOf="parent" />
+
+                </androidx.constraintlayout.widget.ConstraintLayout>
+
+            </com.google.android.material.card.MaterialCardView>
+
+            <com.google.android.material.card.MaterialCardView
                 android:id="@+id/rewardsCard"
                 style="@style/Widget.WeatherXM.MaterialCard"
                 android:layout_width="match_parent"
@@ -247,7 +321,7 @@
                 app:cardElevation="@dimen/elevation_small"
                 app:contentPadding="@dimen/padding_small_to_normal"
                 app:contentPaddingTop="0dp"
-                app:layout_constraintTop_toBottomOf="@id/dataCard">
+                app:layout_constraintTop_toBottomOf="@id/buyCard">
 
                 <androidx.constraintlayout.widget.ConstraintLayout
                     android:layout_width="match_parent"
@@ -482,253 +556,6 @@
 
             </com.google.android.material.card.MaterialCardView>
 
-            <com.google.android.material.card.MaterialCardView
-                android:id="@+id/buyCard"
-                style="@style/Widget.WeatherXM.MaterialCard"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:layout_marginHorizontal="@dimen/margin_normal_to_large"
-                android:layout_marginTop="@dimen/margin_small_to_normal"
-                app:cardBackgroundColor="@color/blueTint"
-                app:cardElevation="@dimen/elevation_small"
-                app:contentPadding="@dimen/padding_small_to_normal"
-                app:contentPaddingLeft="@dimen/padding_large"
-                app:layout_constraintTop_toBottomOf="@id/rewardsCard">
-
-                <androidx.constraintlayout.widget.ConstraintLayout
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content">
-
-                    <androidx.constraintlayout.widget.ConstraintLayout
-                        android:layout_width="0dp"
-                        android:layout_height="match_parent"
-                        app:layout_constraintBottom_toBottomOf="parent"
-                        app:layout_constraintEnd_toStartOf="@id/buyStationBtn"
-                        app:layout_constraintStart_toStartOf="parent"
-                        app:layout_constraintTop_toTopOf="parent">
-
-                        <com.google.android.material.textview.MaterialTextView
-                            android:id="@+id/earnWxm"
-                            android:layout_width="wrap_content"
-                            android:layout_height="wrap_content"
-                            android:text="@string/earn_prompt"
-                            android:textAppearance="@style/TextAppearance.WeatherXM.Default.BodySmall"
-                            app:layout_constraintStart_toStartOf="parent"
-                            app:layout_constraintTop_toTopOf="parent" />
-
-                        <com.google.android.material.textview.MaterialTextView
-                            android:id="@+id/earnWxmPerMonth"
-                            android:layout_width="wrap_content"
-                            android:layout_height="wrap_content"
-                            android:layout_marginEnd="@dimen/margin_small"
-                            android:text="@string/earn_wxm"
-                            android:textAppearance="@style/TextAppearance.WeatherXM.Default.PrimaryColor"
-                            android:textSize="16sp"
-                            app:layout_constraintBottom_toBottomOf="parent"
-                            app:layout_constraintStart_toStartOf="parent"
-                            app:layout_constraintTop_toBottomOf="@id/earnWxm" />
-
-                        <ImageButton
-                            android:id="@+id/earnWxmInfoBtn"
-                            style="@style/Widget.WeatherXM.ImageButton"
-                            android:layout_width="30dp"
-                            android:layout_height="30dp"
-                            android:contentDescription="@string/read_more"
-                            android:src="@drawable/ic_learn_more_info"
-                            app:layout_constraintBottom_toBottomOf="@id/earnWxmPerMonth"
-                            app:layout_constraintStart_toEndOf="@id/earnWxmPerMonth"
-                            app:layout_constraintTop_toTopOf="@id/earnWxmPerMonth" />
-
-                    </androidx.constraintlayout.widget.ConstraintLayout>
-
-                    <com.google.android.material.button.MaterialButton
-                        android:id="@+id/buyStationBtn"
-                        android:layout_width="wrap_content"
-                        android:layout_height="wrap_content"
-                        android:paddingStart="@dimen/padding_normal"
-                        android:paddingEnd="@dimen/padding_normal"
-                        android:text="@string/action_buy_station"
-                        app:layout_constraintBottom_toBottomOf="parent"
-                        app:layout_constraintEnd_toEndOf="parent"
-                        app:layout_constraintTop_toTopOf="parent" />
-
-                </androidx.constraintlayout.widget.ConstraintLayout>
-
-            </com.google.android.material.card.MaterialCardView>
-
-            <com.google.android.material.card.MaterialCardView
-                android:id="@+id/tokenCard"
-                style="@style/Widget.WeatherXM.MaterialCard"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:layout_marginHorizontal="@dimen/margin_normal_to_large"
-                android:layout_marginTop="@dimen/margin_small_to_normal"
-                app:cardElevation="@dimen/elevation_small"
-                app:contentPadding="@dimen/padding_small_to_normal"
-                app:layout_constraintTop_toBottomOf="@id/buyCard">
-
-                <androidx.constraintlayout.widget.ConstraintLayout
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content">
-
-                    <com.google.android.material.textview.MaterialTextView
-                        android:id="@+id/tokenTitle"
-                        android:layout_width="wrap_content"
-                        android:layout_height="wrap_content"
-                        android:layout_marginStart="@dimen/margin_small_to_normal"
-                        android:text="@string/wxm_token"
-                        android:textAppearance="@style/TextAppearance.WeatherXM.Default.BodyLarge"
-                        android:textStyle="bold"
-                        app:layout_constraintStart_toStartOf="parent"
-                        app:layout_constraintTop_toTopOf="parent" />
-
-                    <com.google.android.material.textview.MaterialTextView
-                        android:id="@+id/viewTokenContractBtn"
-                        android:layout_width="wrap_content"
-                        android:layout_height="wrap_content"
-                        android:layout_marginStart="@dimen/margin_small_to_normal"
-                        android:layout_marginTop="@dimen/margin_extra_extra_small"
-                        android:autoLink="none"
-                        android:drawableEnd="@drawable/ic_open_new"
-                        android:drawablePadding="@dimen/padding_extra_small"
-                        android:drawableTint="@color/colorPrimary"
-                        android:text="@string/view_token_contract"
-                        android:textAppearance="@style/TextAppearance.WeatherXM.Default.BodySmall"
-                        android:textColor="@color/colorPrimary"
-                        android:textStyle="bold"
-                        android:visibility="gone"
-                        app:layout_constraintStart_toStartOf="parent"
-                        app:layout_constraintTop_toBottomOf="@id/tokenTitle"
-                        tools:visibility="visible" />
-
-                    <LinearLayout
-                        android:layout_width="match_parent"
-                        android:layout_height="wrap_content"
-                        android:layout_marginTop="@dimen/margin_small_to_normal"
-                        android:orientation="horizontal"
-                        android:weightSum="2"
-                        app:layout_constraintTop_toBottomOf="@id/viewTokenContractBtn">
-
-                        <com.google.android.material.card.MaterialCardView
-                            style="@style/Widget.WeatherXM.MaterialCard"
-                            android:layout_width="0dp"
-                            android:layout_height="match_parent"
-                            android:layout_marginEnd="6dp"
-                            android:layout_weight="1"
-                            app:cardBackgroundColor="@color/layer1"
-                            app:cardCornerRadius="@dimen/radius_medium"
-                            app:contentPadding="@dimen/padding_small_to_normal">
-
-                            <androidx.constraintlayout.widget.ConstraintLayout
-                                android:layout_width="match_parent"
-                                android:layout_height="wrap_content">
-
-                                <com.google.android.material.textview.MaterialTextView
-                                    android:id="@+id/totalSupplyTitle"
-                                    android:layout_width="wrap_content"
-                                    android:layout_height="wrap_content"
-                                    android:text="@string/total_supply"
-                                    android:textAllCaps="true"
-                                    android:textAppearance="@style/TextAppearance.WeatherXM.Default.BodySmall"
-                                    app:layout_constraintStart_toStartOf="parent"
-                                    app:layout_constraintTop_toTopOf="parent" />
-
-                                <ImageButton
-                                    android:id="@+id/totalSupplyBtn"
-                                    style="@style/Widget.WeatherXM.ImageButton"
-                                    android:layout_width="15dp"
-                                    android:layout_height="15dp"
-                                    android:layout_marginStart="@dimen/margin_extra_small"
-                                    android:contentDescription="@string/read_more"
-                                    android:src="@drawable/ic_learn_more_info"
-                                    app:layout_constraintBottom_toBottomOf="@id/totalSupplyTitle"
-                                    app:layout_constraintEnd_toEndOf="parent"
-                                    app:layout_constraintTop_toTopOf="@id/totalSupplyTitle" />
-
-                                <com.google.android.material.textview.MaterialTextView
-                                    android:id="@+id/totalSupply"
-                                    android:layout_width="match_parent"
-                                    android:layout_height="wrap_content"
-                                    android:layout_marginTop="@dimen/margin_small"
-                                    android:textAppearance="@style/TextAppearance.WeatherXM.Default.HeadlineSmall"
-                                    android:textStyle="bold"
-                                    app:layout_constraintTop_toBottomOf="@id/totalSupplyTitle"
-                                    tools:text="100M" />
-
-                            </androidx.constraintlayout.widget.ConstraintLayout>
-                        </com.google.android.material.card.MaterialCardView>
-
-                        <com.google.android.material.card.MaterialCardView
-                            style="@style/Widget.WeatherXM.MaterialCard"
-                            android:layout_width="0dp"
-                            android:layout_height="wrap_content"
-                            android:layout_marginStart="6dp"
-                            android:layout_weight="1"
-                            app:cardBackgroundColor="@color/layer1"
-                            app:cardCornerRadius="@dimen/radius_medium"
-                            app:contentPadding="@dimen/padding_small_to_normal"
-                            app:contentPaddingLeft="0dp"
-                            app:contentPaddingRight="0dp">
-
-                            <androidx.constraintlayout.widget.ConstraintLayout
-                                android:layout_width="match_parent"
-                                android:layout_height="wrap_content">
-
-                                <com.google.android.material.textview.MaterialTextView
-                                    android:id="@+id/circSupplyTitle"
-                                    android:layout_width="0dp"
-                                    android:layout_height="wrap_content"
-                                    android:layout_marginStart="@dimen/margin_small_to_normal"
-                                    android:text="@string/circulating_supply"
-                                    android:textAllCaps="true"
-                                    android:textAppearance="@style/TextAppearance.WeatherXM.Default.BodySmall"
-                                    app:layout_constraintEnd_toStartOf="@id/circSupplyBtn"
-                                    app:layout_constraintStart_toStartOf="parent"
-                                    app:layout_constraintTop_toTopOf="parent" />
-
-                                <ImageButton
-                                    android:id="@+id/circSupplyBtn"
-                                    style="@style/Widget.WeatherXM.ImageButton"
-                                    android:layout_width="15dp"
-                                    android:layout_height="15dp"
-                                    android:layout_marginStart="@dimen/margin_extra_small"
-                                    android:layout_marginEnd="@dimen/margin_small_to_normal"
-                                    android:contentDescription="@string/read_more"
-                                    android:src="@drawable/ic_learn_more_info"
-                                    app:layout_constraintBottom_toBottomOf="@id/circSupplyTitle"
-                                    app:layout_constraintEnd_toEndOf="parent"
-                                    app:layout_constraintTop_toTopOf="@id/circSupplyTitle" />
-
-                                <com.google.android.material.textview.MaterialTextView
-                                    android:id="@+id/circSupply"
-                                    android:layout_width="match_parent"
-                                    android:layout_height="wrap_content"
-                                    android:layout_marginHorizontal="@dimen/margin_small_to_normal"
-                                    android:layout_marginTop="@dimen/margin_small"
-                                    android:textAppearance="@style/TextAppearance.WeatherXM.Default.HeadlineSmall"
-                                    android:textStyle="bold"
-                                    app:layout_constraintTop_toBottomOf="@id/circSupplyTitle"
-                                    tools:text="55.4M" />
-
-                                <com.google.android.material.slider.RangeSlider
-                                    android:id="@+id/circSupplyBar"
-                                    style="@style/Widget.WeatherXM.Slider.NetworkStats"
-                                    android:layout_width="match_parent"
-                                    android:layout_height="wrap_content"
-                                    android:layout_marginHorizontal="@dimen/margin_extra_small"
-                                    android:enabled="false"
-                                    android:valueFrom="0"
-                                    app:layout_constraintTop_toBottomOf="@id/circSupply"
-                                    app:trackHeight="4dp"
-                                    tools:values="@array/network_stats_circ_supply_default_values" />
-
-                            </androidx.constraintlayout.widget.ConstraintLayout>
-                        </com.google.android.material.card.MaterialCardView>
-                    </LinearLayout>
-
-                </androidx.constraintlayout.widget.ConstraintLayout>
-            </com.google.android.material.card.MaterialCardView>
-
             <androidx.compose.ui.platform.ComposeView
                 android:id="@+id/proPromotionCard"
                 android:layout_width="match_parent"
@@ -736,7 +563,7 @@
                 android:layout_marginHorizontal="@dimen/margin_normal_to_large"
                 android:layout_marginTop="@dimen/margin_small_to_normal"
                 android:clipChildren="false"
-                app:layout_constraintTop_toBottomOf="@id/tokenCard"
+                app:layout_constraintTop_toBottomOf="@id/rewardsCard"
                 tools:composableName="com.weatherxm.ui.components.compose.ProPromotionCardKt.PreviewProPromotionCard" />
 
             <com.google.android.material.card.MaterialCardView

--- a/app/src/main/res/layout/activity_token_metrics.xml
+++ b/app/src/main/res/layout/activity_token_metrics.xml
@@ -1,0 +1,240 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.coordinatorlayout.widget.CoordinatorLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/root"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:animateLayoutChanges="true"
+    android:fitsSystemWindows="true">
+
+    <com.google.android.material.appbar.AppBarLayout
+        android:id="@+id/app_bar"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        app:liftOnScroll="false">
+
+        <com.google.android.material.appbar.MaterialToolbar
+            android:id="@+id/toolbar"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            app:navigationIcon="@drawable/ic_back"
+            app:title="@string/token_metrics" />
+
+    </com.google.android.material.appbar.AppBarLayout>
+
+    <androidx.core.widget.NestedScrollView
+        android:id="@+id/dataContainer"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        app:layout_behavior="com.google.android.material.appbar.AppBarLayout$ScrollingViewBehavior">
+
+        <androidx.constraintlayout.widget.ConstraintLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:clipChildren="false">
+
+            <com.google.android.material.card.MaterialCardView
+                android:id="@+id/tokenCard"
+                style="@style/Widget.WeatherXM.MaterialCard"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginHorizontal="@dimen/margin_normal_to_large"
+                android:layout_marginTop="@dimen/margin_normal_to_large"
+                app:cardElevation="@dimen/elevation_small"
+                app:contentPadding="@dimen/padding_small_to_normal"
+                app:layout_constraintTop_toTopOf="parent">
+
+                <androidx.constraintlayout.widget.ConstraintLayout
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content">
+
+                    <com.google.android.material.textview.MaterialTextView
+                        android:id="@+id/tokenTitle"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:layout_marginStart="@dimen/margin_small_to_normal"
+                        android:text="@string/wxm_token"
+                        android:textAppearance="@style/TextAppearance.WeatherXM.Default.BodyLarge"
+                        android:textStyle="bold"
+                        app:layout_constraintStart_toStartOf="parent"
+                        app:layout_constraintTop_toTopOf="parent" />
+
+                    <com.google.android.material.textview.MaterialTextView
+                        android:id="@+id/viewTokenContractBtn"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:layout_marginStart="@dimen/margin_small_to_normal"
+                        android:layout_marginTop="@dimen/margin_extra_extra_small"
+                        android:autoLink="none"
+                        android:drawableEnd="@drawable/ic_open_new"
+                        android:drawablePadding="@dimen/padding_extra_small"
+                        android:drawableTint="@color/colorPrimary"
+                        android:text="@string/view_token_contract"
+                        android:textAppearance="@style/TextAppearance.WeatherXM.Default.BodySmall"
+                        android:textColor="@color/colorPrimary"
+                        android:textStyle="bold"
+                        android:visibility="gone"
+                        app:layout_constraintStart_toStartOf="parent"
+                        app:layout_constraintTop_toBottomOf="@id/tokenTitle"
+                        tools:visibility="visible" />
+
+                    <LinearLayout
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:layout_marginTop="@dimen/margin_small_to_normal"
+                        android:orientation="horizontal"
+                        android:weightSum="2"
+                        app:layout_constraintTop_toBottomOf="@id/viewTokenContractBtn">
+
+                        <com.google.android.material.card.MaterialCardView
+                            style="@style/Widget.WeatherXM.MaterialCard"
+                            android:layout_width="0dp"
+                            android:layout_height="match_parent"
+                            android:layout_marginEnd="6dp"
+                            android:layout_weight="1"
+                            app:cardBackgroundColor="@color/layer1"
+                            app:cardCornerRadius="@dimen/radius_medium"
+                            app:contentPadding="@dimen/padding_small_to_normal">
+
+                            <androidx.constraintlayout.widget.ConstraintLayout
+                                android:layout_width="match_parent"
+                                android:layout_height="wrap_content">
+
+                                <com.google.android.material.textview.MaterialTextView
+                                    android:id="@+id/totalSupplyTitle"
+                                    android:layout_width="wrap_content"
+                                    android:layout_height="wrap_content"
+                                    android:text="@string/total_supply"
+                                    android:textAllCaps="true"
+                                    android:textAppearance="@style/TextAppearance.WeatherXM.Default.BodySmall"
+                                    app:layout_constraintStart_toStartOf="parent"
+                                    app:layout_constraintTop_toTopOf="parent" />
+
+                                <ImageButton
+                                    android:id="@+id/totalSupplyBtn"
+                                    style="@style/Widget.WeatherXM.ImageButton"
+                                    android:layout_width="15dp"
+                                    android:layout_height="15dp"
+                                    android:layout_marginStart="@dimen/margin_extra_small"
+                                    android:contentDescription="@string/read_more"
+                                    android:src="@drawable/ic_learn_more_info"
+                                    app:layout_constraintBottom_toBottomOf="@id/totalSupplyTitle"
+                                    app:layout_constraintEnd_toEndOf="parent"
+                                    app:layout_constraintTop_toTopOf="@id/totalSupplyTitle" />
+
+                                <com.google.android.material.textview.MaterialTextView
+                                    android:id="@+id/totalSupply"
+                                    android:layout_width="match_parent"
+                                    android:layout_height="wrap_content"
+                                    android:layout_marginTop="@dimen/margin_small"
+                                    android:textAppearance="@style/TextAppearance.WeatherXM.Default.HeadlineSmall"
+                                    android:textStyle="bold"
+                                    app:layout_constraintTop_toBottomOf="@id/totalSupplyTitle"
+                                    tools:text="100M" />
+
+                            </androidx.constraintlayout.widget.ConstraintLayout>
+                        </com.google.android.material.card.MaterialCardView>
+
+                        <com.google.android.material.card.MaterialCardView
+                            style="@style/Widget.WeatherXM.MaterialCard"
+                            android:layout_width="0dp"
+                            android:layout_height="wrap_content"
+                            android:layout_marginStart="6dp"
+                            android:layout_weight="1"
+                            app:cardBackgroundColor="@color/layer1"
+                            app:cardCornerRadius="@dimen/radius_medium"
+                            app:contentPadding="@dimen/padding_small_to_normal"
+                            app:contentPaddingLeft="0dp"
+                            app:contentPaddingRight="0dp">
+
+                            <androidx.constraintlayout.widget.ConstraintLayout
+                                android:layout_width="match_parent"
+                                android:layout_height="wrap_content">
+
+                                <com.google.android.material.textview.MaterialTextView
+                                    android:id="@+id/circSupplyTitle"
+                                    android:layout_width="0dp"
+                                    android:layout_height="wrap_content"
+                                    android:layout_marginStart="@dimen/margin_small_to_normal"
+                                    android:text="@string/circulating_supply"
+                                    android:textAllCaps="true"
+                                    android:textAppearance="@style/TextAppearance.WeatherXM.Default.BodySmall"
+                                    app:layout_constraintEnd_toStartOf="@id/circSupplyBtn"
+                                    app:layout_constraintStart_toStartOf="parent"
+                                    app:layout_constraintTop_toTopOf="parent" />
+
+                                <ImageButton
+                                    android:id="@+id/circSupplyBtn"
+                                    style="@style/Widget.WeatherXM.ImageButton"
+                                    android:layout_width="15dp"
+                                    android:layout_height="15dp"
+                                    android:layout_marginStart="@dimen/margin_extra_small"
+                                    android:layout_marginEnd="@dimen/margin_small_to_normal"
+                                    android:contentDescription="@string/read_more"
+                                    android:src="@drawable/ic_learn_more_info"
+                                    app:layout_constraintBottom_toBottomOf="@id/circSupplyTitle"
+                                    app:layout_constraintEnd_toEndOf="parent"
+                                    app:layout_constraintTop_toTopOf="@id/circSupplyTitle" />
+
+                                <com.google.android.material.textview.MaterialTextView
+                                    android:id="@+id/circSupply"
+                                    android:layout_width="match_parent"
+                                    android:layout_height="wrap_content"
+                                    android:layout_marginHorizontal="@dimen/margin_small_to_normal"
+                                    android:layout_marginTop="@dimen/margin_small"
+                                    android:textAppearance="@style/TextAppearance.WeatherXM.Default.HeadlineSmall"
+                                    android:textStyle="bold"
+                                    app:layout_constraintTop_toBottomOf="@id/circSupplyTitle"
+                                    tools:text="55.4M" />
+
+                                <com.google.android.material.slider.RangeSlider
+                                    android:id="@+id/circSupplyBar"
+                                    style="@style/Widget.WeatherXM.Slider.NetworkStats"
+                                    android:layout_width="match_parent"
+                                    android:layout_height="wrap_content"
+                                    android:layout_marginHorizontal="@dimen/margin_extra_small"
+                                    android:enabled="false"
+                                    android:valueFrom="0"
+                                    app:layout_constraintTop_toBottomOf="@id/circSupply"
+                                    app:trackColorActive="@color/blue"
+                                    app:trackHeight="4dp"
+                                    tools:values="@array/network_stats_circ_supply_default_values" />
+
+                            </androidx.constraintlayout.widget.ConstraintLayout>
+                        </com.google.android.material.card.MaterialCardView>
+                    </LinearLayout>
+
+                </androidx.constraintlayout.widget.ConstraintLayout>
+            </com.google.android.material.card.MaterialCardView>
+
+            <com.google.android.material.textview.MaterialTextView
+                android:id="@+id/lastUpdated"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="@dimen/margin_normal"
+                android:layout_marginEnd="@dimen/margin_large"
+                android:layout_marginBottom="@dimen/margin_normal_to_large"
+                android:gravity="end"
+                android:paddingHorizontal="@dimen/padding_extra_small"
+                android:text="@string/last_updated"
+                android:textAppearance="@style/TextAppearance.WeatherXM.Default.BodyMedium"
+                android:textFontWeight="100"
+                app:layout_constraintBottom_toBottomOf="parent"
+                app:layout_constraintTop_toBottomOf="@id/tokenCard" />
+        </androidx.constraintlayout.widget.ConstraintLayout>
+    </androidx.core.widget.NestedScrollView>
+
+    <!-- Empty -->
+
+    <com.weatherxm.ui.components.EmptyView
+        android:id="@+id/empty"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:layout_gravity="center"
+        android:padding="@dimen/padding_extra_large"
+        android:visibility="gone"
+        app:empty_animation="@raw/anim_empty_devices"
+        tools:empty_subtitle="How are you?"
+        tools:empty_title="Nothing here" />
+</androidx.coordinatorlayout.widget.CoordinatorLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -115,6 +115,7 @@
     <string name="manufacturer_prompt">Join the ecosystem</string>
     <string name="last_updated">Last Updated on %s</string>
     <string name="total">Total</string>
+    <string name="token_metrics">Token Metrics</string>
 
     <!-- Network Stats & Search -->
     <string name="search_station_name_address">Search station name or address</string>


### PR DESCRIPTION
### **Why?**
The existing $WXM Token card with the change that it should be moved in the Token Metrics screen. Also, change the color of the Circulating Supply bar 

### **How?**
- Create `TokenMetricsActivity` with the "$WXM Token" card, which opens when the "$WXM Rewards" card is clicked.
- Removed that card from the previous network stats activity.
- Moved the "Buy a station" prompt in network stats **above** the "$WXM Rewards".

### **Testing**

Describe the testing process or steps taken to verify the changes made in this pull request.

### **Additional context**

Add any other context about the PR here or remove this section.
