### PR TITLE
Open Pro App in an external browser

### DIFF
--- a/app/src/main/java/com/weatherxm/ui/Navigator.kt
+++ b/app/src/main/java/com/weatherxm/ui/Navigator.kt
@@ -15,6 +15,7 @@ import androidx.activity.result.PickVisualMediaRequest
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.annotation.StringRes
 import androidx.browser.customtabs.CustomTabsIntent
+import androidx.core.net.toUri
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.FragmentActivity
 import androidx.fragment.app.FragmentManager
@@ -646,7 +647,7 @@ class Navigator(private val analytics: AnalyticsWrapper) {
                 it.startActivity(
                     Intent(
                         Intent.ACTION_VIEW,
-                        Uri.parse(context.getString(R.string.support_center_url))
+                        context.getString(R.string.support_center_url).toUri()
                     )
                 )
             } catch (e: ActivityNotFoundException) {
@@ -672,7 +673,7 @@ class Navigator(private val analytics: AnalyticsWrapper) {
             try {
                 CustomTabsIntent.Builder()
                     .build()
-                    .launchUrl(it, Uri.parse(url))
+                    .launchUrl(it, url.toUri())
             } catch (e: ActivityNotFoundException) {
                 Timber.d(e, "Could not load url: $url")
                 it.toast(R.string.error_open_website_support_cannot_open_url, url)
@@ -680,10 +681,21 @@ class Navigator(private val analytics: AnalyticsWrapper) {
         }
     }
 
+    fun openWebsiteExternally(context: Context?, url: String) {
+        context?.let {
+            try {
+                it.startActivity(Intent(Intent.ACTION_VIEW, url.toUri()))
+            } catch (e: ActivityNotFoundException) {
+                Timber.d(e, "Could not open the external browser.")
+                openWebsite(it, url)
+            }
+        }
+    }
+
     fun openPlayStore(context: Context?, url: String) {
         context?.let {
             try {
-                it.startActivity(Intent(Intent.ACTION_VIEW, Uri.parse(url)))
+                it.startActivity(Intent(Intent.ACTION_VIEW, url.toUri()))
             } catch (e: ActivityNotFoundException) {
                 Timber.d(e, "Could not open play store.")
                 it.toast(R.string.error_cannot_open_play_store)

--- a/app/src/main/java/com/weatherxm/ui/components/ProPromotionDialogFragment.kt
+++ b/app/src/main/java/com/weatherxm/ui/components/ProPromotionDialogFragment.kt
@@ -47,7 +47,7 @@ class ProPromotionDialogFragment : BaseBottomSheetDialogFragment() {
                     AnalyticsService.ParamValue.PRO_PROMOTION.paramValue
                 )
             )
-            navigator.openWebsite(context, getString(R.string.pro_url))
+            navigator.openWebsiteExternally(context, getString(R.string.pro_url))
         }
     }
 


### PR DESCRIPTION
### **Why?**
Open Pro App in an external browser

### **How?**
Created an `openWebsiteExternally` function in `Navigator` and used that for opening the Pro.

### **Testing**
For some reason the emulator crashes when testing it on my Windows, in any case feel free to give it a try, it may be specific to my system. Works OK in a physical device so if you have one please test it there.