### PR TITLE
Fix multiple $opt_in events in Mixpanel

### DIFF
--- a/app/src/main/java/com/weatherxm/analytics/MixpanelAnalyticsService.kt
+++ b/app/src/main/java/com/weatherxm/analytics/MixpanelAnalyticsService.kt
@@ -16,9 +16,9 @@ class MixpanelAnalyticsService(private val mixpanelAPI: MixpanelAPI) : Analytics
     }
 
     override fun setAnalyticsEnabled(enabled: Boolean) {
-        if (enabled) {
+        if (enabled && mixpanelAPI.hasOptedOutTracking()) {
             mixpanelAPI.optInTracking()
-        } else {
+        } else if(!enabled) {
             mixpanelAPI.optOutTracking()
         }
     }

--- a/app/src/test/java/com/weatherxm/analytics/MixpanelAnalyticsServiceTest.kt
+++ b/app/src/test/java/com/weatherxm/analytics/MixpanelAnalyticsServiceTest.kt
@@ -3,6 +3,7 @@ package com.weatherxm.analytics
 import com.mixpanel.android.mpmetrics.MixpanelAPI
 import com.weatherxm.ui.deviceforecast.ForecastDetailsActivity
 import io.kotest.core.spec.style.BehaviorSpec
+import io.mockk.every
 import io.mockk.justRun
 import io.mockk.mockk
 import io.mockk.spyk
@@ -99,10 +100,21 @@ class MixpanelAnalyticsServiceTest : KoinTest, BehaviorSpec({
     context("Enable or Disable Analytics") {
         given("a boolean flag indicating if analytics are enabled or not") {
             When("enabled") {
-                then("then call setAnalyticsCollectionEnabled with TRUE") {
-                    service.setAnalyticsEnabled(true)
-                    verify(exactly = 1) { mixpanelAPI.optInTracking() }
-                    verify(exactly = 0) { mixpanelAPI.optOutTracking() }
+                and("the user has already opted in") {
+                    every { mixpanelAPI.hasOptedOutTracking() } returns false
+                    then("do NOT call optInTracking, do nothing") {
+                        service.setAnalyticsEnabled(true)
+                        verify(exactly = 0) { mixpanelAPI.optInTracking() }
+                        verify(exactly = 0) { mixpanelAPI.optOutTracking() }
+                    }
+                }
+                and("the user has NOT already opted in") {
+                    every { mixpanelAPI.hasOptedOutTracking() } returns true
+                    then("call optInTracking") {
+                        service.setAnalyticsEnabled(true)
+                        verify(exactly = 1) { mixpanelAPI.optInTracking() }
+                        verify(exactly = 0) { mixpanelAPI.optOutTracking() }
+                    }
                 }
             }
             When("disabled") {


### PR DESCRIPTION
### **Why?**
Fix too many opt-in events tracked, issue happening on Android where in the last month we have 278K events.

### **How?**
We check if the user is opted out with `mixpanelAPI.hasOptedOutTracking()` and only if that's true, we proceed with the `optInTracking`.

### **Testing**
Open and close the app multiple times, on the dev flavor, ensure that in the events in Mixpanel Dev, only one Opt In is being shown.