### PR TITLE
Support 16KB pages of Android 15

### DIFF
--- a/app/src/main/java/com/weatherxm/ui/components/BaseMapFragment.kt
+++ b/app/src/main/java/com/weatherxm/ui/components/BaseMapFragment.kt
@@ -9,7 +9,6 @@ import com.mapbox.maps.CameraOptions
 import com.mapbox.maps.MapView
 import com.mapbox.maps.MapboxMap
 import com.mapbox.maps.Style
-import com.mapbox.maps.plugin.annotation.AnnotationConfig
 import com.mapbox.maps.plugin.annotation.annotations
 import com.mapbox.maps.plugin.annotation.generated.PointAnnotationManager
 import com.mapbox.maps.plugin.annotation.generated.PolygonAnnotationManager
@@ -19,9 +18,8 @@ import com.mapbox.maps.plugin.gestures.gestures
 import com.mapbox.maps.plugin.scalebar.scalebar
 import com.mapbox.maps.viewannotation.ViewAnnotationManager
 import com.weatherxm.databinding.FragmentMapBinding
-import com.weatherxm.ui.components.BaseMapFragment.OnMapDebugInfoListener
 import com.weatherxm.ui.explorer.ExplorerMapFragment.Companion.STATION_COUNT_POINT_TEXT_SIZE
-import com.weatherxm.ui.explorer.ExplorerViewModel.Companion.POINT_LAYER
+import com.weatherxm.ui.explorer.ExplorerViewModel.Companion.SHOW_STATION_COUNT_ZOOM_LEVEL
 import com.weatherxm.util.DisplayModeHelper
 import dev.chrisbanes.insetter.applyInsetter
 import org.koin.android.ext.android.inject
@@ -102,8 +100,8 @@ open class BaseMapFragment : BaseFragment() {
 
             with(binding.mapView.annotations) {
                 polygonManager = createPolygonAnnotationManager()
-                val config = AnnotationConfig(layerId = POINT_LAYER)
-                pointManager = createPointAnnotationManager(config).apply {
+                pointManager = createPointAnnotationManager().apply {
+                    minZoom = SHOW_STATION_COUNT_ZOOM_LEVEL
                     textSize = STATION_COUNT_POINT_TEXT_SIZE
                 }
             }

--- a/app/src/main/java/com/weatherxm/ui/explorer/ExplorerMapFragment.kt
+++ b/app/src/main/java/com/weatherxm/ui/explorer/ExplorerMapFragment.kt
@@ -23,7 +23,6 @@ import com.mapbox.geojson.Point
 import com.mapbox.maps.CameraOptions
 import com.mapbox.maps.MapboxMap
 import com.mapbox.maps.extension.style.layers.addLayerAbove
-import com.mapbox.maps.extension.style.layers.getLayer
 import com.mapbox.maps.extension.style.sources.addSource
 import com.mapbox.maps.extension.style.sources.generated.GeoJsonSource
 import com.mapbox.maps.extension.style.sources.getSource
@@ -48,8 +47,6 @@ import com.weatherxm.ui.common.toast
 import com.weatherxm.ui.common.visible
 import com.weatherxm.ui.components.BaseMapFragment
 import com.weatherxm.ui.explorer.ExplorerViewModel.Companion.HEATMAP_SOURCE_ID
-import com.weatherxm.ui.explorer.ExplorerViewModel.Companion.POINT_LAYER
-import com.weatherxm.ui.explorer.ExplorerViewModel.Companion.SHOW_STATION_COUNT_ZOOM_LEVEL
 import com.weatherxm.ui.explorer.search.NetworkSearchResultsListAdapter
 import com.weatherxm.ui.explorer.search.NetworkSearchViewModel
 import com.weatherxm.ui.networkstats.NetworkStatsActivity
@@ -108,8 +105,6 @@ class ExplorerMapFragment : BaseMapFragment() {
             MapboxUtils.getCustomData(it)?.let { cell -> navigator.showCellInfo(context, cell) }
             true
         }
-
-        map.getLayer(POINT_LAYER)?.minZoom(SHOW_STATION_COUNT_ZOOM_LEVEL)
 
         map.addOnMapClickListener {
             model.onMapClick()

--- a/app/src/main/java/com/weatherxm/ui/explorer/ExplorerViewModel.kt
+++ b/app/src/main/java/com/weatherxm/ui/explorer/ExplorerViewModel.kt
@@ -41,7 +41,6 @@ class ExplorerViewModel(
         const val HEATMAP_LAYER_SOURCE = "heatmap"
         const val HEATMAP_WEIGHT_KEY = ExplorerUseCase.DEVICE_COUNT_KEY
         const val SHOW_STATION_COUNT_ZOOM_LEVEL: Double = 10.0
-        const val POINT_LAYER: String = "point_layer"
     }
 
     // Explorer Data

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -44,9 +44,9 @@ kotest-koin = "1.3.0"
 kpermissions = "3.5.0"
 lottie = "6.6.7"
 material = "1.12.0"
-mapbox = "11.12.0"
+mapbox = "11.13.1"
 mapbox-sdk-services = "7.4.0"
-mapbox-search-android = "2.12.0"
+mapbox-search-android = "2.14.0-alpha.2"
 mixpanel = "8.2.0"
 mockk = "1.14.3"
 moshi = "1.15.2"
@@ -134,9 +134,9 @@ kotest-assertions = { module = "io.kotest:kotest-assertions-core-jvm", version.r
 kotest-koin = { module = "io.kotest.extensions:kotest-extensions-koin-jvm", version.ref = "kotest-koin" }
 kpermissions = { module = "com.github.fondesa:kpermissions", version.ref = "kpermissions" }
 lottie = { module = "com.airbnb.android:lottie", version.ref = "lottie" }
-mapbox = { module = "com.mapbox.maps:android", version.ref = "mapbox" }
+mapbox = { module = "com.mapbox.maps:android-ndk27", version.ref = "mapbox" }
 mapbox-sdk-services = { module = "com.mapbox.mapboxsdk:mapbox-sdk-services", version.ref = "mapbox-sdk-services" }
-mapbox-search-android = { module = "com.mapbox.search:mapbox-search-android", version.ref = "mapbox-search-android" }
+mapbox-search-android = { module = "com.mapbox.search:mapbox-search-android-ndk27", version.ref = "mapbox-search-android" }
 material = { module = "com.google.android.material:material", version.ref = "material" }
 mixpanel = { module = "com.mixpanel.android:mixpanel-android", version.ref = "mixpanel" }
 moshi-kotlin-codegen = { module = "com.squareup.moshi:moshi-kotlin-codegen", version.ref = "moshi" }


### PR DESCRIPTION
### **Why?**
Support 16KB pages of Android 15.

### **How?**
- Added the respective `-ndk27` versions of our mapbox libraries.
- Also used the new `minZoom` param in `PointManager` of the newest version of Mapbox.

### **Testing**
Create an emulator of 16KB page size and ensure it compiles and launches correctly.

![εικόνα](https://github.com/user-attachments/assets/90e1b557-28b3-4b77-bafe-4b9dfe1056c5)