### PR TITLE
Feature/fe 1908 start the upload of the photos after claiming is successful

### DIFF
--- a/app/src/main/java/com/weatherxm/ui/claimdevice/helium/ClaimHeliumActivity.kt
+++ b/app/src/main/java/com/weatherxm/ui/claimdevice/helium/ClaimHeliumActivity.kt
@@ -92,7 +92,7 @@ class ClaimHeliumActivity : BaseActivity() {
                 device,
                 photosViewModel.onPhotos.toList(),
                 metadata,
-                device.id
+                DeviceType.HELIUM.name
             )
         }
 

--- a/app/src/main/java/com/weatherxm/ui/claimdevice/helium/result/ClaimHeliumResultFragment.kt
+++ b/app/src/main/java/com/weatherxm/ui/claimdevice/helium/result/ClaimHeliumResultFragment.kt
@@ -14,6 +14,7 @@ import com.weatherxm.analytics.AnalyticsService
 import com.weatherxm.databinding.FragmentClaimHeliumResultBinding
 import com.weatherxm.ui.claimdevice.helium.ClaimHeliumViewModel
 import com.weatherxm.ui.claimdevice.location.ClaimLocationViewModel
+import com.weatherxm.ui.claimdevice.photosgallery.ClaimPhotosGalleryViewModel
 import com.weatherxm.ui.common.Resource
 import com.weatherxm.ui.common.Status
 import com.weatherxm.ui.common.UIDevice
