### PR TITLE
Handle the logout response and update the UI accordingly

### DIFF
--- a/app/src/main/java/com/weatherxm/data/repository/AuthRepository.kt
+++ b/app/src/main/java/com/weatherxm/data/repository/AuthRepository.kt
@@ -6,7 +6,7 @@ import com.weatherxm.data.network.AuthToken
 
 interface AuthRepository {
     suspend fun login(username: String, password: String): Either<Failure, AuthToken>
-    suspend fun logout()
+    suspend fun logout(): Either<Failure, Unit>
     fun isLoggedIn(): Boolean
     suspend fun signup(
         username: String,

--- a/app/src/main/java/com/weatherxm/service/workers/ForceLogoutWorker.kt
+++ b/app/src/main/java/com/weatherxm/service/workers/ForceLogoutWorker.kt
@@ -21,19 +21,20 @@ class ForceLogoutWorker(
 
     override suspend fun doWork(): Result {
         Timber.d("Starting Work Manager for forced logout.")
-        authRepository.logout()
-        widgetHelper.getWidgetIds().onRight {
-            val intent = Intent(AppWidgetManager.ACTION_APPWIDGET_UPDATE)
-            val ids = it.map { id ->
-                id.toInt()
+        authRepository.logout().onRight {
+            widgetHelper.getWidgetIds().onRight {
+                val intent = Intent(AppWidgetManager.ACTION_APPWIDGET_UPDATE)
+                val ids = it.map { id ->
+                    id.toInt()
+                }
+                intent.putExtra(
+                    AppWidgetManager.EXTRA_APPWIDGET_IDS,
+                    ids.toIntArray()
+                )
+                intent.putExtra(Contracts.ARG_IS_CUSTOM_APPWIDGET_UPDATE, true)
+                intent.putExtra(Contracts.ARG_WIDGET_SHOULD_LOGIN, true)
+                context.sendBroadcast(intent)
             }
-            intent.putExtra(
-                AppWidgetManager.EXTRA_APPWIDGET_IDS,
-                ids.toIntArray()
-            )
-            intent.putExtra(Contracts.ARG_IS_CUSTOM_APPWIDGET_UPDATE, true)
-            intent.putExtra(Contracts.ARG_WIDGET_SHOULD_LOGIN, true)
-            context.sendBroadcast(intent)
         }
         return Result.success()
     }

--- a/app/src/main/java/com/weatherxm/ui/preferences/PreferenceActivity.kt
+++ b/app/src/main/java/com/weatherxm/ui/preferences/PreferenceActivity.kt
@@ -5,7 +5,9 @@ import android.os.Bundle
 import android.view.MenuItem
 import com.weatherxm.analytics.AnalyticsService
 import com.weatherxm.databinding.ActivityPreferencesBinding
+import com.weatherxm.ui.common.Status
 import com.weatherxm.ui.common.classSimpleName
+import com.weatherxm.ui.common.visible
 import com.weatherxm.ui.components.BaseActivity
 import org.koin.android.ext.android.inject
 import org.koin.androidx.viewmodel.ext.android.viewModel
@@ -22,6 +24,23 @@ class PreferenceActivity : BaseActivity() {
 
         binding.toolbar.setNavigationOnClickListener {
             onBackPressedDispatcher.onBackPressed()
+        }
+
+        model.onLogout().observe(this) {
+            when (it.status) {
+                Status.SUCCESS -> {
+                    binding.statusViewContainer.visible(false)
+                }
+                Status.ERROR -> {
+                    binding.statusViewContainer.visible(false)
+                    it.message?.let { message ->
+                        showSnackbarMessage(binding.root, message, callback = { model.logout() })
+                    }
+                }
+                Status.LOADING -> {
+                    binding.statusViewContainer.visible(true)
+                }
+            }
         }
 
         sharedPreferences.registerOnSharedPreferenceChangeListener(model.onPreferencesChanged)

--- a/app/src/main/java/com/weatherxm/ui/preferences/PreferenceFragment.kt
+++ b/app/src/main/java/com/weatherxm/ui/preferences/PreferenceFragment.kt
@@ -17,6 +17,7 @@ import com.weatherxm.analytics.AnalyticsService
 import com.weatherxm.analytics.AnalyticsWrapper
 import com.weatherxm.ui.Navigator
 import com.weatherxm.ui.common.Contracts
+import com.weatherxm.ui.common.Status
 import com.weatherxm.ui.components.ActionDialogFragment
 import com.weatherxm.util.AndroidBuildInfo
 import com.weatherxm.util.DisplayModeHelper
@@ -108,8 +109,8 @@ class PreferenceFragment : PreferenceFragmentCompat() {
             onLoggedOut(logoutBtn, resetPassBtn, deleteAccountButton, analyticsPreference)
         }
 
-        model.onLogout().observe(this) { hasLoggedOut ->
-            if (hasLoggedOut) {
+        model.onLogout().observe(this) { logoutResponse ->
+            if (logoutResponse.status == Status.SUCCESS) {
                 analytics.trackEventSelectContent(AnalyticsService.ParamValue.LOGOUT.paramValue)
                 widgetHelper.getWidgetIds().onRight {
                     val intent = Intent(AppWidgetManager.ACTION_APPWIDGET_UPDATE)

--- a/app/src/main/java/com/weatherxm/usecases/AuthUseCase.kt
+++ b/app/src/main/java/com/weatherxm/usecases/AuthUseCase.kt
@@ -17,7 +17,7 @@ interface AuthUseCase {
     suspend fun resetPassword(email: String): Either<Failure, Unit>
     fun isLoggedIn(): Boolean
     suspend fun isPasswordCorrect(password: String): Either<Failure, Boolean>
-    suspend fun logout()
+    suspend fun logout(): Either<Failure, Unit>
 }
 
 class AuthUseCaseImpl(
@@ -53,7 +53,7 @@ class AuthUseCaseImpl(
         return authRepository.isPasswordCorrect(password)
     }
 
-    override suspend fun logout() {
-        authRepository.logout()
+    override suspend fun logout(): Either<Failure, Unit> {
+        return authRepository.logout()
     }
 }

--- a/app/src/main/res/layout/activity_preferences.xml
+++ b/app/src/main/res/layout/activity_preferences.xml
@@ -43,4 +43,22 @@
 
     </androidx.core.widget.NestedScrollView>
 
+    <FrameLayout
+        android:id="@+id/statusViewContainer"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:background="@color/translucent"
+        android:visibility="gone"
+        tools:visibility="visible">
+
+        <com.weatherxm.ui.components.EmptyView
+            android:id="@+id/statusView"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:layout_gravity="center"
+            app:empty_animation="@raw/anim_loading"
+            app:lottie_autoPlay="true"
+            app:lottie_loop="true" />
+    </FrameLayout>
+
 </androidx.coordinatorlayout.widget.CoordinatorLayout>

--- a/app/src/test/java/com/weatherxm/usecases/AuthUseCaseTest.kt
+++ b/app/src/test/java/com/weatherxm/usecases/AuthUseCaseTest.kt
@@ -28,7 +28,6 @@ class AuthUseCaseTest : BehaviorSpec({
 
     beforeSpec {
         coJustRun { notificationsRepository.setFcmToken() }
-        coJustRun { authRepository.logout() }
     }
 
     context("Get if a user is logged in or not") {
@@ -122,13 +121,22 @@ class AuthUseCaseTest : BehaviorSpec({
         }
     }
 
+
+
     context("Logout a user") {
         given("A repository providing LOGOUT mechanism") {
-            then("logout the user") {
-                usecase.logout()
-                coVerify(exactly = 1) { authRepository.logout() }
+            When("the response is a failure") {
+                coMockEitherLeft({ authRepository.logout() }, failure)
+                then("return that failure") {
+                    usecase.logout().isError()
+                }
             }
-
+            When("the response is a success") {
+                coMockEitherRight({ authRepository.logout() }, Unit)
+                then("return the username") {
+                    usecase.logout().isSuccess(Unit)
+                }
+            }
         }
     }
 })


### PR DESCRIPTION
### **Why?**
Handle the logout response and update the UI accordingly.

### **How?**
Instead of instantly returning, now we return the respective `Either<Failure, Unit>` to the UI and using `Resource(...)` we propagate to the activity + fragment the respective loading, success or error state which we show to the user respectively.

### **Testing**
Perform some logouts and ensure everything looks OK in that preferences screen.
