### PR TITLE
Feature/fe 1886 background job to schedule station alert notifications

### DIFF
--- a/app/src/main/java/com/weatherxm/app/App.kt
+++ b/app/src/main/java/com/weatherxm/app/App.kt
@@ -3,7 +3,6 @@ package com.weatherxm.app
 import android.app.Application
 import android.app.NotificationChannel
 import android.app.NotificationManager
-import android.content.Context
 import com.weatherxm.BuildConfig
 import com.weatherxm.service.GlobalUploadObserverService
 import net.gotev.uploadservice.UploadServiceConfig
@@ -28,7 +27,7 @@ class App : Application() {
             UPLOADING_NOTIFICATION_CHANNEL_NAME,
             NotificationManager.IMPORTANCE_DEFAULT
         )
-        val manager = getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
+        val manager = getSystemService(NOTIFICATION_SERVICE) as NotificationManager
         manager.createNotificationChannel(channel)
 
         UploadServiceConfig.initialize(

--- a/app/src/main/java/com/weatherxm/data/datasource/DeviceNotificationsDataSource.kt
+++ b/app/src/main/java/com/weatherxm/data/datasource/DeviceNotificationsDataSource.kt
@@ -1,6 +1,8 @@
 package com.weatherxm.data.datasource
 
+import com.weatherxm.data.models.DeviceNotificationType
 import com.weatherxm.data.services.CacheService
+import com.weatherxm.data.services.CacheService.Companion.getDeviceNotificationFormattedKey
 import com.weatherxm.data.services.CacheService.Companion.getDeviceNotificationTypesFormattedKey
 import com.weatherxm.data.services.CacheService.Companion.getDeviceNotificationsFormattedKey
 
@@ -11,6 +13,8 @@ interface DeviceNotificationsDataSource {
     fun getDeviceNotificationTypesEnabled(deviceId: String): Set<String>
     fun showDeviceNotificationsPrompt(): Boolean
     fun checkDeviceNotificationsPrompt()
+    fun setDeviceNotificationTypeTimestamp(deviceId: String, type: DeviceNotificationType)
+    fun getDeviceNotificationTypeTimestamp(deviceId: String, type: DeviceNotificationType): Long
 }
 
 class DeviceNotificationsDataSourceImpl(
@@ -35,6 +39,22 @@ class DeviceNotificationsDataSourceImpl(
     override fun getDeviceNotificationTypesEnabled(deviceId: String): Set<String> {
         val key = getDeviceNotificationTypesFormattedKey(deviceId)
         return cacheService.getDeviceNotificationTypesEnabled(key)
+    }
+
+    override fun setDeviceNotificationTypeTimestamp(
+        deviceId: String,
+        type: DeviceNotificationType
+    ) {
+        val key = getDeviceNotificationFormattedKey(deviceId, type)
+        cacheService.setDeviceNotificationTypeTimestamp(key, System.currentTimeMillis())
+    }
+
+    override fun getDeviceNotificationTypeTimestamp(
+        deviceId: String,
+        type: DeviceNotificationType
+    ): Long {
+        val key = getDeviceNotificationFormattedKey(deviceId, type)
+        return cacheService.getDeviceNotificationTypeTimestamp(key)
     }
 
     override fun showDeviceNotificationsPrompt() = cacheService.getDeviceNotificationsPrompt()

--- a/app/src/main/java/com/weatherxm/data/models/DataModels.kt
+++ b/app/src/main/java/com/weatherxm/data/models/DataModels.kt
@@ -122,7 +122,7 @@ enum class RemoteMessageType(val id: String, val publicName: String, val desc: S
     STATION(
         "station",
         "Station Notifications",
-        "These notifications are used for announcements regarding your station(s)."
+        "These notifications are used for announcements or alerts regarding your station(s)."
     ),
     DEFAULT("DEFAULT", "Default", "These are general purpose notifications.");
 

--- a/app/src/main/java/com/weatherxm/data/repository/DeviceNotificationsRepository.kt
+++ b/app/src/main/java/com/weatherxm/data/repository/DeviceNotificationsRepository.kt
@@ -14,6 +14,8 @@ interface DeviceNotificationsRepository {
 
     fun showDeviceNotificationsPrompt(): Boolean
     fun checkDeviceNotificationsPrompt()
+    fun setDeviceNotificationTypeTimestamp(deviceId: String, type: DeviceNotificationType)
+    fun getDeviceNotificationTypeTimestamp(deviceId: String, type: DeviceNotificationType): Long
 }
 
 class DeviceNotificationsRepositoryImpl(
@@ -46,4 +48,17 @@ class DeviceNotificationsRepositoryImpl(
 
     override fun showDeviceNotificationsPrompt() = datasource.showDeviceNotificationsPrompt()
     override fun checkDeviceNotificationsPrompt() = datasource.checkDeviceNotificationsPrompt()
+    override fun setDeviceNotificationTypeTimestamp(
+        deviceId: String,
+        type: DeviceNotificationType
+    ) {
+        datasource.setDeviceNotificationTypeTimestamp(deviceId, type)
+    }
+
+    override fun getDeviceNotificationTypeTimestamp(
+        deviceId: String,
+        type: DeviceNotificationType
+    ): Long {
+        return datasource.getDeviceNotificationTypeTimestamp(deviceId, type)
+    }
 }

--- a/app/src/main/java/com/weatherxm/data/services/CacheService.kt
+++ b/app/src/main/java/com/weatherxm/data/services/CacheService.kt
@@ -59,6 +59,7 @@ class CacheService(
         const val KEY_DEVICE_NOTIFICATIONS = "device_notifications"
         const val KEY_DEVICE_NOTIFICATION_TYPES = "device_notification_types"
         const val KEY_DEVICE_NOTIFICATIONS_PROMPT = "device_notifications_prompt"
+        const val KEY_DEVICE_NOTIFICATION = "device_notification"
 
         // Default in-memory cache expiration time 15 minutes
         val DEFAULT_CACHE_EXPIRATION = TimeUnit.MINUTES.toMillis(15L)
@@ -86,6 +87,13 @@ class CacheService(
 
         fun getDeviceNotificationTypesFormattedKey(deviceId: String): String {
             return "${KEY_DEVICE_NOTIFICATION_TYPES}_${deviceId}"
+        }
+
+        fun getDeviceNotificationFormattedKey(
+            deviceId: String,
+            deviceNotificationType: DeviceNotificationType
+        ): String {
+            return "${KEY_DEVICE_NOTIFICATION}_${deviceNotificationType}_${deviceId}"
         }
     }
 
@@ -470,6 +478,14 @@ class CacheService(
 
     fun getDeviceNotificationsPrompt(): Boolean {
         return preferences.getBoolean(KEY_DEVICE_NOTIFICATIONS_PROMPT, true)
+    }
+
+    fun setDeviceNotificationTypeTimestamp(key: String, timestamp: Long) {
+        preferences.edit { putLong(key, timestamp) }
+    }
+
+    fun getDeviceNotificationTypeTimestamp(key: String): Long {
+        return preferences.getLong(key, 0L)
     }
 
     fun getPreferredUnit(

--- a/app/src/main/java/com/weatherxm/service/workers/DevicesNotificationsWorker.kt
+++ b/app/src/main/java/com/weatherxm/service/workers/DevicesNotificationsWorker.kt
@@ -1,0 +1,266 @@
+package com.weatherxm.service.workers
+
+import android.Manifest.permission.POST_NOTIFICATIONS
+import android.annotation.SuppressLint
+import android.app.NotificationChannel
+import android.app.NotificationManager
+import android.app.PendingIntent
+import android.app.TaskStackBuilder
+import android.content.Context
+import android.content.Context.NOTIFICATION_SERVICE
+import android.content.Intent
+import android.os.Build
+import androidx.core.app.NotificationCompat
+import androidx.core.app.NotificationManagerCompat
+import androidx.work.Constraints
+import androidx.work.CoroutineWorker
+import androidx.work.ExistingPeriodicWorkPolicy
+import androidx.work.PeriodicWorkRequestBuilder
+import androidx.work.WorkManager
+import androidx.work.WorkerParameters
+import arrow.core.Either
+import arrow.core.getOrElse
+import com.weatherxm.R
+import com.weatherxm.data.models.ApiError
+import com.weatherxm.data.models.DeviceNotificationType
+import com.weatherxm.data.models.RemoteMessageType
+import com.weatherxm.data.models.UserActionError
+import com.weatherxm.data.repository.AuthRepository
+import com.weatherxm.data.repository.DeviceNotificationsRepository
+import com.weatherxm.data.requireNetwork
+import com.weatherxm.ui.common.Contracts
+import com.weatherxm.ui.common.UIDevice
+import com.weatherxm.ui.devicedetails.DeviceDetailsActivity
+import com.weatherxm.usecases.DeviceListUseCase
+import com.weatherxm.util.AndroidBuildInfo
+import com.weatherxm.util.hasPermission
+import com.weatherxm.util.isYesterday
+import org.koin.core.component.KoinComponent
+import org.koin.core.component.inject
+import timber.log.Timber
+import kotlin.time.Duration.Companion.minutes
+import kotlin.time.toJavaDuration
+
+class DevicesNotificationsWorker(
+    private val context: Context,
+    workerParams: WorkerParameters
+) : CoroutineWorker(context, workerParams), KoinComponent {
+    companion object {
+        // STOPSHIP: TODO: change the below to 2 hours, currently testing.
+        private val UPDATE_INTERVAL = 20.minutes.toJavaDuration()
+        private const val WORK_NAME = "DEVICES_NOTIFICATIONS_WORKER"
+        private const val QOD_THRESHOLD = 80
+
+        fun stopWorkers(context: Context) {
+            Timber.d("[Devices BG Worker]: Stopping Work Manager for devices workers.")
+            WorkManager.getInstance(context).cancelUniqueWork(WORK_NAME)
+        }
+
+        fun initAndStart(context: Context) {
+            Timber.d("[Devices BG Worker]: Starting Work Manager for devices.")
+
+            val request = PeriodicWorkRequestBuilder<DevicesNotificationsWorker>(UPDATE_INTERVAL)
+                .setConstraints(Constraints.Companion.requireNetwork())
+                .setInitialDelay(UPDATE_INTERVAL)
+                .build()
+
+            WorkManager.Companion.getInstance(context).enqueueUniquePeriodicWork(
+                WORK_NAME,
+                ExistingPeriodicWorkPolicy.KEEP,
+                request
+            )
+        }
+    }
+
+    private val devicesUseCase: DeviceListUseCase by inject()
+    private val notificationsRepo: DeviceNotificationsRepository by inject()
+    private val authRepo: AuthRepository by inject()
+
+    @SuppressLint("InlinedApi")
+    override suspend fun doWork(): Result {
+        val hasPermission = if (AndroidBuildInfo.sdkInt >= Build.VERSION_CODES.TIRAMISU) {
+            context.hasPermission(POST_NOTIFICATIONS)
+        } else {
+            NotificationManagerCompat.from(context).areNotificationsEnabled()
+        }
+        if (!hasPermission) {
+            Timber.d("[Devices BG Worker]: No notifications permissions, stopping worker.")
+            stopWorkers(context)
+            return Result.failure()
+        }
+        Timber.d("[Devices BG Worker]: Starting work...")
+
+        return authRepo.isLoggedIn().let { isLoggedIn ->
+            if (isLoggedIn) {
+                devicesUseCase.getUserDevices().map {
+                    checkDevices(it)
+                    Result.success()
+                }
+            } else {
+                Either.Left(UserActionError.UserNotLoggedInError())
+            }
+        }.getOrElse { failure ->
+            when (failure) {
+                is UserActionError.UserNotLoggedInError -> {
+                    Timber.w("[Devices BG Worker]: UserNotLoggedInError.")
+                    stopWorkers(context)
+                    Result.success()
+                }
+                is ApiError.GenericError.JWTError.ForbiddenError -> {
+                    Timber.w("[Devices BG Worker]: JWTError.ForbiddenError.")
+                    stopWorkers(context)
+                    Result.success()
+                }
+                else -> {
+                    Timber.w(
+                        Exception("Fetching user devices failed: ${failure.code}"),
+                        failure.toString()
+                    )
+                    Result.retry()
+                }
+            }
+        }
+    }
+
+    private fun checkDevices(devices: List<UIDevice>) {
+        val ownedDevicesWithNotifications = devices.filter {
+            it.isOwned() && notificationsRepo.getDeviceNotificationsEnabled(it.id)
+        }.ifEmpty {
+            Timber.d("[Devices BG Worker]: No owned devices with notifications enabled found.")
+            stopWorkers(context)
+            return
+        }
+
+        Timber.d("[Devices BG Worker]: Devices with notifications enabled found.")
+        ownedDevicesWithNotifications.forEach {
+            val typesEnabled = notificationsRepo.getDeviceNotificationTypesEnabled(it.id)
+
+            if (!it.isOnline() && typesEnabled.contains(DeviceNotificationType.ACTIVITY)) {
+                Timber.d("[Devices BG Worker]: Sending notification for offline device ${it.id}")
+                // TODO: Send notification ONLY if previous notification was before the latest activity or a day has passed
+                sendNotification(
+                    context = context,
+                    title = context.getString(R.string.station_inactive),
+                    body = context.getString(
+                        R.string.station_inactive_notification_msg,
+                        it.getDefaultOrFriendlyName()
+                    ),
+                    device = it,
+                    notificationType = DeviceNotificationType.ACTIVITY
+                )
+            }
+            if (it.hasLowBattery == true && typesEnabled.contains(DeviceNotificationType.BATTERY)) {
+                Timber.d("[Devices BG Worker]: Sending notification for low battery ${it.id}")
+                // TODO: Send notification ONLY if we haven't sent today
+                sendNotification(
+                    context = context,
+                    title = context.getString(R.string.station_low_battery),
+                    body = context.getString(
+                        R.string.station_low_battery_notification_msg,
+                        it.getDefaultOrFriendlyName()
+                    ),
+                    device = it,
+                    notificationType = DeviceNotificationType.BATTERY
+                )
+            }
+            if (it.shouldPromptUpdate() && typesEnabled.contains(DeviceNotificationType.FIRMWARE)) {
+                Timber.d("[Devices BG Worker]: Sending notification for firmware update ${it.id}")
+                // TODO: Send notification ONLY if we haven't sent today
+                sendNotification(
+                    context = context,
+                    title = context.getString(R.string.firmware_update),
+                    body = context.getString(
+                        R.string.firmware_update_notification_msg,
+                        it.getDefaultOrFriendlyName()
+                    ),
+                    device = it,
+                    notificationType = DeviceNotificationType.FIRMWARE
+                )
+            }
+            if (it.notifyOfBadHealth() && typesEnabled.contains(DeviceNotificationType.HEALTH)) {
+                Timber.d("[Devices BG Worker]: Sending notification for health issues ${it.id}")
+                // TODO: Send notification ONLY if we haven't sent today
+                sendNotification(
+                    context = context,
+                    title = context.getString(R.string.station_health_issues),
+                    body = context.getString(
+                        R.string.station_health_issues_notification_msg,
+                        it.getDefaultOrFriendlyName()
+                    ),
+                    device = it,
+                    notificationType = DeviceNotificationType.HEALTH
+                )
+            }
+        }
+    }
+
+    private fun UIDevice.notifyOfBadHealth(): Boolean {
+        val qodBelowThreshold = qodScore != null && qodScore < QOD_THRESHOLD
+        val hasPolIssue = polReason != null
+        val areDataForPreviousDay = metricsTimestamp != null && metricsTimestamp.isYesterday()
+        (qodScore != null && qodScore < QOD_THRESHOLD) || polReason != null
+
+        return areDataForPreviousDay && (qodBelowThreshold || hasPolIssue)
+    }
+
+    private fun sendNotification(
+        context: Context,
+        title: String,
+        body: String,
+        device: UIDevice,
+        notificationType: DeviceNotificationType
+    ) {
+        val type = RemoteMessageType.STATION
+
+        val manager = context.getSystemService(NOTIFICATION_SERVICE) as NotificationManager
+        val channel = NotificationChannel(
+            type.id, type.publicName, NotificationManager.IMPORTANCE_DEFAULT
+        )
+        channel.description = type.desc
+        manager.createNotificationChannel(channel)
+
+        val notification = NotificationCompat.Builder(context, type.id).apply {
+            createPendingIntent(context, device, notificationType)?.let {
+                setContentIntent(it)
+            }
+            setSmallIcon(R.drawable.ic_logo)
+            setContentTitle(title)
+            setContentText(body)
+            setAutoCancel(true)
+        }.build()
+
+        /**
+         * As long as the IDs are different a different notification will show up:
+         * https://developer.android.com/reference/android/app/NotificationManager#notify(java.lang.String,%20int,%20android.app.Notification)
+         */
+        val notificationId = notificationType.name.hashCode() + device.id.hashCode()
+        manager.notify(null, notificationId, notification)
+    }
+
+    private fun createPendingIntent(
+        context: Context,
+        device: UIDevice,
+        notificationType: DeviceNotificationType
+    ): PendingIntent? {
+        val deviceDetailsActivity = Intent(context, DeviceDetailsActivity::class.java)
+            .putExtra(Contracts.ARG_DEVICE, device)
+
+        /**
+         * A unique request code per Intent, to allow different notifications for the same device
+         * to open the Device Details screen.
+         */
+        val requestCode = notificationType.name.hashCode() + device.id.hashCode()
+
+        return TaskStackBuilder.create(context).run {
+            addNextIntentWithParentStack(deviceDetailsActivity)
+            if (AndroidBuildInfo.sdkInt >= Build.VERSION_CODES.S) {
+                getPendingIntent(
+                    requestCode,
+                    PendingIntent.FLAG_CANCEL_CURRENT or PendingIntent.FLAG_MUTABLE
+                )
+            } else {
+                getPendingIntent(requestCode, PendingIntent.FLAG_CANCEL_CURRENT)
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/weatherxm/ui/common/UIModels.kt
+++ b/app/src/main/java/com/weatherxm/ui/common/UIModels.kt
@@ -146,7 +146,7 @@ data class UIDevice(
     }
 
     fun isEmpty() = id.isEmpty() && name.isEmpty() && cellIndex.isEmpty()
-    fun isOnline() = isActive != null && isActive == true
+    fun isOnline() = isActive != null && isActive
 
     fun hasErrors(): Boolean {
         return alerts.firstOrNull {

--- a/app/src/main/java/com/weatherxm/ui/devicenotifications/DeviceNotificationsActivity.kt
+++ b/app/src/main/java/com/weatherxm/ui/devicenotifications/DeviceNotificationsActivity.kt
@@ -7,6 +7,7 @@ import android.os.Bundle
 import androidx.core.app.NotificationManagerCompat
 import com.weatherxm.R
 import com.weatherxm.databinding.ActivityDeviceNotificationsBinding
+import com.weatherxm.service.workers.DevicesNotificationsWorker
 import com.weatherxm.ui.common.Contracts.ARG_DEVICE
 import com.weatherxm.ui.common.DeviceRelation
 import com.weatherxm.ui.common.UIDevice
@@ -72,11 +73,11 @@ class DeviceNotificationsActivity : BaseActivity() {
             SwitchWithIcon(isChecked = model.notificationsEnabled.value) {
                 if (it) {
                     if (hasNotificationPermissions) {
-                        model.setDeviceNotificationsEnabled(true)
+                        onNotificationsEnabled()
                     } else if (AndroidBuildInfo.sdkInt >= TIRAMISU) {
                         checkPermissionsAndThen(
                             permissions = arrayOf(POST_NOTIFICATIONS),
-                            onGranted = { model.setDeviceNotificationsEnabled(true) },
+                            onGranted = { onNotificationsEnabled() },
                             onDenied = { model.setDeviceNotificationsEnabled(false) }
                         )
                     }
@@ -85,6 +86,11 @@ class DeviceNotificationsActivity : BaseActivity() {
                 }
             }
         }
+    }
+
+    private fun onNotificationsEnabled() {
+        DevicesNotificationsWorker.initAndStart(this)
+        model.setDeviceNotificationsEnabled(true)
     }
 
     private fun handleNotificationCategories() {

--- a/app/src/main/java/com/weatherxm/ui/home/HomeActivity.kt
+++ b/app/src/main/java/com/weatherxm/ui/home/HomeActivity.kt
@@ -12,6 +12,7 @@ import com.mapbox.geojson.Point
 import com.weatherxm.R
 import com.weatherxm.data.models.Location
 import com.weatherxm.databinding.ActivityHomeBinding
+import com.weatherxm.service.workers.DevicesNotificationsWorker
 import com.weatherxm.ui.common.Contracts
 import com.weatherxm.ui.common.Resource
 import com.weatherxm.ui.common.Status
@@ -182,6 +183,9 @@ class HomeActivity : BaseActivity(), BaseMapFragment.OnMapDebugInfoListener {
         } else {
             binding.emptyContainer.visible(false)
             binding.claimRedDot.visible(false)
+        }
+        if (resource.data?.any { it.isOwned() } ?: false) {
+            DevicesNotificationsWorker.initAndStart(this)
         }
     }
 

--- a/app/src/main/java/com/weatherxm/usecases/StartupUseCase.kt
+++ b/app/src/main/java/com/weatherxm/usecases/StartupUseCase.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import com.weatherxm.data.repository.AppConfigRepository
 import com.weatherxm.data.repository.AuthRepository
 import com.weatherxm.data.repository.UserPreferencesRepository
+import com.weatherxm.service.workers.DevicesNotificationsWorker
 import com.weatherxm.service.workers.RefreshFcmApiWorker
 import com.weatherxm.ui.startup.StartupState
 import kotlinx.coroutines.CoroutineDispatcher
@@ -44,7 +45,10 @@ class StartupUseCaseImpl(
                 trySend(StartupState.ShowUpdate)
             } else {
                 val isLoggedIn = authRepository.isLoggedIn().apply {
-                    if (this) RefreshFcmApiWorker.initAndRefreshToken(context, null)
+                    if (this) {
+                        RefreshFcmApiWorker.initAndRefreshToken(context, null)
+                        DevicesNotificationsWorker.initAndStart(context)
+                    }
                 }
                 Timber.d("User logged in: $isLoggedIn")
                 if (isLoggedIn && userPreferencesRepository.shouldShowAnalyticsOptIn()) {

--- a/app/src/main/java/com/weatherxm/usecases/StartupUseCase.kt
+++ b/app/src/main/java/com/weatherxm/usecases/StartupUseCase.kt
@@ -4,7 +4,6 @@ import android.content.Context
 import com.weatherxm.data.repository.AppConfigRepository
 import com.weatherxm.data.repository.AuthRepository
 import com.weatherxm.data.repository.UserPreferencesRepository
-import com.weatherxm.service.workers.DevicesNotificationsWorker
 import com.weatherxm.service.workers.RefreshFcmApiWorker
 import com.weatherxm.ui.startup.StartupState
 import kotlinx.coroutines.CoroutineDispatcher
@@ -45,10 +44,7 @@ class StartupUseCaseImpl(
                 trySend(StartupState.ShowUpdate)
             } else {
                 val isLoggedIn = authRepository.isLoggedIn().apply {
-                    if (this) {
-                        RefreshFcmApiWorker.initAndRefreshToken(context, null)
-                        DevicesNotificationsWorker.initAndStart(context)
-                    }
+                    if (this) RefreshFcmApiWorker.initAndRefreshToken(context, null)
                 }
                 Timber.d("User logged in: $isLoggedIn")
                 if (isLoggedIn && userPreferencesRepository.shouldShowAnalyticsOptIn()) {

--- a/app/src/main/java/com/weatherxm/util/ZonedDateTime.kt
+++ b/app/src/main/java/com/weatherxm/util/ZonedDateTime.kt
@@ -7,6 +7,12 @@ fun ZonedDateTime.isToday(): Boolean {
     return now.dayOfYear == this.dayOfYear
 }
 
+fun ZonedDateTime.isYesterday(): Boolean {
+    val today = ZonedDateTime.now(this.zone).toLocalDate()
+    val yesterdayDate = today.minusDays(1)
+    return this.toLocalDate() == yesterdayDate
+}
+
 fun ZonedDateTime.toISODate(): String = this.toLocalDate().toString()
 
 fun ZonedDateTime.isSameDayAndHour(targetTimestamp: ZonedDateTime): Boolean {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -597,6 +597,13 @@
     <string name="health_notification_subtitle">Get notified when there are issues affecting the station’s health.</string>
     <string name="station_notifications">Station Notifications</string>
     <string name="station_notifications_dialog_prompt">You’ll now receive notifications for critical issues like inactivity or low battery. This feature is enabled by default if you’ve already allowed app notifications.\n\nYou can manage these settings from the menu at the top right corner.</string>
+    <string name="station_inactive">Station Inactive</string>
+    <string name="station_inactive_notification_msg">Your station %s appears inactive. Please check its status.</string>
+    <string name="station_low_battery">Station Low Battery</string>
+    <string name="station_low_battery_notification_msg">To avoid data interruptions, please replace the batteries of %s.</string>
+    <string name="firmware_update_notification_msg">A new version is available for %s. Upgrade to enjoy the latest improvements.</string>
+    <string name="station_health_issues">Station Health Issues</string>
+    <string name="station_health_issues_notification_msg">Your station %s has some health issues. Tap to view its status.</string>
 
     <!-- Alerts -->
     <string name="alerts">Alerts</string>

--- a/app/src/test/java/com/weatherxm/data/repository/DeviceNotificationsRepositoryTest.kt
+++ b/app/src/test/java/com/weatherxm/data/repository/DeviceNotificationsRepositoryTest.kt
@@ -14,7 +14,8 @@ class DeviceNotificationsRepositoryTest : BehaviorSpec({
     val repository = DeviceNotificationsRepositoryImpl(dataSource)
 
     val deviceId = "deviceId"
-    val notificationTypes = setOf(DeviceNotificationType.ACTIVITY, DeviceNotificationType.HEALTH)
+    val healthType = DeviceNotificationType.HEALTH
+    val notificationTypes = setOf(DeviceNotificationType.ACTIVITY, healthType)
     val typesAsStringSet = notificationTypes.map { it.name }.toSet()
 
     beforeSpec {
@@ -24,6 +25,8 @@ class DeviceNotificationsRepositoryTest : BehaviorSpec({
         every { dataSource.getDeviceNotificationTypesEnabled(deviceId) } returns typesAsStringSet
         every { dataSource.showDeviceNotificationsPrompt() } returns true
         coJustRun { dataSource.checkDeviceNotificationsPrompt() }
+        every { dataSource.getDeviceNotificationTypeTimestamp(deviceId, healthType) } returns 0L
+        coJustRun { dataSource.setDeviceNotificationTypeTimestamp(deviceId, healthType) }
     }
 
     context("GET / SET if the device notifications are enabled") {
@@ -58,7 +61,6 @@ class DeviceNotificationsRepositoryTest : BehaviorSpec({
         }
     }
 
-
     context("GET / SET if the notifications prompt should be shown") {
         When("GET") {
             then("return if the prompt should be shown") {
@@ -69,6 +71,22 @@ class DeviceNotificationsRepositoryTest : BehaviorSpec({
             then("check that the prompt is set") {
                 repository.checkDeviceNotificationsPrompt()
                 verify(exactly = 1) { dataSource.checkDeviceNotificationsPrompt() }
+            }
+        }
+    }
+
+    context("GET / SET the timestamp of a specific device notification type") {
+        When("GET") {
+            then("return that timestamp") {
+                repository.getDeviceNotificationTypeTimestamp(deviceId, healthType) shouldBe 0L
+            }
+        }
+        When("SET") {
+            then("set that timestamp") {
+                repository.setDeviceNotificationTypeTimestamp(deviceId, healthType)
+                verify(exactly = 1) {
+                    dataSource.setDeviceNotificationTypeTimestamp(deviceId, healthType)
+                }
             }
         }
     }

--- a/app/src/test/java/com/weatherxm/data/services/PrefsSingleVarTest.kt
+++ b/app/src/test/java/com/weatherxm/data/services/PrefsSingleVarTest.kt
@@ -6,6 +6,7 @@ import com.weatherxm.data.models.DeviceNotificationType
 import com.weatherxm.data.models.RemoteBannerType
 import com.weatherxm.data.services.CacheService.Companion.KEY_ACCEPT_TERMS_TIMESTAMP
 import com.weatherxm.data.services.CacheService.Companion.KEY_ANALYTICS_OPT_IN_OR_OUT_TIMESTAMP
+import com.weatherxm.data.services.CacheService.Companion.KEY_DEVICE_NOTIFICATION
 import com.weatherxm.data.services.CacheService.Companion.KEY_DEVICE_NOTIFICATIONS_PROMPT
 import com.weatherxm.data.services.CacheService.Companion.KEY_DISMISSED_ANNOUNCEMENT_ID
 import com.weatherxm.data.services.CacheService.Companion.KEY_DISMISSED_INFO_BANNER_ID
@@ -200,6 +201,15 @@ class PrefsSingleVarTest(
             { prefEditor.putBoolean(KEY_DEVICE_NOTIFICATIONS_PROMPT, false) },
             { cacheService.getDeviceNotificationsPrompt() },
             { cacheService.checkDeviceNotificationsPrompt() }
+        )
+
+        behaviorSpec.testGetSetSingleVar(
+            "Device Notification Type Timestamp",
+            timestamp,
+            { sharedPref.getLong(KEY_DEVICE_NOTIFICATION, 0) },
+            { prefEditor.putLong(KEY_DEVICE_NOTIFICATION, timestamp) },
+            { cacheService.getDeviceNotificationTypeTimestamp(KEY_DEVICE_NOTIFICATION) },
+            { cacheService.setDeviceNotificationTypeTimestamp(KEY_DEVICE_NOTIFICATION, timestamp) }
         )
     }
 }

--- a/app/src/test/java/com/weatherxm/util/ZonedDateTimeTest.kt
+++ b/app/src/test/java/com/weatherxm/util/ZonedDateTimeTest.kt
@@ -7,6 +7,7 @@ import java.time.ZonedDateTime
 class ZonedDateTimeTest : BehaviorSpec({
     val today = ZonedDateTime.now()
     val tomorrow = today.plusDays(1)
+    val yesterday = today.minusDays(1)
 
     given("A ZonedDateTime") {
         When("is today") {
@@ -29,6 +30,11 @@ class ZonedDateTimeTest : BehaviorSpec({
             }
             and("Compare with different ZonedDateTime if they are same day & hour") {
                 today.isSameDayAndHour(tomorrow) shouldBe false
+            }
+        }
+        When("is yesterday") {
+            then("return true") {
+                yesterday.isYesterday() shouldBe true
             }
         }
     }


### PR DESCRIPTION
### **Why?**
Background job to schedule station alert notifications

### **How?**
- Created the respective functions `setDeviceNotificationTypeTimestamp` and `getDeviceNotificationTypeTimestamp` in the data source, repo and cache which SET/GET the timestamp of the latest notification on a specific device + type.
- Created the worker `DevicesNotificationsWorker` which is responsible for running in the background, performing the required checks and sending a notification if needed. 
- The entry point for that worker is on the `HomeActivity` and whenever the main switch is enabled in a device's notification screen. That worker has the `KEEP` param which means on every `initAndStart` that is called, if there is already an instance pending to run, it won't be replaced (to avoid recreating instances on multiple start-ups or multiple on/off in the workers).
- If the user has no notification permissions, or logged out, or no notifications enabled on his own devices, then the `stopWorker` function is called.

### **Testing**
Install the app and enable notifications and make sure the worker & notifications work properly based on the requirements we have. For testing purposes you can change the 2 hours interval to 20 minutes, in `class DevicesNotificationsWorker` (change `private val UPDATE_INTERVAL = 2.hours.toJavaDuration()` to `private val UPDATE_INTERVAL = 20.minutes.toJavaDuration()`)
