### PR TITLE
Handle error codes 429 + force refresh in the profile screen

### DIFF
--- a/app/src/main/java/com/weatherxm/data/Extensions.kt
+++ b/app/src/main/java/com/weatherxm/data/Extensions.kt
@@ -78,7 +78,7 @@ fun Response.path(): String = this.request.path()
  * Map a NetworkResponse to Either using Failure sealed classes.
  * Suppress ComplexMethod because it is just a bunch of "when statements"
  */
-@Suppress("ComplexMethod")
+@Suppress("ComplexMethod", "MagicNumber")
 fun <T : Any> NetworkResponse<T, ErrorResponse>.mapResponse(): Either<Failure, T> {
     Timber.d("Mapping network response")
     return try {
@@ -91,6 +91,9 @@ fun <T : Any> NetworkResponse<T, ErrorResponse>.mapResponse(): Either<Failure, T
                 Timber.d(this.error, "Network response: ServerError")
                 Timber.w(this.error, this.body.toString())
                 val code = this.body?.code
+                if(this.code == 429) {
+                    return Either.Left(Failure.TooManyRequestsError)
+                }
                 Either.Left(
                     when (code) {
                         INVALID_USERNAME -> InvalidUsername(code, this.body?.message)

--- a/app/src/main/java/com/weatherxm/data/models/Failure.kt
+++ b/app/src/main/java/com/weatherxm/data/models/Failure.kt
@@ -40,6 +40,7 @@ sealed class Failure(val code: String? = null) {
     object InvalidRefreshTokenError : Failure()
     object InstallationIdNotFound : Failure()
     object FirmwareBytesParsingError : Failure()
+    object TooManyRequestsError : Failure()
 }
 
 @Keep

--- a/app/src/main/java/com/weatherxm/ui/home/profile/ProfileFragment.kt
+++ b/app/src/main/java/com/weatherxm/ui/home/profile/ProfileFragment.kt
@@ -50,7 +50,7 @@ class ProfileFragment : BaseFragment() {
         registerForActivityResult(StartActivityForResult()) { result: ActivityResult ->
             if (result.resultCode == Activity.RESULT_OK) {
                 parentModel.setWalletNotMissing()
-                model.fetchUser(true)
+                model.fetchUser(parentModel.isLoggedIn(), true)
             }
         }
 
@@ -87,7 +87,7 @@ class ProfileFragment : BaseFragment() {
         }
 
         binding.swiperefresh.setOnRefreshListener {
-            model.fetchUser(parentModel.isLoggedIn())
+            model.fetchUser(parentModel.isLoggedIn(), true)
             if (parentModel.isLoggedIn()) {
                 parentModel.getSurvey()
             }

--- a/app/src/main/java/com/weatherxm/util/Failure.kt
+++ b/app/src/main/java/com/weatherxm/util/Failure.kt
@@ -5,6 +5,7 @@ import com.weatherxm.R
 import com.weatherxm.data.models.ApiError.GenericError.UnsupportedAppVersion
 import com.weatherxm.data.models.ApiError.GenericError.ValidationError
 import com.weatherxm.data.models.Failure
+import com.weatherxm.data.models.Failure.TooManyRequestsError
 import com.weatherxm.data.models.NetworkError.ConnectionTimeoutError
 import com.weatherxm.data.models.NetworkError.NoConnectionError
 import org.koin.core.component.KoinComponent
@@ -21,6 +22,7 @@ object Failure : KoinComponent {
             is NoConnectionError -> R.string.error_network_generic
             is ConnectionTimeoutError -> R.string.error_network_timed_out
             is ValidationError -> R.string.error_server_validation
+            is TooManyRequestsError -> R.string.error_refreshed_too_quickly
             else -> fallback ?: R.string.error_reach_out
         }
     }

--- a/app/src/main/res/values/messages.xml
+++ b/app/src/main/res/values/messages.xml
@@ -51,6 +51,7 @@
     <string name="error_helium_ota_133_suffix">STATION NOT IN RANGE</string>
     <string name="error_max_followed">Max followed stations threshold reached.</string>
     <string name="error_boost_not_supported">Boost is not supported, please check for app updates.</string>
+    <string name="error_refreshed_too_quickly">You’ve refreshed a bit too quickly. Please wait a moment and try again.</string>
 
     <!-- Warn Messages -->
     <string name="warn_validation_invalid_email">Not a valid email</string>


### PR DESCRIPTION
### **Why?**
Handle error codes 429 + force refresh in the profile screen

### **How?**
- Added a new check in `mapResponse` if the code returned is 429 to map it to a `TooManyRequestsError` in order then to handle it respectively and map it to a specific error message.
- Added the correct params to force refresh on the profile screen when a pull-to-refresh takes place or a user connects their wallet and goes back to that screen

### **Testing**
Not suer you can test the error, just make sure that the API calls take place in the correct order I guess via the logcat in Android Studio.