### PR TITLE
Hotfix for a crash

### DIFF
--- a/app/src/main/java/com/weatherxm/ui/explorer/ExplorerMapFragment.kt
+++ b/app/src/main/java/com/weatherxm/ui/explorer/ExplorerMapFragment.kt
@@ -130,7 +130,7 @@ class ExplorerMapFragment : BaseMapFragment() {
 
         setSearchListeners()
 
-        activity?.onBackPressedDispatcher?.addCallback(owner = this, enabled = false) {
+        activity?.onBackPressedDispatcher?.addCallback(owner = this) {
             onBackPressed()
         }
 


### PR DESCRIPTION
### **Why?**
Fix crash when clicking the system back button on any other screen after passing the explorer (e.g. Devices List -> Explorer -> Profile -> Back Button = crash)

### **How?**
Added the missing `owner = this, enabled = false` in the callback. 

### **Testing**
Ensure it doesn't crash anymore in the above scenario.