@@ -29,6 +30,7 @@ class ClaimHeliumResultFragment : BaseFragment() {
     private val parentModel: ClaimHeliumViewModel by activityViewModel()
     private val locationModel: ClaimLocationViewModel by activityViewModel()
     private val model: ClaimHeliumResultViewModel by activityViewModel()
+    private val photosModel: ClaimPhotosGalleryViewModel by activityViewModel()
     private lateinit var binding: FragmentClaimHeliumResultBinding
 
     companion object {
@@ -79,7 +81,7 @@ class ClaimHeliumResultFragment : BaseFragment() {
 
         model.onBLEClaimingKey().observe(viewLifecycleOwner) {
             parentModel.setDeviceKey(it)
-            parentModel.claimDevice(locationModel.getInstallationLocation())
+            parentModel.claimDevice(locationModel.getInstallationLocation(), photosModel.onPhotos)
         }
 
         model.onBLEError().observe(viewLifecycleOwner) { uiError ->
@@ -190,7 +192,10 @@ class ClaimHeliumResultFragment : BaseFragment() {
                     )
                     onLoadingState()
                     onStep(STEP_CLAIM_STATION)
-                    parentModel.claimDevice(locationModel.getInstallationLocation())
+                    parentModel.claimDevice(
+                        locationModel.getInstallationLocation(),
+                        photosModel.onPhotos
+                    )
                 }
                 binding.failureButtonsContainer.visible(true)
                 binding.status.clear()

--- a/app/src/main/java/com/weatherxm/ui/claimdevice/photosgallery/ClaimPhotosGalleryViewModel.kt
+++ b/app/src/main/java/com/weatherxm/ui/claimdevice/photosgallery/ClaimPhotosGalleryViewModel.kt
@@ -1,10 +1,8 @@
 package com.weatherxm.ui.claimdevice.photosgallery
 
 import androidx.compose.runtime.mutableStateListOf
-import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
-import com.weatherxm.data.models.PhotoPresignedMetadata
 import com.weatherxm.ui.common.PhotoSource
 import com.weatherxm.ui.common.StationPhoto
 import java.io.File
@@ -12,11 +10,9 @@ import java.io.File
 class ClaimPhotosGalleryViewModel : ViewModel() {
     private val _onRequestCameraPermission = MutableLiveData(false)
     private val _onPhotos = mutableStateListOf<StationPhoto>()
-    private val onPhotosMetadata = MutableLiveData<List<PhotoPresignedMetadata>>()
 
     fun onRequestCameraPermission() = _onRequestCameraPermission
     val onPhotos: List<StationPhoto> = _onPhotos
-    fun onPhotosMetadata(): LiveData<List<PhotoPresignedMetadata>> = onPhotosMetadata
 
     fun addPhoto(path: String, photoSource: PhotoSource) {
         if (path.isNotEmpty()) {

--- a/app/src/main/java/com/weatherxm/ui/claimdevice/photosgallery/ClaimPhotosGalleryViewModel.kt
+++ b/app/src/main/java/com/weatherxm/ui/claimdevice/photosgallery/ClaimPhotosGalleryViewModel.kt
@@ -1,8 +1,10 @@
 package com.weatherxm.ui.claimdevice.photosgallery
 
 import androidx.compose.runtime.mutableStateListOf
+import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
+import com.weatherxm.data.models.PhotoPresignedMetadata
 import com.weatherxm.ui.common.PhotoSource
 import com.weatherxm.ui.common.StationPhoto
 import java.io.File
@@ -10,9 +12,11 @@ import java.io.File
 class ClaimPhotosGalleryViewModel : ViewModel() {
     private val _onRequestCameraPermission = MutableLiveData(false)
     private val _onPhotos = mutableStateListOf<StationPhoto>()
+    private val onPhotosMetadata = MutableLiveData<List<PhotoPresignedMetadata>>()
 
     fun onRequestCameraPermission() = _onRequestCameraPermission
     val onPhotos: List<StationPhoto> = _onPhotos
+    fun onPhotosMetadata(): LiveData<List<PhotoPresignedMetadata>> = onPhotosMetadata
 
     fun addPhoto(path: String, photoSource: PhotoSource) {
         if (path.isNotEmpty()) {

--- a/app/src/main/java/com/weatherxm/ui/claimdevice/pulse/ClaimPulseActivity.kt
+++ b/app/src/main/java/com/weatherxm/ui/claimdevice/pulse/ClaimPulseActivity.kt
@@ -79,7 +79,7 @@ class ClaimPulseActivity : BaseActivity() {
                 device,
                 photosViewModel.onPhotos.toList(),
                 metadata,
-                device.id
+                model.getSerialNumber()
             )
         }
 

--- a/app/src/main/java/com/weatherxm/ui/claimdevice/pulse/ClaimPulseActivity.kt
+++ b/app/src/main/java/com/weatherxm/ui/claimdevice/pulse/ClaimPulseActivity.kt
@@ -7,6 +7,7 @@ import androidx.viewpager2.adapter.FragmentStateAdapter
 import com.weatherxm.R
 import com.weatherxm.analytics.AnalyticsService
 import com.weatherxm.databinding.ActivityClaimDeviceBinding
+import com.weatherxm.service.GlobalUploadObserverService
 import com.weatherxm.ui.claimdevice.beforeyouclaim.ClaimBeforeYouClaimFragment
 import com.weatherxm.ui.claimdevice.location.ClaimLocationFragment
 import com.weatherxm.ui.claimdevice.location.ClaimLocationViewModel
@@ -27,7 +28,9 @@ import com.weatherxm.ui.common.classSimpleName
 import com.weatherxm.ui.common.empty
 import com.weatherxm.ui.common.visible
 import com.weatherxm.ui.components.BaseActivity
+import org.koin.android.ext.android.inject
 import org.koin.androidx.viewmodel.ext.android.viewModel
+import kotlin.getValue
 
 class ClaimPulseActivity : BaseActivity() {
     companion object {
@@ -37,6 +40,7 @@ class ClaimPulseActivity : BaseActivity() {
     }
 
     private lateinit var binding: ActivityClaimDeviceBinding
+    private val uploadObserverService: GlobalUploadObserverService by inject()
     private val model: ClaimPulseViewModel by viewModel()
     private val locationModel: ClaimLocationViewModel by viewModel()
     private val photosViewModel: ClaimPhotosGalleryViewModel by viewModel()
@@ -63,6 +67,20 @@ class ClaimPulseActivity : BaseActivity() {
         binding.toolbar.title = getString(R.string.title_claim_pulse_4g)
         binding.toolbar.setNavigationOnClickListener {
             finish()
+        }
+
+        model.onPhotosMetadata().observe(this) { (device, metadata) ->
+            val numberOfPhotosToUpload = List(photosViewModel.onPhotos.size) { index ->
+                metadata.getOrNull(index)
+            }.filterNotNull().size
+            uploadObserverService.setData(device, numberOfPhotosToUpload)
+
+            startWorkerForUploadingPhotos(
+                device,
+                photosViewModel.onPhotos.toList(),
+                metadata,
+                device.id
+            )
         }
 
         savedInstanceState?.let {
@@ -102,7 +120,10 @@ class ClaimPulseActivity : BaseActivity() {
                 PAGE_RESULT -> {
                     binding.appBar.visible(false)
                     binding.progress.visible(false)
-                    model.claimDevice(locationModel.getInstallationLocation())
+                    model.claimDevice(
+                        locationModel.getInstallationLocation(),
+                        photosViewModel.onPhotos
+                    )
                 }
             }
         }

--- a/app/src/main/java/com/weatherxm/ui/claimdevice/result/ClaimResultFragment.kt
+++ b/app/src/main/java/com/weatherxm/ui/claimdevice/result/ClaimResultFragment.kt
@@ -11,6 +11,7 @@ import com.weatherxm.R
 import com.weatherxm.analytics.AnalyticsService
 import com.weatherxm.databinding.FragmentClaimResultBinding
 import com.weatherxm.ui.claimdevice.location.ClaimLocationViewModel
+import com.weatherxm.ui.claimdevice.photosgallery.ClaimPhotosGalleryViewModel
 import com.weatherxm.ui.claimdevice.pulse.ClaimPulseViewModel
 import com.weatherxm.ui.claimdevice.wifi.ClaimWifiViewModel
 import com.weatherxm.ui.common.Contracts.ARG_DEVICE_TYPE
@@ -29,6 +30,7 @@ class ClaimResultFragment : BaseFragment() {
     private val wifiParentModel: ClaimWifiViewModel by activityViewModel()
     private val pulseParentModel: ClaimPulseViewModel by activityViewModel()
     private val locationModel: ClaimLocationViewModel by activityViewModel()
+    private val photosModel: ClaimPhotosGalleryViewModel by activityViewModel()
     private lateinit var binding: FragmentClaimResultBinding
     private lateinit var deviceType: DeviceType
 
@@ -89,9 +91,15 @@ class ClaimResultFragment : BaseFragment() {
                 )
             )
             if (deviceType == PULSE_4G) {
-                pulseParentModel.claimDevice(locationModel.getInstallationLocation())
+                pulseParentModel.claimDevice(
+                    locationModel.getInstallationLocation(),
+                    photosModel.onPhotos
+                )
             } else {
-                wifiParentModel.claimDevice(locationModel.getInstallationLocation())
+                wifiParentModel.claimDevice(
+                    locationModel.getInstallationLocation(),
+                    photosModel.onPhotos
+                )
             }
         }
 

--- a/app/src/main/java/com/weatherxm/ui/claimdevice/wifi/ClaimWifiActivity.kt
+++ b/app/src/main/java/com/weatherxm/ui/claimdevice/wifi/ClaimWifiActivity.kt
@@ -87,7 +87,7 @@ class ClaimWifiActivity : BaseActivity() {
                 device,
                 photosViewModel.onPhotos.toList(),
                 metadata,
-                device.id
+                model.getSerialNumber()
             )
         }
 

--- a/app/src/test/java/com/weatherxm/ui/claimdevice/photosgallery/ClaimPhotosGalleryViewModelTest.kt
+++ b/app/src/test/java/com/weatherxm/ui/claimdevice/photosgallery/ClaimPhotosGalleryViewModelTest.kt
@@ -1,0 +1,70 @@
+package com.weatherxm.ui.claimdevice.photosgallery
+
+import com.weatherxm.ui.InstantExecutorListener
+import com.weatherxm.ui.common.PhotoSource
+import com.weatherxm.ui.common.StationPhoto
+import io.kotest.core.spec.style.BehaviorSpec
+import io.kotest.matchers.shouldBe
+
+class ClaimPhotosGalleryViewModelTest : BehaviorSpec({
+    val emptyPhotos = mutableListOf<StationPhoto>()
+    val viewModel = ClaimPhotosGalleryViewModel()
+
+    val localPath = "localPath"
+    val localPhoto = StationPhoto(null, localPath, PhotoSource.GALLERY)
+    val photosListWithOneLocalPhoto = mutableListOf(
+        StationPhoto(
+            null,
+            localPath,
+            PhotoSource.GALLERY
+        )
+    )
+
+    listener(InstantExecutorListener())
+
+    context("Add a photo") {
+        given("the path of the photo") {
+            When("the path is empty") {
+                then("Do nothing. So the photos should still be the same empty list.") {
+                    viewModel.addPhoto("", PhotoSource.GALLERY)
+                    viewModel.onPhotos shouldBe emptyPhotos
+                }
+            }
+            When("the path is not empty") {
+                viewModel.addPhoto(localPath, PhotoSource.GALLERY)
+                then("the photo should be added") {
+                    viewModel.onPhotos shouldBe photosListWithOneLocalPhoto
+                }
+            }
+        }
+    }
+
+    context("Delete a photo") {
+        given("the photo to delete") {
+            When("we do not have this photo in our list") {
+                viewModel.deletePhoto(StationPhoto(null, null))
+                then("Do nothing. So the photos should still be the same list.") {
+                    viewModel.onPhotos shouldBe photosListWithOneLocalPhoto
+                }
+            }
+            When("the photo is a local photo and our photos var contain it") {
+                viewModel.deletePhoto(localPhoto)
+                then("The onPhotos function should return the empty list") {
+                    viewModel.onPhotos shouldBe emptyPhotos
+                }
+            }
+        }
+    }
+
+    context("Request camera permissions") {
+        given("a function to trigger that request") {
+            then("the respective LiveData initially should be false") {
+                viewModel.onRequestCameraPermission().value shouldBe false
+            }
+            viewModel.requestCameraPermission()
+            then("the respective LiveData should be triggered") {
+                viewModel.onRequestCameraPermission().value shouldBe true
+            }
+        }
+    }
+})


### PR DESCRIPTION
### **Why?**
Start the upload of the photos after claiming is successful

### **How?**
- Moved some of the code that we use to start the upload worker in `BaseActivity` under the name `fun startWorkerForUploadingPhotos` in order to reuse it throughout our app.
- Created the respective functions for getting the photos metadata from the API in `ClaimHeliumViewModel`, `ClaimPulseViewModel` and `ClaimWifiViewModel` and call these functions when a claiming is successful.
- As soon as that endpoint returns with valid metadata, observe them and start the uploading photo process in `ClaimHeliumActivity`, `ClaimWifiActivity` and `ClaimPulseActivity`.
- Created the missing unit tests

### **Testing**
Currently not testable until we get a device which we can claim for test purposes.
Otherwise what I did is that in `ClaimWifiViewModel` at `onLeft` of `claimDevice` I put the below where `{your_device_id}` could ne a device ID of your own devices to upload the photos there:
```
 prepareUpload(
                    UIDevice(
                        "{your_device_id}",
                        "My Weather Station",
                        String.empty(),
                        DeviceRelation.OWNED,
                        null,
                        "friendlyName",
                        null,
                        null,
                        null,
                        null,
                        null,
                        null,
                        null,
                        null,
                        null,
                        null,
                        null,
                        null,
                        null,
                        null,
                        null,
                        null,
                        null,
                        null,
                        null,
                        100F,
                        100F,
                        null,
                        null,
                        null
                    ),
                    photos
                )
```

### **Additional Context**
A lot of the code in this PR is duplicate one, given that this is a temporary solution (aka [ζελοτέιπ](https://www.google.com/search?client=firefox-b-d&q=%CE%B6%CE%B5%CE%BB%CE%BF%CF%84%CE%B5%CE%B9%CF%80)) it was faster/easier to do it like this than create new reusable mechanisms, test everything from scratch and then after some time discard it again.