### PR TITLE
Different handling of update prompts for Solana users.

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -18,13 +18,17 @@ jacoco {
     toolVersion = "0.8.12"
 }
 
-fun getVersionGitTags(printForDebugging: Boolean = false): List<String> {
+fun getVersionGitTags(isSolana: Boolean, printForDebugging: Boolean = false): List<String> {
     if (printForDebugging) {
-        println("Filter and print ordered release tags")
+        println("Filter and print ordered release tags - [Includes Solana: $isSolana]")
     }
-    val versionTagsWithOptionalRCRegex = Regex("[RC-]*[0-9]*_*[0-9]+[.][0-9]+[.][0-9]+")
+    val versionTagsRegex = if (isSolana) {
+        Regex("Solana_[0-9]*_*[0-9]+[.][0-9]+[.][0-9]+")
+    } else {
+        Regex("[RC-]*[0-9]*_*[0-9]+[.][0-9]+[.][0-9]+")
+    }
     return grgit.tag.list().filter {
-        it.name.matches(versionTagsWithOptionalRCRegex)
+        it.name.matches(versionTagsRegex)
     }.sortedBy {
         it.dateTime
     }.map {
@@ -35,9 +39,9 @@ fun getVersionGitTags(printForDebugging: Boolean = false): List<String> {
     }
 }
 
-fun getLastVersionGitTag(printForDebugging: Boolean = true): String {
-    var lastVersionTag = getVersionGitTags(printForDebugging).last()
-    if (lastVersionTag.startsWith("RC")) {
+fun getLastVersionGitTag(isSolana: Boolean, printForDebugging: Boolean = true): String {
+    var lastVersionTag = getVersionGitTags(isSolana, printForDebugging).last()
+    if (isSolana || lastVersionTag.startsWith("RC")) {
         lastVersionTag = lastVersionTag.substringAfterLast("_")
     }
     println("Last Version Tag: $lastVersionTag")
@@ -78,13 +82,14 @@ android {
     compileSdk = 36
     buildToolsVersion = "36.0.0"
 
+    val skipTagsLogging = !project.hasProperty("SKIP_TAGS_LOGGING")
+
     defaultConfig {
         applicationId = "com.weatherxm.app"
         minSdk = 28
         targetSdk = 36
-        versionCode = 10 + getVersionGitTags().size
-        val skipTagsLogging = !project.hasProperty("SKIP_TAGS_LOGGING")
-        versionName = getLastVersionGitTag(skipTagsLogging)
+        versionCode = 10 + getVersionGitTags(isSolana = false).size
+        versionName = getLastVersionGitTag(false, skipTagsLogging)
 
         // Resource value fields
         resValue("string", "mapbox_access_token", getStringProperty("MAPBOX_ACCESS_TOKEN"))
@@ -203,6 +208,13 @@ android {
             }
         }
         create("solana") {
+            /**
+             * We need different version codes and version names for Solana to use them for checking
+             * if a user should be prompted to update.
+             * That's why we have introduced a different handling here.
+             */
+            versionCode = 10 + getVersionGitTags(isSolana = true).size
+            versionName = getLastVersionGitTag(true, skipTagsLogging)
             val apiURL = getFlavorProperty("API_URL", "production.env")
             val claimDAppUrl = getFlavorProperty("CLAIM_APP_URL", "production.env")
             val mixpanelToken = getFlavorProperty("MIXPANEL_TOKEN", "production.env")

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -29,6 +29,16 @@
     <uses-permission android:name="com.google.android.gms.permission.AD_ID" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE_CONNECTED_DEVICE" />
 
+    <queries>
+        <intent>
+            <action android:name="android.intent.action.VIEW" />
+            <category android:name="android.intent.category.BROWSABLE" />
+            <data
+                android:host="details"
+                android:scheme="solanadappstore" />
+        </intent>
+    </queries>
+
     <application
         android:name="com.weatherxm.app.App"
         android:allowBackup="false"

--- a/app/src/main/java/com/weatherxm/ui/Navigator.kt
+++ b/app/src/main/java/com/weatherxm/ui/Navigator.kt
@@ -684,13 +684,13 @@ class Navigator(private val analytics: AnalyticsWrapper) {
         }
     }
 
-    fun openPlayStore(context: Context?, url: String) {
+    fun openStore(context: Context?, url: String) {
         context?.let {
             try {
                 it.startActivity(Intent(Intent.ACTION_VIEW, url.toUri()))
             } catch (e: ActivityNotFoundException) {
-                Timber.d(e, "Could not open play store.")
-                it.toast(R.string.error_cannot_open_play_store)
+                Timber.d(e, "Could not open the store.")
+                it.toast(R.string.error_cannot_open_store)
             }
         }
     }

--- a/app/src/main/java/com/weatherxm/ui/login/LoginActivity.kt
+++ b/app/src/main/java/com/weatherxm/ui/login/LoginActivity.kt
@@ -123,7 +123,6 @@ class LoginActivity : BaseActivity() {
     private fun onLoginResult(result: Resource<Unit>) {
         when (result.status) {
             Status.SUCCESS -> {
-                Timber.d("Login success. Get user to check if he has a wallet")
                 setInputEnabled(false)
                 binding.loading.invisible()
             }

--- a/app/src/main/java/com/weatherxm/ui/login/LoginViewModel.kt
+++ b/app/src/main/java/com/weatherxm/ui/login/LoginViewModel.kt
@@ -52,7 +52,7 @@ class LoginViewModel(
                     return@launch
                 }
                 .flatMap {
-                    onLogin.postValue(Resource.success(Unit))
+                    Timber.d("Login success. Get user to check if he has a wallet")
                     userUseCase.getUser()
                 }
                 .mapLeft {

--- a/app/src/main/java/com/weatherxm/ui/updateprompt/UpdatePromptActivity.kt
+++ b/app/src/main/java/com/weatherxm/ui/updateprompt/UpdatePromptActivity.kt
@@ -55,7 +55,8 @@ class UpdatePromptActivity : BaseActivity() {
                     AnalyticsService.ParamValue.UPDATE.paramValue
                 )
             )
-            navigator.openPlayStore(this, getString(R.string.market_url, packageName))
+            // STOPSHIP: Until we have the URL of the Solana. 
+            navigator.openStore(this, getString(R.string.market_url))
         }
 
         binding.continueWithoutUpdatingBtn.setOnClickListener {

--- a/app/src/main/java/com/weatherxm/ui/updateprompt/UpdatePromptActivity.kt
+++ b/app/src/main/java/com/weatherxm/ui/updateprompt/UpdatePromptActivity.kt
@@ -55,7 +55,6 @@ class UpdatePromptActivity : BaseActivity() {
                     AnalyticsService.ParamValue.UPDATE.paramValue
                 )
             )
-            // STOPSHIP: Until we have the URL of the Solana. 
             navigator.openStore(this, getString(R.string.market_url))
         }
 

--- a/app/src/main/res/values/company_info.xml
+++ b/app/src/main/res/values/company_info.xml
@@ -10,7 +10,7 @@
     <string name="troubleshooting_helium_url">https://docs.weatherxm.com/wxm-devices/helium/troubleshooting</string>
     <string name="user_panel_url">https://docs.google.com/forms/d/e/1FAIpQLSc35pJdxM0tosVh-az0goKEjE1xzBs_OVo5V23coC8z1ayD6g/viewform</string>
     <string name="delete_account_survey_url">https://docs.google.com/forms/d/e/1FAIpQLSdWPLpyUx2fNIiohQ-XaskbkZuoUSqYhwIkGGjupJ7IDEX_aA/viewform?usp=pp_url</string>
-    <string name="market_url">market://details?id=%s</string>
+    <string name="market_url">market://details?id=com.weatherxm.app</string>
     <string name="m5_connect_wifi_instructional_video">https://www.youtube.com/watch?v=sUJEwuFq1CE</string>
     <string name="d1_connect_wifi_instructional_video">https://www.youtube.com/watch?v=D3rz1Y01Qhg</string>
     <string name="helium_frequencies_mapping_url">https://docs.helium.com/iot/lorawan-region-plans/</string>

--- a/app/src/main/res/values/messages.xml
+++ b/app/src/main/res/values/messages.xml
@@ -37,7 +37,7 @@
     <string name="error_cell_devices_no_data">Failed to get the cell devices.</string>
     <string name="error_rewards_no_data">Oops! $WXM rewards could not be fetched.</string>
     <string name="error_open_website_support_cannot_open_url">Oops! Could not open %s</string>
-    <string name="error_cannot_open_play_store">Oops! Could not open Play Store.</string>
+    <string name="error_cannot_open_store">Oops! Could not open the Store.</string>
     <string name="error_cannot_open_app_settings">Oops! Could not open App Settings.</string>
     <string name="error_cannot_open_support_center">Oops! Could not open browser.</string>
     <string name="error_cannot_open_wallet">Oops! Could not open that wallet.</string>

--- a/app/src/solana/res/values/company_info.xml
+++ b/app/src/solana/res/values/company_info.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="market_url">https://weatherxm.com</string>
+    <string name="market_url">solanadappstore://details?id=com.weatherxm.app.solana</string>
 </resources>

--- a/app/src/solana/res/values/company_info.xml
+++ b/app/src/solana/res/values/company_info.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="market_url">https://weatherxm.com</string>
+</resources>

--- a/app/src/test/java/com/weatherxm/ui/login/LoginViewModelTest.kt
+++ b/app/src/test/java/com/weatherxm/ui/login/LoginViewModelTest.kt
@@ -138,9 +138,6 @@ class LoginViewModelTest : BehaviorSpec({
                 coMockEitherRight({ usecase.login(username, password) }, authToken)
                 coMockEitherLeft({ userUseCase.getUser() }, failure)
                 runTest { viewModel.login(username, password) }
-                then("LiveData of login posts a success") {
-                    viewModel.onLogin().isSuccess(Unit)
-                }
                 then("Log that error as a failure event") {
                     verify(exactly = 5) { analytics.trackEventFailure(any()) }
                 }
@@ -152,9 +149,6 @@ class LoginViewModelTest : BehaviorSpec({
                 coMockEitherRight({ usecase.login(username, password) }, authToken)
                 coMockEitherRight({ userUseCase.getUser() }, user)
                 runTest { viewModel.login(username, password) }
-                then("LiveData of login posts a success") {
-                    viewModel.onLogin().isSuccess(Unit)
-                }
                 then("Set the user id in analytics") {
                     verify(exactly = 1) { analytics.setUserId(user.id) }
                 }


### PR DESCRIPTION
### **Why?**
As of now, we were using auto-generated version names and version codes for our apps. In this PR a similar mechanism is introduced, but for Solana. Instead of using the current tags we use in our prod app, different tags will be used for Solana, only those starting with the prefix `Solana_` (such as, the already created `Solana_4.10.0` and `Solana_5.0.0`).

This ensures that Solana versions don't need to follow and/or match our production app's one and we don't have to create new releases in our prod app to match the Solana ones.

Also, conditional audiences have been created in the Firebase's Remote Config that target our Solana app.
So, in case of an update prompt is found, redirect the users to the Solana DApp Store.

### **How?**
In the `getVersionGitTags` and `getLastVersionGitTag`, we introduced the variable `isSolana` which handles the regex differently. The default config is still used in all flavors except the Solana one which runs the above functions and sets the respective `versionCode` and `versionNumber` with the `isSolana = true`.

### **Testing**
1. Run the app and ensure in the in-app settings that the version number is 5.0.0
2. Play around with the Firebase Remote Config, increase the `android_app_version_code` **for the Solana audience only** and ensure you get an update prompt.